### PR TITLE
Enable parallel builds.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
+org.gradle.parallel=true
 
 GROUP=com.squareup.workflow
 VERSION_NAME=0.6.0-SNAPSHOT


### PR DESCRIPTION
This makes running lint on our multiple android modules so much faster.