### PR TITLE
Introduce a switchMapState variant that takes a lambda returning an Rx2 Observable (closes #53).

### DIFF
--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowOperators.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowOperators.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.experimental.CoroutineScope
 import kotlinx.coroutines.experimental.Deferred
 import kotlinx.coroutines.experimental.Dispatchers
 import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.Job
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
@@ -80,6 +81,7 @@ fun <S1 : Any, S2 : Any, E : Any, O : Any> Workflow<S1, E, O>.switchMapState(
       var transformedChannel: ReceiveChannel<S2>? = null
       val downstreamChannel = channel
 
+      coroutineContext[Job]?.invokeOnCompletion { transformedChannel?.cancel(it) }
       upstreamChannel.consume {
         whileSelect {
           upstreamChannel.onReceiveOrNull { upstreamState ->

--- a/workflow-rx2/src/main/java/com/squareup/workflow/rx2/WorkflowOperators.kt
+++ b/workflow-rx2/src/main/java/com/squareup/workflow/rx2/WorkflowOperators.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Square Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.rx2
+
+import com.squareup.workflow.Workflow
+import io.reactivex.Completable
+import io.reactivex.Observable
+import kotlinx.coroutines.experimental.rx2.openSubscription
+import com.squareup.workflow.switchMapState as coreSwitchMapState
+
+/**
+ * Returns a [Completable] that fires either when [Workflow.result] fires, or when
+ * [Workflow.cancel] is called.
+ */
+@Suppress("unused")
+fun Workflow<*, *, *>.toCompletable(): Completable = state.ignoreElements()
+
+/**
+ * Like [mapState][com.squareup.workflow.mapState], transforms the receiving workflow with
+ * [Workflow.state] of type [S1] to one with states of [S2]. Unlike that method, each [S1] update is
+ * transformed into a stream of [S2] updates -- useful when an [S1] state might wrap an underlying
+ * workflow whose own screens need to be shown.
+ */
+fun <S1 : Any, S2 : Any, E : Any, O : Any> Workflow<S1, E, O>.switchMapState(
+  transform: (S1) -> Observable<out S2>
+): Workflow<S2, E, O> = coreSwitchMapState {
+  transform(it).openSubscription()
+}

--- a/workflow-rx2/src/main/java/com/squareup/workflow/rx2/Workflows.kt
+++ b/workflow-rx2/src/main/java/com/squareup/workflow/rx2/Workflows.kt
@@ -16,7 +16,6 @@
 package com.squareup.workflow.rx2
 
 import com.squareup.workflow.Workflow
-import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import kotlinx.coroutines.experimental.CancellationException
@@ -69,9 +68,3 @@ val <O : Any> Workflow<*, *, O>.result: Maybe<out O>
           Maybe.error(error)
         }
       }
-
-/**
- * Returns a [Completable] that fires either when [Workflow.result] fires, or when
- * [Workflow.cancel] is called.
- */
-fun Workflow<*, *, *>.toCompletable(): Completable = state.ignoreElements()

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowOperatorsTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowOperatorsTest.kt
@@ -1,0 +1,82 @@
+package com.squareup.workflow.rx2
+
+import com.squareup.workflow.Workflow
+import io.reactivex.Observable
+import io.reactivex.observers.TestObserver
+import io.reactivex.subjects.PublishSubject
+import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.experimental.channels.Channel
+import kotlinx.coroutines.experimental.channels.ReceiveChannel
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.junit.Test
+
+class WorkflowOperatorsTest {
+
+  @Test fun `switch map state works`() {
+    val downstreamTrigger = PublishSubject.create<Unit>()
+    val workflow = object : Workflow<String, Nothing, Nothing>,
+        Deferred<Nothing> by CompletableDeferred() {
+      // Return a channel with a single item.
+      override fun openSubscriptionToState(): ReceiveChannel<String> =
+        Channel<String>(capacity = 1)
+            .apply { offer("Hello") }
+
+      override fun sendEvent(event: Nothing) {
+      }
+    }
+
+    val mapped = workflow.switchMapState {
+      var n = 0
+      Observable.fromIterable(it.asIterable())
+          // Emit characters one-at-a-time.
+          .delay { downstreamTrigger.skip(n++.toLong()) }
+    }
+
+    val states = mapped.state.test() as TestObserver<Char>
+
+    downstreamTrigger.onNext(Unit)
+    assertThat(states.values().last()).isEqualTo('H')
+    downstreamTrigger.onNext(Unit)
+    assertThat(states.values().last()).isEqualTo('e')
+    downstreamTrigger.onNext(Unit)
+    assertThat(states.values().last()).isEqualTo('l')
+    downstreamTrigger.onNext(Unit)
+    assertThat(states.values().last()).isEqualTo('l')
+    downstreamTrigger.onNext(Unit)
+    assertThat(states.values().last()).isEqualTo('o')
+  }
+
+  @Test fun `switchMapState disposes observable when cancelled`() {
+    val workflow = object : Workflow<Unit, Nothing, Nothing>,
+        Deferred<Nothing> by CompletableDeferred() {
+      // Return a channel with a single item.
+      override fun openSubscriptionToState(): ReceiveChannel<Unit> =
+        Channel<Unit>(capacity = 1)
+            .apply { offer(Unit) }
+
+      override fun sendEvent(event: Nothing) {
+      }
+    }
+    var subscribeCount = 0
+    var disposeCount = 0
+    val mapped = workflow.switchMapState {
+      Observable.never<Unit>()
+          .doOnSubscribe { subscribeCount++ }
+          .doOnDispose { disposeCount++ }
+    }
+
+    assertThat(subscribeCount).isEqualTo(0)
+    assertThat(disposeCount).isEqualTo(0)
+
+    val states = mapped.openSubscriptionToState()
+
+    assertThat(subscribeCount).isEqualTo(1)
+    assertThat(disposeCount).isEqualTo(0)
+
+    states.cancel()
+
+    assertThat(subscribeCount).isEqualTo(1)
+    assertThat(disposeCount).isEqualTo(1)
+  }
+}


### PR DESCRIPTION
Also fixed a bug in core `switchMapState` where the downstream didn't get cancelled when the transformed workflow's state was cancelled.