### PR TITLE
Fix workflow operators

### DIFF
--- a/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -17,13 +17,7 @@ package com.squareup.workflow
 
 import kotlinx.coroutines.experimental.CancellationException
 import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.Dispatchers.Unconfined
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
-import kotlinx.coroutines.experimental.channels.consumeEach
-import kotlinx.coroutines.experimental.channels.produce
-import kotlin.coroutines.experimental.CoroutineContext
 
 /**
  * Models a process in the app as a stream of [states][openSubscriptionToState] of type [S],
@@ -46,77 +40,4 @@ interface Workflow<out S : Any, in E : Any, out O : Any> : Deferred<O>, Workflow
    * itself will not throw.
    */
   fun openSubscriptionToState(): ReceiveChannel<S>
-}
-
-/**
- * [CoroutineContext] used by [Workflow] operators below.
- */
-private val operatorContext: CoroutineContext = Unconfined
-
-/**
- * [Transforms][https://stackoverflow.com/questions/15457015/explain-contramap]
- * the receiver to accept events of type [E2] instead of [E1].
- */
-fun <S : Any, E2 : Any, E1 : Any, O : Any> Workflow<S, E1, O>.adaptEvents(transform: (E2) -> E1):
-    Workflow<S, E2, O> = object : Workflow<S, E2, O>, Deferred<O> by this {
-  override fun openSubscriptionToState(): ReceiveChannel<S> =
-    this@adaptEvents.openSubscriptionToState()
-
-  override fun sendEvent(event: E2) = this@adaptEvents.sendEvent(transform(event))
-}
-
-/**
- * Transforms the receiver to emit states of type [S2] instead of [S1].
- */
-fun <S1 : Any, S2 : Any, E : Any, O : Any> Workflow<S1, E, O>.mapState(
-  transform: suspend (S1) -> S2
-): Workflow<S2, E, O> = object : Workflow<S2, E, O>,
-    Deferred<O> by this,
-    WorkflowInput<E> by this {
-  override fun openSubscriptionToState(): ReceiveChannel<S2> =
-    GlobalScope.produce(operatorContext) {
-      val source = this@mapState.openSubscriptionToState()
-      source.consumeEach {
-        send(transform(it))
-      }
-    }
-}
-
-/**
- * Like [mapState], transforms the receiving workflow with [Workflow.state] of type
- * [S1] to one with states of [S2]. Unlike that method, each [S1] update is transformed
- * into a stream of [S2] updates -- useful when an [S1] state might wrap an underlying
- * workflow whose own screens need to be shown.
- */
-fun <S1 : Any, S2 : Any, E : Any, O : Any> Workflow<S1, E, O>.switchMapState(
-  transform: suspend (S1) -> ReceiveChannel<S2>
-): Workflow<S2, E, O> = object : Workflow<S2, E, O>,
-    Deferred<O> by this,
-    WorkflowInput<E> by this {
-  override fun openSubscriptionToState(): ReceiveChannel<S2> =
-    GlobalScope.produce(operatorContext) {
-      val source = this@switchMapState.openSubscriptionToState()
-      source.consumeEach { rawState ->
-        transform(rawState).consumeEach { transformedState ->
-          send(transformedState)
-        }
-      }
-    }
-}
-
-/**
- * Transforms the receiver to emit a result of type [O2] instead of [O1].
- */
-fun <S : Any, E : Any, O1 : Any, O2 : Any> Workflow<S, E, O1>.mapResult(
-  transform: suspend (O1) -> O2
-): Workflow<S, E, O2> {
-  val transformedResult = GlobalScope.async(operatorContext) {
-    transform(this@mapResult.await())
-  }
-  return object : Workflow<S, E, O2>,
-      Deferred<O2> by transformedResult,
-      WorkflowInput<E> by this {
-    override fun openSubscriptionToState(): ReceiveChannel<S> =
-      this@mapResult.openSubscriptionToState()
-  }
 }

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowOperators.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowOperators.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.async
+import kotlinx.coroutines.experimental.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import kotlinx.coroutines.experimental.channels.consumeEach
+import kotlinx.coroutines.experimental.channels.produce
+import kotlin.coroutines.experimental.CoroutineContext
+
+/**
+ * [CoroutineContext] used by [Workflow] operators below.
+ */
+private val operatorContext: CoroutineContext = Dispatchers.Unconfined
+
+/**
+ * [Transforms][https://stackoverflow.com/questions/15457015/explain-contramap]
+ * the receiver to accept events of type [E2] instead of [E1].
+ */
+fun <S : Any, E2 : Any, E1 : Any, O : Any> Workflow<S, E1, O>.adaptEvents(transform: (E2) -> E1):
+    Workflow<S, E2, O> = object : Workflow<S, E2, O>, Deferred<O> by this {
+  override fun openSubscriptionToState(): ReceiveChannel<S> =
+    this@adaptEvents.openSubscriptionToState()
+
+  override fun sendEvent(event: E2) = this@adaptEvents.sendEvent(transform(event))
+}
+
+/**
+ * Transforms the receiver to emit states of type [S2] instead of [S1].
+ */
+fun <S1 : Any, S2 : Any, E : Any, O : Any> Workflow<S1, E, O>.mapState(
+  transform: suspend (S1) -> S2
+): Workflow<S2, E, O> = object : Workflow<S2, E, O>,
+    Deferred<O> by this,
+    WorkflowInput<E> by this {
+  override fun openSubscriptionToState(): ReceiveChannel<S2> =
+    GlobalScope.produce(operatorContext) {
+      val source = this@mapState.openSubscriptionToState()
+      source.consumeEach {
+        send(transform(it))
+      }
+    }
+}
+
+/**
+ * Like [mapState], transforms the receiving workflow with [Workflow.state] of type
+ * [S1] to one with states of [S2]. Unlike that method, each [S1] update is transformed
+ * into a stream of [S2] updates -- useful when an [S1] state might wrap an underlying
+ * workflow whose own screens need to be shown.
+ */
+fun <S1 : Any, S2 : Any, E : Any, O : Any> Workflow<S1, E, O>.switchMapState(
+  transform: suspend CoroutineScope.(S1) -> ReceiveChannel<S2>
+): Workflow<S2, E, O> = object : Workflow<S2, E, O>,
+    Deferred<O> by this,
+    WorkflowInput<E> by this {
+  override fun openSubscriptionToState(): ReceiveChannel<S2> =
+    GlobalScope.produce(operatorContext, capacity = CONFLATED) {
+      val source = this@switchMapState.openSubscriptionToState()
+      source.consumeEach { rawState ->
+        transform(rawState).consumeEach { transformedState ->
+          send(transformedState)
+        }
+      }
+    }
+}
+
+/**
+ * Transforms the receiver to emit a result of type [O2] instead of [O1].
+ */
+fun <S : Any, E : Any, O1 : Any, O2 : Any> Workflow<S, E, O1>.mapResult(
+  transform: suspend (O1) -> O2
+): Workflow<S, E, O2> {
+  val transformedResult = GlobalScope.async(operatorContext) {
+    transform(this@mapResult.await())
+  }
+  return object : Workflow<S, E, O2>,
+      Deferred<O2> by transformedResult,
+      WorkflowInput<E> by this {
+    override fun openSubscriptionToState(): ReceiveChannel<S> =
+      this@mapResult.openSubscriptionToState()
+  }
+}

