### PR TITLE
Adds two arg Render.render() extension.

### DIFF
--- a/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellRenderer.kt
+++ b/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellRenderer.kt
@@ -25,6 +25,7 @@ import com.squareup.viewbuilder.toMainAndModal
 import com.squareup.workflow.Renderer
 import com.squareup.workflow.WorkflowInput
 import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.render
 
 /**
  * TODO(rjrjr): it's weird and distracting that the specific modal type (ConfirmQuitScreen) leaks
@@ -38,18 +39,9 @@ object ShellRenderer :
     workflows: WorkflowPool
   ): StackedMainAndModalScreen<*, ConfirmQuitScreen> {
     return when (state) {
-      is Authenticating ->
-        AuthRenderer.render(
-            state.authWorkflow.state,
-            workflows.input(state.authWorkflow),
-            workflows
-        ).toMainAndModal()
+      is Authenticating -> AuthRenderer.render(state.authWorkflow, workflows).toMainAndModal()
 
-      is RunningGame -> RunGameRenderer.render(
-          state.runGameWorkflow.state,
-          workflows.input(state.runGameWorkflow),
-          workflows
-      )
+      is RunningGame -> RunGameRenderer.render(state.runGameWorkflow, workflows)
     }
   }
 }

--- a/sample-game-common/src/main/java/com/squareup/sample/tictactoe/RunGameRenderer.kt
+++ b/sample-game-common/src/main/java/com/squareup/sample/tictactoe/RunGameRenderer.kt
@@ -23,6 +23,7 @@ import com.squareup.viewbuilder.StackedMainAndModalScreen
 import com.squareup.workflow.Renderer
 import com.squareup.workflow.WorkflowInput
 import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.render
 
 object RunGameRenderer :
     Renderer<RunGameState, RunGameEvent, StackedMainAndModalScreen<*, ConfirmQuitScreen>> {
@@ -36,7 +37,7 @@ object RunGameRenderer :
 
       is Playing -> {
         return TakeTurnsRenderer
-            .render(state.takingTurns.state, workflows.input(state.takingTurns), workflows)
+            .render(state.takingTurns, workflows)
             .let { MainAndModalScreen(it) }
       }
 

--- a/workflow-core/src/main/java/com/squareup/workflow/Renderer.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Renderer.kt
@@ -37,3 +37,12 @@ interface Renderer<S : Any, E : Any, R : Any> {
     workflows: WorkflowPool
   ): R
 }
+
+/**
+ * Convenience for the usual case where we're rendering a [handle][RunWorkflow] and sending
+ * events to the [WorkflowInput] it identifies.
+ */
+fun <S : Any, E : Any, O : Any, R : Any> Renderer<S, E, R>.render(
+  handle: RunWorkflow<S, E, O>,
+  workflows: WorkflowPool
+): R = render(handle.state, workflows.input(handle), workflows)


### PR DESCRIPTION
Allows this:

```
return TakeTurnsRenderer
    .render(state.takingTurns, workflows)
    .let { MainAndModalScreen(it) }
```

instead of this:

```
return TakeTurnsRenderer
    .render(state.takingTurns.state, workflows.input(state.takingTurns), workflows)
    .let { MainAndModalScreen(it) }
```

Closes #103