### PR TITLE
Rename makeId functions to makeWorkflowId

### DIFF
--- a/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellState.kt
+++ b/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellState.kt
@@ -24,7 +24,7 @@ import com.squareup.sample.tictactoe.RunGameResult
 import com.squareup.sample.tictactoe.RunGameState
 import com.squareup.workflow.Delegating
 import com.squareup.workflow.Snapshot
-import com.squareup.workflow.makeId
+import com.squareup.workflow.makeWorkflowId
 import com.squareup.workflow.parse
 import com.squareup.workflow.readByteStringWithLength
 import com.squareup.workflow.readUtf8WithLength
@@ -45,13 +45,13 @@ sealed class ShellState {
   internal data class Authenticating(
     override val delegateState: AuthState = AuthState.start()
   ) : ShellState(), Delegating<AuthState, AuthEvent, String> {
-    override val id = AuthReactor::class.makeId()
+    override val id = AuthReactor::class.makeWorkflowId()
   }
 
   internal data class RunningGame(
     override val delegateState: RunGameState = RunGameState.start()
   ) : ShellState(), Delegating<RunGameState, RunGameEvent, RunGameResult> {
-    override val id = RunGameReactor::class.makeId()
+    override val id = RunGameReactor::class.makeWorkflowId()
   }
 
   fun toSnapshot(): Snapshot {

--- a/sample-game-common/src/main/java/com/squareup/sample/tictactoe/RunGameState.kt
+++ b/sample-game-common/src/main/java/com/squareup/sample/tictactoe/RunGameState.kt
@@ -18,7 +18,7 @@ package com.squareup.sample.tictactoe
 import com.squareup.sample.tictactoe.SyncState.SAVING
 import com.squareup.workflow.Delegating
 import com.squareup.workflow.Snapshot
-import com.squareup.workflow.makeId
+import com.squareup.workflow.makeWorkflowId
 import com.squareup.workflow.parse
 import com.squareup.workflow.readByteStringWithLength
 import com.squareup.workflow.readUtf8WithLength
@@ -33,7 +33,7 @@ import kotlin.reflect.jvm.jvmName
 sealed class RunGameState {
   internal data class Playing(override val delegateState: Turn) : RunGameState(),
       Delegating<Turn, TakeTurnsEvent, CompletedGame> {
-    override val id = TakeTurnsReactor::class.makeId()
+    override val id = TakeTurnsReactor::class.makeWorkflowId()
   }
 
   internal data class NewGame(

--- a/workflow-core/src/main/java/com/squareup/workflow/Delegating.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Delegating.kt
@@ -24,7 +24,7 @@ import com.squareup.workflow.WorkflowPool.Type
 interface Delegating<S : Any, E : Any, O : Any> {
   /**
    * Uniquely identifies the delegate across the [WorkflowPool].
-   * See [WorkflowPool.Type.makeId] for details.
+   * See [WorkflowPool.Type.makeWorkflowId] for details.
    */
   val id: Id<S, E, O>
 
@@ -41,10 +41,10 @@ interface Delegating<S : Any, E : Any, O : Any> {
  * This is a convenience function intended to be used inside delegating states, to initialize
  * their [Delegating.id] property.
  *
- * @see Type.makeId
+ * @see Type.makeWorkflowId
  */
 @Suppress("unused")
 inline fun <reified S : Any, reified E : Any, reified O : Any>
-    Delegating<S, E, O>.makeId(name: String = ""): Id<S, E, O> =
+    Delegating<S, E, O>.makeWorkflowId(name: String = ""): Id<S, E, O> =
 // We can't use id.type since ID hasn't been initialized yet.
-  Type(S::class, E::class, O::class).makeId(name)
+  Type(S::class, E::class, O::class).makeWorkflowId(name)

--- a/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -95,12 +95,12 @@ fun <T : Any> Deferred<T>.asWorker(): Worker<Unit, T> = worker { await() }
 
 /**
  * Uniquely identifies the [Worker] across the [WorkflowPool].
- * See [WorkflowPool.Type.makeId] for details.
+ * See [WorkflowPool.Type.makeWorkflowId] for details.
  */
 @Suppress("unused")
-inline fun <reified I : Any, reified O : Any> Worker<I, O>.makeId(
+inline fun <reified I : Any, reified O : Any> Worker<I, O>.makeWorkflowId(
   name: String = ""
-): Id<I, Nothing, O> = workflowType.makeId(name)
+): Id<I, Nothing, O> = workflowType.makeWorkflowId(name)
 
 /**
  * Returns the [Type] of the [Worker] for the [WorkflowPool]

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowPool.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowPool.kt
@@ -54,7 +54,7 @@ class WorkflowPool {
      * @param name allows multiple workflows of the same type to be managed at once. If
      * no name is specified, we unique only on the [Type] itself.
      */
-    fun makeId(name: String = ""): Id<S, E, O> = Id(name, this)
+    fun makeWorkflowId(name: String = ""): Id<S, E, O> = Id(name, this)
 
     override fun hashCode(): Int = hashCode
     override fun equals(other: Any?): Boolean = when {
@@ -87,11 +87,11 @@ class WorkflowPool {
 
   /**
    * Unique identifier for a particular [Workflow] to be run by a [WorkflowPool].
-   * See [Type.makeId] for details.
+   * See [Type.makeWorkflowId] for details.
    *
    * Convenience extension functions exist on `KClass<Launcher>` and [Delegating] to create IDs:
-   *  - `KClass<Launcher>.makeId()`
-   *  - [Delegating.makeId]
+   *  - `KClass<Launcher>.makeWorkflowId()`
+   *  - [Delegating.makeWorkflowId]
    */
   data class Id<S : Any, in E : Any, out O : Any>
   internal constructor(
@@ -174,7 +174,7 @@ class WorkflowPool {
   ): O {
     register(worker.asReactor(), type)
     val delegating = object : Delegating<I, Nothing, O> {
-      override val id: Id<I, Nothing, O> = type.makeId(name)
+      override val id: Id<I, Nothing, O> = type.makeWorkflowId(name)
       override val delegateState: I get() = input
     }
     return requireWorkflow(delegating)
@@ -306,13 +306,14 @@ inline val <reified S : Any, reified E : Any, reified O : Any>
 /**
  * Make an ID for the [workflowType] of this [Delegating].
  *
- * E.g. `MyLauncher::class.makeId()`
+ * E.g. `MyLauncher::class.makeWorkflowId()`
  *
- * @see Type.makeId
+ * @see Type.makeWorkflowId
  */
 @Suppress("unused")
 inline fun <reified S : Any, reified E : Any, reified O : Any>
-    KClass<out Launcher<S, E, O>>.makeId(name: String = ""): Id<S, E, O> = workflowType.makeId(name)
+    KClass<out Launcher<S, E, O>>.makeWorkflowId(name: String = ""): Id<S, E, O> =
+    workflowType.makeWorkflowId(name)
 
 /**
  * Returns the [Type] that represents this [Launcher] class's type parameters.

--- a/workflow-core/src/test/java/com/squareup/workflow/ComposedReactorIntegrationTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/ComposedReactorIntegrationTest.kt
@@ -196,7 +196,7 @@ class ComposedReactorIntegrationTest {
       constructor(
         id: String,
         state: String
-      ) : this(StringEchoer::class.makeId(id), state)
+      ) : this(StringEchoer::class.makeWorkflowId(id), state)
     }
 
     data class Paused(
@@ -205,7 +205,7 @@ class ComposedReactorIntegrationTest {
     ) : OuterState()
 
     object RunningImmediateJob : OuterState(), Delegating<Unit, String, Unit> {
-      override val id = makeId()
+      override val id = makeWorkflowId()
       override val delegateState = Unit
     }
   }
@@ -322,7 +322,7 @@ class ComposedReactorIntegrationTest {
     echoJobId: String,
     event: String
   ) {
-    pool.input(StringEchoer::class.makeId(echoJobId))
+    pool.input(StringEchoer::class.makeWorkflowId(echoJobId))
         .sendEvent(event)
   }
 }

--- a/workflow-core/src/test/java/com/squareup/workflow/WorkerTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/WorkerTest.kt
@@ -63,7 +63,7 @@ class WorkerTest {
     val reaction = pool.workerResult(worker, Unit)
     assertFalse(reaction.isCompleted)
 
-    pool.abandonDelegate(worker.makeId())
+    pool.abandonDelegate(worker.makeWorkflowId())
 
     assertFailsWith<CancellationException> { reaction.getCompleted() }
   }

--- a/workflow-core/src/test/java/com/squareup/workflow/WorkflowPoolTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/WorkflowPoolTest.kt
@@ -69,7 +69,7 @@ class WorkflowPoolTest {
     override val delegateState: String = "",
     name: String = ""
   ) : Delegating<String, String, String> {
-    override val id: Id<String, String, String> = myReactor.workflowType.makeId(name)
+    override val id: Id<String, String, String> = myReactor.workflowType.makeWorkflowId(name)
   }
 
   @Test fun metaTest_myReactorReportsStatesAndResult() {
@@ -173,7 +173,7 @@ class WorkflowPoolTest {
 
   @Test fun routesEvents() {
     pool.nextDelegateReaction(DelegatingState())
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
 
     input.sendEvent("able")
     input.sendEvent("baker")
@@ -183,7 +183,7 @@ class WorkflowPoolTest {
   }
 
   @Test fun dropsLateEvents() {
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
     pool.nextDelegateReaction(DelegatingState())
 
     input.sendEvent("able")
@@ -195,7 +195,7 @@ class WorkflowPoolTest {
   }
 
   @Test fun dropsEarlyEvents() {
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
     input.sendEvent("able")
     pool.nextDelegateReaction(DelegatingState())
     input.sendEvent("baker")
@@ -205,7 +205,7 @@ class WorkflowPoolTest {
 
   @Test fun resumesRoutingEvents() {
     pool.nextDelegateReaction(DelegatingState())
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
 
     input.sendEvent("able")
     input.sendEvent("baker")

--- a/workflow-rx2/src/test/java/com/squareup/workflow/WorkflowPoolIntegrationTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/WorkflowPoolIntegrationTest.kt
@@ -78,7 +78,7 @@ class WorkflowPoolIntegrationTest {
     override val delegateState: String = "",
     name: String = ""
   ) : Delegating<String, String, String> {
-    override val id: Id<String, String, String> = myReactor.workflowType.makeId(name)
+    override val id: Id<String, String, String> = myReactor.workflowType.makeWorkflowId(name)
   }
 
   @Test fun metaTest_myReactorReportsStatesAndResult() {
@@ -192,7 +192,7 @@ class WorkflowPoolIntegrationTest {
 
   @Test fun routesEvents() {
     pool.nextDelegateReaction(DelegatingState())
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
 
     input.sendEvent("able")
     input.sendEvent("baker")
@@ -202,7 +202,7 @@ class WorkflowPoolIntegrationTest {
   }
 
   @Test fun dropsLateEvents() {
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
     pool.nextDelegateReaction(DelegatingState())
 
     input.sendEvent("able")
@@ -219,7 +219,7 @@ class WorkflowPoolIntegrationTest {
   }
 
   @Test fun dropsEarlyEvents() {
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
     input.sendEvent("able")
     pool.nextDelegateReaction(DelegatingState())
     input.sendEvent("baker")
@@ -229,7 +229,7 @@ class WorkflowPoolIntegrationTest {
 
   @Test fun resumesRoutingEvents() {
     pool.nextDelegateReaction(DelegatingState())
-    val input = pool.input(myReactor.workflowType.makeId())
+    val input = pool.input(myReactor.workflowType.makeWorkflowId())
 
     input.sendEvent("able")
     input.sendEvent("baker")

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/ComposedReactorIntegrationTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/ComposedReactorIntegrationTest.kt
@@ -22,7 +22,7 @@ import com.squareup.workflow.Reaction
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowPool
 import com.squareup.workflow.WorkflowPool.Id
-import com.squareup.workflow.makeId
+import com.squareup.workflow.makeWorkflowId
 import com.squareup.workflow.register
 import com.squareup.workflow.rx2.ComposedReactorIntegrationTest.OuterEvent.Background
 import com.squareup.workflow.rx2.ComposedReactorIntegrationTest.OuterEvent.Cancel
@@ -213,7 +213,7 @@ class ComposedReactorIntegrationTest {
       constructor(
         id: String,
         state: String
-      ) : this(StringEchoer::class.makeId(id), state)
+      ) : this(StringEchoer::class.makeWorkflowId(id), state)
     }
 
     data class Paused(
@@ -222,7 +222,7 @@ class ComposedReactorIntegrationTest {
     ) : OuterState()
 
     object RunningImmediateJob : OuterState(), Delegating<Unit, String, Unit> {
-      override val id = makeId()
+      override val id = makeWorkflowId()
       override val delegateState = Unit
     }
   }
@@ -329,7 +329,7 @@ class ComposedReactorIntegrationTest {
     echoJobId: String,
     event: String
   ) {
-    pool.input(StringEchoer::class.makeId(echoJobId))
+    pool.input(StringEchoer::class.makeWorkflowId(echoJobId))
         .sendEvent(event)
   }
 }

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkerIntegrationTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkerIntegrationTest.kt
@@ -17,7 +17,7 @@ package com.squareup.workflow.rx2
 
 import com.squareup.workflow.ReactorException
 import com.squareup.workflow.WorkflowPool
-import com.squareup.workflow.makeId
+import com.squareup.workflow.makeWorkflowId
 import io.reactivex.subjects.SingleSubject
 import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.Test
@@ -57,7 +57,7 @@ class WorkerIntegrationTest {
         .test()
     reaction.assertNotTerminated()
 
-    pool.abandonDelegate(worker.makeId())
+    pool.abandonDelegate(worker.makeWorkflowId())
 
     // The rx2 version of nextProcessResult will never complete the single if the workflow is
     // cancelled.


### PR DESCRIPTION
This renaming is required in order to be clearer that it's a workflow-related function.

Closes issue: https://github.com/square/workflow/issues/17