### PR TITLE
Move the event channel test helper to the test module.

### DIFF
--- a/sample-game-common/src/test/java/com/squareup/sample/tictactoe/TakeTurnsReactorTest.kt
+++ b/sample-game-common/src/test/java/com/squareup/sample/tictactoe/TakeTurnsReactorTest.kt
@@ -22,8 +22,8 @@ import com.squareup.sample.tictactoe.Player.X
 import com.squareup.sample.tictactoe.TakeTurnsEvent.Quit
 import com.squareup.sample.tictactoe.TakeTurnsEvent.TakeSquare
 import com.squareup.workflow.WorkflowPool
-import com.squareup.workflow.rx2.assertFinish
-import com.squareup.workflow.rx2.assertTransition
+import com.squareup.workflow.test.assertFinish
+import com.squareup.workflow.test.assertTransition
 import com.squareup.workflow.rx2.result
 import com.squareup.workflow.rx2.state
 import io.reactivex.observers.TestObserver

--- a/workflow-rx2/src/main/java/com/squareup/workflow/rx2/EventChannel.kt
+++ b/workflow-rx2/src/main/java/com/squareup/workflow/rx2/EventChannel.kt
@@ -20,11 +20,9 @@ import kotlinx.coroutines.experimental.CancellationException
 import kotlinx.coroutines.experimental.Dispatchers.Unconfined
 import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.Job
-import kotlinx.coroutines.experimental.channels.Channel
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
 import kotlinx.coroutines.experimental.rx2.await
 import kotlinx.coroutines.experimental.rx2.rxSingle
-import org.jetbrains.annotations.TestOnly
 import kotlin.coroutines.experimental.suspendCoroutine
 
 /**
@@ -129,20 +127,3 @@ fun <E : Any> ReceiveChannel<E>.asEventChannel() = object : EventChannel<E> {
     }
   }
 }
-
-// Helpers for testing.
-
-/**
- * **Helper for testing:**
- * Creates an [EventChannel] that will send all the values passed, and then throw if another
- * select is attempted.
- */
-@TestOnly fun <E : Any> eventChannelOf(vararg values: E): EventChannel<E> =
-  Channel<E>(values.size)
-      .apply {
-        // Load all the values into the channel's buffer.
-        values.forEach { check(offer(it)) }
-        // Ensure any receives after the values are read will fail.
-        close()
-      }
-      .asEventChannel()

--- a/workflow-test/README.md
+++ b/workflow-test/README.md
@@ -1,0 +1,3 @@
+# workflow-test
+
+This module contains utilities for testing workflow-based code.

--- a/workflow-test/src/main/java/com/squareup/workflow/test/Assertions.kt
+++ b/workflow-test/src/main/java/com/squareup/workflow/test/Assertions.kt
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:JvmName("TestUtils")
+@file:JvmName("Assertions")
 
-package com.squareup.workflow.rx2
+package com.squareup.workflow.test
 
 import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.rx2.Reactor
+import com.squareup.workflow.rx2.result
+import com.squareup.workflow.rx2.state
 import io.reactivex.observers.TestObserver
 
 /**
@@ -29,6 +32,7 @@ fun <S : Any, E : Any, O : Any> Reactor<S, E, O>.assertTransition(
   toState: S
 ) {
   val workflow = launch(fromState, WorkflowPool())
+  @Suppress("UNCHECKED_CAST")
   val observer = workflow.state.test() as TestObserver<S>
   workflow.sendEvent(event)
   observer.assertValues(fromState, toState)
@@ -43,6 +47,7 @@ fun <S : Any, E : Any, O : Any> Reactor<S, E, O>.assertFinish(
   output: O
 ) {
   val workflow = launch(fromState, WorkflowPool())
+  @Suppress("UNCHECKED_CAST")
   val observer = workflow.result.test() as TestObserver<O>
   workflow.sendEvent(event)
   observer.assertValues(output)

--- a/workflow-test/src/main/java/com/squareup/workflow/test/rx2/EventChannels.kt
+++ b/workflow-test/src/main/java/com/squareup/workflow/test/rx2/EventChannels.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("EventChannels")
+
+package com.squareup.workflow.test.rx2
+
+import com.squareup.workflow.rx2.EventChannel
+import com.squareup.workflow.rx2.asEventChannel
+import kotlinx.coroutines.experimental.channels.Channel
+
+/**
+ * Creates an [EventChannel] that will send all the values passed, and then throw if another
+ * select is attempted.
+ */
+fun <E : Any> eventChannelOf(vararg values: E): EventChannel<E> =
+  Channel<E>(values.size)
+      .apply {
+        // Load all the values into the channel's buffer.
+        values.forEach { check(offer(it)) }
+        // Ensure any receives after the values are read will fail.
+        close()
+      }
+      .asEventChannel()


### PR DESCRIPTION
Also suppresses some warnings, and organizes the test code with better packages and file names.