--- a/workflow-core/src/test/java/com/squareup/workflow/CoroutineWorkflowTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/CoroutineWorkflowTest.kt
@@ -186,6 +186,8 @@ class CoroutineWorkflowTest : CoroutineScope {
     assertTrue(cancelReason is CancellationException)
     assertEquals(ExpectedException, cancelReason.cause)
   }
-}
 
-private object ExpectedException : RuntimeException()
+  private companion object {
+    object ExpectedException : RuntimeException()
+  }
+}

--- a/workflow-core/src/test/java/com/squareup/workflow/WorkflowOperatorsTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/WorkflowOperatorsTest.kt
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import kotlinx.coroutines.experimental.CancellationException
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.Dispatchers.Unconfined
+import kotlinx.coroutines.experimental.channels.Channel
+import kotlinx.coroutines.experimental.channels.consume
+import kotlinx.coroutines.experimental.channels.produce
+import kotlinx.coroutines.experimental.suspendCancellableCoroutine
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WorkflowOperatorsTest {
+
+  private val scope = CoroutineScope(Unconfined)
+
+  @Test fun `adaptEvents works`() {
+    val source = scope.workflow<Nothing, String, String> { _, events ->
+      events.receive()
+    }
+    val withAdaptedEvents: Workflow<Nothing, Int, String> = source.adaptEvents {
+      it.toString()
+    }
+
+    withAdaptedEvents.sendEvent(42)
+
+    assertEquals("42", withAdaptedEvents.getCompleted())
+  }
+
+  @Test fun `adaptEvents send throws when transformer throws`() {
+    val source = scope.workflow<Nothing, String, String> { _, events ->
+      events.receive()
+    }
+    val withAdaptedEvents: Workflow<Nothing, Int, String> = source.adaptEvents {
+      throw ExpectedException
+    }
+
+    assertFailsWith<ExpectedException> { withAdaptedEvents.sendEvent(42) }
+    assertFalse(source.isCompleted)
+  }
+
+  @Test fun `adaptEvents cancels upstream when transformed channel is cancelled`() {
+    var sourceCancellation: Throwable? = null
+    val source = scope.workflow<Nothing, String, Nothing> { _, _ ->
+      suspendCancellableCoroutine<Nothing> { continuation ->
+        continuation.invokeOnCancellation { cause ->
+          sourceCancellation = cause
+        }
+      }
+    }
+    val withAdaptedEvents: Workflow<Nothing, Int, String> = source.adaptEvents {
+      it.toString()
+    }
+
+    withAdaptedEvents.cancel(ExpectedException)
+
+    assertTrue(sourceCancellation is CancellationException)
+    assertEquals(ExpectedException, sourceCancellation!!.cause)
+  }
+
+  @Test fun `mapState works`() {
+    val source = scope.workflow<Int, Unit, Unit> { state, events ->
+      events.receive()
+      state.send(1)
+      events.receive()
+      state.send(2)
+      events.receive()
+      state.send(3)
+    }
+    val withMappedStates = source.mapState {
+      it * 2
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          withMappedStates.sendEvent(Unit)
+          assertEquals(2, poll())
+          withMappedStates.sendEvent(Unit)
+          assertEquals(4, poll())
+          withMappedStates.sendEvent(Unit)
+          assertEquals(6, poll())
+        }
+  }
+
+  @Test fun `mapState completes with error when transformer throws`() {
+    val source = scope.workflow<Int, Unit, Unit> { state, events ->
+      events.receive()
+      state.send(42)
+    }
+    val withMappedStates: Workflow<Int, Unit, Unit> = source.mapState {
+      throw ExpectedException
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertFalse(withMappedStates.isCompleted)
+          withMappedStates.sendEvent(Unit)
+          assertFailsWith<ExpectedException> { poll() }
+          // Exception is not sent through the result.
+          assertEquals(Unit, withMappedStates.getCompleted())
+        }
+  }
+
+  @Test fun `mapState forwards error from source`() {
+    val source = scope.workflow<Int, Unit, Unit> { _, events ->
+      events.receive()
+      throw ExpectedException
+    }
+    val withMappedStates = source.mapState {
+      it * 2
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertFalse(withMappedStates.isCompleted)
+          withMappedStates.sendEvent(Unit)
+          assertFailsWith<ExpectedException> { poll() }
+          assertFailsWith<ExpectedException> { withMappedStates.getCompleted() }
+        }
+  }
+
+  @Test fun `mapState cancels upstream when transformed channel is cancelled`() {
+    var sourceCancellation: Throwable? = null
+    val source = scope.workflow<Nothing, Nothing, Nothing> { _, _ ->
+      suspendCancellableCoroutine<Nothing> { continuation ->
+        continuation.invokeOnCancellation {
+          sourceCancellation = it
+        }
+      }
+    }
+    val withMappedStates = source.mapState { it }
+
+    assertNull(sourceCancellation)
+    withMappedStates.cancel(ExpectedException)
+    assertTrue(sourceCancellation is CancellationException)
+    assertEquals(ExpectedException, sourceCancellation!!.cause)
+  }
+
+  @Test fun `switchMapState forwards all transformed values when not preempted`() {
+    val switchMapTrigger = Channel<Unit>()
+    val source = scope.workflow<String, String, Unit> { state, events ->
+      state.send(events.receive())
+      state.send(events.receive())
+    }
+    val withMappedStates = source.switchMapState { state ->
+      produce {
+        state.forEach {
+          send(it)
+          switchMapTrigger.receive()
+        }
+      }
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertNull(poll())
+
+          withMappedStates.sendEvent("foo")
+          assertEquals('f', poll())
+          switchMapTrigger.offer(Unit)
+          assertEquals('o', poll())
+          switchMapTrigger.offer(Unit)
+          assertEquals('o', poll())
+          switchMapTrigger.offer(Unit)
+          assertNull(poll())
+
+          withMappedStates.sendEvent("bar")
+          assertEquals('b', poll())
+          switchMapTrigger.offer(Unit)
+          assertEquals('a', poll())
+          switchMapTrigger.offer(Unit)
+          assertEquals('r', poll())
+          switchMapTrigger.offer(Unit)
+          assertNull(poll())
+          assertTrue(isClosedForReceive)
+        }
+  }
+
+  @Ignore("https://github.com/square/workflow/issues/69")
+  @Test fun `switchMapState cuts off previous transformed channel on new source value`() {
+    val switchMapTrigger = Channel<Unit>()
+    val source = scope.workflow<String, String, Unit> { state, events ->
+      state.send(events.receive())
+      state.send(events.receive())
+    }
+    val withMappedStates = source.switchMapState { state ->
+      produce {
+        state.forEach {
+          send(it)
+          switchMapTrigger.receive()
+        }
+      }
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertNull(poll())
+
+          withMappedStates.sendEvent("foo")
+          assertEquals('f', poll())
+          assertNull(poll())
+
+          withMappedStates.sendEvent("bar")
+          assertEquals('b', poll())
+          switchMapTrigger.offer(Unit)
+          assertEquals('a', poll())
+          switchMapTrigger.offer(Unit)
+          assertEquals('r', poll())
+          switchMapTrigger.offer(Unit)
+          assertNull(poll())
+          assertTrue(isClosedForReceive)
+        }
+  }
+
+  @Ignore("https://github.com/square/workflow/issues/69")
+  @Test fun `switchMapState cancels previous transformed channel on new source value`() {
+    val source = scope.workflow<String, String, Unit> { state, events ->
+      state.send(events.receive())
+      state.send(events.receive())
+    }
+    var mappedCancellation: Throwable? = null
+    val withMappedStates = source.switchMapState {
+      Channel<Nothing>().apply {
+        invokeOnClose { cause ->
+          mappedCancellation = cause
+        }
+      }
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertNull(mappedCancellation)
+
+          withMappedStates.sendEvent("foo")
+          assertNull(mappedCancellation)
+
+          withMappedStates.sendEvent("bar")
+          assertTrue(mappedCancellation is CancellationException)
+        }
+  }
+
+  @Test fun `switchMapState conflates transformed values`() {
+    val source = scope.workflow<String, String, Unit> { state, events ->
+      state.send(events.receive())
+      // Suspend forever.
+      suspendCancellableCoroutine { }
+    }
+    val withMappedStates = source.switchMapState { state ->
+      produce {
+        // This state should get dropped.
+        send("first $state")
+        // Only this state should be seen.
+        send("last $state")
+      }
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          withMappedStates.sendEvent("foo")
+          assertEquals("last foo", poll())
+        }
+  }
+
+  @Test fun `switchMapState completes with error when transformer throws`() {
+    val source = scope.workflow<Int, Unit, Unit> { state, events ->
+      events.receive()
+      state.send(42)
+    }
+    val withMappedStates: Workflow<Int, Unit, Unit> = source.switchMapState {
+      throw ExpectedException
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertFalse(withMappedStates.isCompleted)
+          withMappedStates.sendEvent(Unit)
+          assertFailsWith<ExpectedException> { poll() }
+          // Exception is not sent through the result.
+          assertEquals(Unit, withMappedStates.getCompleted())
+        }
+  }
+
+  @Test fun `switchMapState completes with error when transformed channel is cancelled`() {
+    val source = scope.workflow<Int, Unit, Unit> { state, events ->
+      events.receive()
+      state.send(42)
+    }
+    val withMappedStates: Workflow<Int, Unit, Unit> = source.switchMapState {
+      Channel<Int>().apply { cancel(ExpectedException) }
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertFalse(withMappedStates.isCompleted)
+          withMappedStates.sendEvent(Unit)
+          assertFailsWith<ExpectedException> { poll() }
+          // Exception is not sent through the result.
+          assertEquals(Unit, withMappedStates.getCompleted())
+        }
+  }
+
+  @Test fun `switchMapState forwards error from source`() {
+    val source = scope.workflow<Int, Unit, Unit> { _, events ->
+      events.receive()
+      throw ExpectedException
+    }
+    val withMappedStates: Workflow<Int, Unit, Unit> = source.switchMapState {
+      produce {
+        send(it * 2)
+      }
+    }
+
+    withMappedStates.openSubscriptionToState()
+        .consume {
+          assertFalse(withMappedStates.isCompleted)
+          withMappedStates.sendEvent(Unit)
+          assertFailsWith<ExpectedException> { poll() }
+          assertFailsWith<ExpectedException> { withMappedStates.getCompleted() }
+        }
+  }
+
+  @Test fun `switchMapState cancels upstream when transformed channel is cancelled`() {
+    var sourceCancellation: Throwable? = null
+    val source = scope.workflow<Unit, Nothing, Nothing> { _, _ ->
+      suspendCancellableCoroutine<Nothing> { continuation ->
+        continuation.invokeOnCancellation {
+          sourceCancellation = it
+        }
+      }
+    }
+    val withMappedStates = source.switchMapState { produce { send(it) } }
+
+    assertNull(sourceCancellation)
+    withMappedStates.cancel(ExpectedException)
+    assertTrue(sourceCancellation is CancellationException)
+    assertEquals(ExpectedException, sourceCancellation!!.cause)
+  }
+
+  @Test fun `mapResult works`() {
+    val source = scope.workflow<Nothing, Unit, Int> { state, events ->
+      events.receive()
+      return@workflow 42
+    }
+    val withMappedResult = source.mapResult {
+      it * 2
+    }
+
+    assertFalse(withMappedResult.isCompleted)
+    withMappedResult.sendEvent(Unit)
+    assertEquals(84, withMappedResult.getCompleted())
+  }
+
+  @Test fun `mapResult completes with error when transformer throws`() {
+    val source = scope.workflow<Nothing, Unit, Int> { state, events ->
+      events.receive()
+      return@workflow 42
+    }
+    val withMappedResult: Workflow<Int, Unit, Unit> = source.mapResult {
+      throw ExpectedException
+    }
+
+    assertFalse(withMappedResult.isCompleted)
+    withMappedResult.sendEvent(Unit)
+    assertFailsWith<ExpectedException> { withMappedResult.getCompleted() }
+  }
+
+  @Test fun `mapResult forwards error from source`() {
+    val source = scope.workflow<Nothing, Unit, Int> { _, events ->
+      events.receive()
+      throw ExpectedException
+    }
+    val withMappedResult = source.mapResult {
+      it * 2
+    }
+
+    assertFalse(withMappedResult.isCompleted)
+    withMappedResult.sendEvent(Unit)
+    assertFailsWith<ExpectedException> { withMappedResult.getCompleted() }
+  }
+
+  @Ignore("https://github.com/square/workflow/issues/71")
+  @Test fun `mapResult cancels upstream when transformed workflow is cancelled`() {
+    var sourceCancellation: Throwable? = null
+    val source = scope.workflow<Nothing, Nothing, Nothing> { _, _ ->
+      suspendCancellableCoroutine<Nothing> { continuation ->
+        continuation.invokeOnCancellation {
+          sourceCancellation = it
+        }
+      }
+    }
+    val withMappedResult = source.mapResult { it }
+
+    assertNull(sourceCancellation)
+    withMappedResult.cancel(ExpectedException)
+    assertTrue(sourceCancellation is CancellationException)
+    assertEquals(ExpectedException, sourceCancellation!!.cause)
+  }
+
+  private companion object {
+    object ExpectedException : RuntimeException()
+  }
+}

--- a/workflow-core/src/test/java/com/squareup/workflow/WorkflowOperatorsTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/WorkflowOperatorsTest.kt
@@ -398,7 +398,6 @@ class WorkflowOperatorsTest {
     assertFailsWith<ExpectedException> { withMappedResult.getCompleted() }
   }
 
-  @Ignore("https://github.com/square/workflow/issues/71")
   @Test fun `mapResult cancels upstream when transformed workflow is cancelled`() {
     var sourceCancellation: Throwable? = null
     val source = scope.workflow<Nothing, Nothing, Nothing> { _, _ ->


### PR DESCRIPTION
* 9c879cd Fix #69 by correctly implementing switchMapState operator.
* e304784 Fix #71 by cancelling upstream workflow when mapResult workflow is cancelled.
* 1876788 Move the workflow operators into their own file and write unit tests.