### PR TITLE
Removed "Basically a monad"

### DIFF
--- a/workflow-core/src/main/java/com/squareup/workflow/Reaction.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/Reaction.kt
@@ -16,7 +16,7 @@
 package com.squareup.workflow
 
 /**
- * Basically a monad that indicates whether a [Reactor] should enter another state ([EnterState]), with
+ * Indicates whether a [Reactor] should enter another state ([EnterState]), with
  * [EnterState.state] as the next state, or [FinishWith] the result [FinishWith.result].
  */
 @Suppress("UNUSED")


### PR DESCRIPTION
Several internal slack messages showed developers are getting scared and confused by "basically a monad". The sentence that follows is super clear, so seems worth sticking to that?