### PR TITLE
Introduce WorkflowPoolMonitor and an implementation that produces trace files.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ buildscript {
       'mavenPublishPlugin': '0.6.0',
       'mockito': '2.7.5',
       'mockitoKotlin': '1.5.0',
+      'moshiVersion': '1.8.0',
       'rxjava2Extensions': '0.20.4',
   ]
 
@@ -49,6 +50,7 @@ buildscript {
       'appcompatv7': "com.android.support:appcompat-v7:${versions.supportVersion}",
       'coordinators': "com.squareup.coordinators:coordinators:${versions.coordinators}",
       'design': "com.android.support:design:${versions.supportVersion}",
+      'moshi': "com.squareup.moshi:moshi:${versions.moshiVersion}",
       'rxandroid2': "io.reactivex.rxjava2:rxandroid:${versions.rxandroid2}",
       'timber': "com.jakewharton.timber:timber:${versions.timberVersion}",
 
@@ -62,8 +64,10 @@ buildscript {
           ],
           'coroutines': [
               'core': "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}",
-              'rx2': "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${versions.kotlinCoroutines}"
+              'rx2': "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${versions.kotlinCoroutines}",
+              'android': "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinCoroutines}"
           ],
+          'moshi': "com.squareup.moshi:moshi-kotlin:${versions.moshiVersion}",
           'reflect': "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}",
           'test': [
               'common': "org.jetbrains.kotlin:kotlin-test-common",

--- a/sample-android-app/build.gradle
+++ b/sample-android-app/build.gradle
@@ -36,9 +36,11 @@ dependencies {
   implementation project(':sample-game-android')
   implementation project(':viewregistry-android')
   implementation project(':workflow-rx2')
+  implementation project(':workflowpoolmonitor-tracing')
 
   implementation deps.appcompatv7
   implementation deps.design
+  implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.reflect
   implementation deps.okio
   implementation deps.rxandroid2

--- a/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellComponent.kt
+++ b/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellComponent.kt
@@ -21,15 +21,24 @@ import com.squareup.sample.tictactoe.RealGameLog
 import com.squareup.sample.tictactoe.RunGameReactor
 import com.squareup.sample.tictactoe.TakeTurnsReactor
 import com.squareup.workflow.WorkflowPool
-import timber.log.Timber
+import com.squareup.workflow.WorkflowPoolMonitor
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitor
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
+import timber.log.Timber
 
 /**
  * Pretend generated code of a pretend DI framework.
  */
 internal class ShellComponent {
 
-  val workflowPool = WorkflowPool()
+  val workflowTracer = TracingWorkflowPoolMonitor()
+
+  val workflowPoolMonitor: WorkflowPoolMonitor = WorkflowPoolMonitor.merge(
+      TimberWorkflowPoolMonitor(),
+      workflowTracer
+  )
+
+  val workflowPool = WorkflowPool(workflowPoolMonitor)
 
   private val authService = AuthService()
 

--- a/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellReactor.kt
+++ b/sample-android-app/src/main/java/com/squareup/sample/authgameapp/ShellReactor.kt
@@ -27,6 +27,7 @@ import com.squareup.workflow.Reaction
 import com.squareup.workflow.Running
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.abandonWorkflow
 import com.squareup.workflow.register
 import com.squareup.workflow.rx2.EventChannel
 import com.squareup.workflow.rx2.Reactor

--- a/sample-android-app/src/main/java/com/squareup/sample/authgameapp/TimberWorkflowPoolMonitor.kt
+++ b/sample-android-app/src/main/java/com/squareup/sample/authgameapp/TimberWorkflowPoolMonitor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Square Inc.
+ * Copyright 2019 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-include ':sample-android-app'
-include ':sample-auth-android'
-include ':sample-auth-common'
-include ':sample-game-android'
-include ':sample-game-common'
-include ':viewregistry-android'
-include ':viewregistry'
-include ':workflow-core'
-include ':workflow-rx2'
-include ':workflow-test'
-include ':workflowpoolmonitor-tracing'
+package com.squareup.sample.authgameapp
+
+import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.WorkflowPoolMonitor
+import com.squareup.workflow.WorkflowPoolMonitorEvent
+import timber.log.Timber
+
+class TimberWorkflowPoolMonitor : WorkflowPoolMonitor {
+  override fun report(
+    pool: WorkflowPool,
+    event: WorkflowPoolMonitorEvent
+  ) {
+    Timber.tag("WorkflowPoolMonitor")
+    Timber.v("WorkflowPool event:\n\t%s", event)
+  }
+}

--- a/sample-game-common/src/main/java/com/squareup/sample/tictactoe/RunGameReactor.kt
+++ b/sample-game-common/src/main/java/com/squareup/sample/tictactoe/RunGameReactor.kt
@@ -44,6 +44,7 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowPool
 import com.squareup.workflow.WorkflowPool.Handle
 import com.squareup.workflow.WorkflowPool.Launcher
+import com.squareup.workflow.abandonWorker
 import com.squareup.workflow.register
 import com.squareup.workflow.rx2.EventChannel
 import com.squareup.workflow.rx2.Reactor

--- a/workflow-core/src/main/java/com/squareup/workflow/RealWorkflowPool.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/RealWorkflowPool.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowPool.Handle
+import com.squareup.workflow.WorkflowPool.Id
+import com.squareup.workflow.WorkflowPool.Launcher
+import com.squareup.workflow.WorkflowPool.Type
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.channels.consume
+
+internal class RealWorkflowPool : WorkflowPool {
+
+  private class WorkflowEntry(val workflow: Workflow<*, *, *>)
+
+  private val launchers = mutableMapOf<Type<*, *, *>, Launcher<*, *, *>>()
+  private val workflows = mutableMapOf<Id<*, *, *>, WorkflowEntry>()
+
+  override val peekWorkflowsCount get() = workflows.values.size
+
+  override fun <S : Any, E : Any, O : Any> register(
+    launcher: Launcher<S, E, O>,
+    type: Type<S, E, O>
+  ) {
+    launchers[type] = launcher
+  }
+
+  override suspend fun <S : Any, E : Any, O : Any> awaitWorkflowUpdate(
+    handle: Handle<S, E, O>
+  ): WorkflowUpdate<S, E, O> {
+    val workflow = requireWorkflow(handle)
+    workflow.openSubscriptionToState()
+        .consume {
+          removeCompletedWorkflowAfter(handle.id) {
+            var state = receiveOrNull()
+            // Skip all the states that match the handle's state.
+            while (state == handle.state) {
+              state = receiveOrNull()
+            }
+            return state
+                ?.let { Running(handle.copy(state = it)) }
+                ?: Finished(workflow.await())
+          }
+        }
+  }
+
+  override suspend fun <I : Any, O : Any> awaitWorkerResult(
+    worker: Worker<I, O>,
+    input: I,
+    name: String,
+    type: Type<I, Nothing, O>
+  ): O {
+    register(worker.asLauncher(), type)
+    val handle = Handle(type.makeWorkflowId(name), input)
+    val workflow = requireWorkflow(handle)
+
+    removeCompletedWorkflowAfter(handle.id) {
+      return workflow.await()
+    }
+  }
+
+  override fun <E : Any> input(
+    handle: Handle<*, E, *>
+  ): WorkflowInput<E> = object : WorkflowInput<E> {
+    override fun sendEvent(event: E) {
+      workflows[handle.id]?.let {
+        @Suppress("UNCHECKED_CAST")
+        (it.workflow as WorkflowInput<E>).sendEvent(event)
+      }
+    }
+  }
+
+  override fun abandonWorkflow(id: Id<*, *, *>) {
+    workflows[id]?.workflow?.cancel()
+  }
+
+  override fun abandonAll() {
+    workflows.values.forEach { it.workflow.cancel() }
+  }
+
+  private fun <S : Any, E : Any, O : Any> launcher(
+    type: Type<S, E, O>
+  ): Launcher<S, E, O> {
+    val launcher = launchers[type]
+    check(launcher != null) {
+      "Expected launcher for \"$type\". Did you forget to call WorkflowPool.register()?"
+    }
+    @Suppress("UNCHECKED_CAST")
+    return launcher as Launcher<S, E, O>
+  }
+
+  private fun <S : Any, E : Any, O : Any> requireWorkflow(
+    handle: Handle<S, E, O>
+  ): Workflow<S, E, O> {
+    // Some complexity here to handle workflows that complete the moment
+    // they are started. We want to return the short-lived workflow so that its
+    // result can be processed, but we also need to make sure it doesn't linger
+    // in the map.
+
+    @Suppress("UNCHECKED_CAST")
+    var workflow = workflows[handle.id]?.workflow as Workflow<S, E, O>?
+
+    if (workflow == null) {
+      workflow = launcher(handle.id.workflowType).launch(handle.state, this)
+
+      val entry = WorkflowEntry(workflow)
+      // This entry will eventually be removed from the map by removeCompletedWorkflowAfter.
+      workflows[handle.id] = entry
+    }
+    return workflow
+  }
+
+  /**
+   * Ensures that the workflow identified by [id] is removed from the pool map before returning,
+   * iff that workflow is completed after [block] returns or throws.
+   *
+   * **This function must be used any time a workflow result is about to be reported.**
+   */
+  private inline fun <R : Any> removeCompletedWorkflowAfter(
+    id: Id<*, *, *>,
+    block: () -> R
+  ): R = try {
+    block()
+  } finally {
+    workflows[id]?.let { workflow ->
+      if (workflow.workflow.isCompleted) {
+        workflows -= id
+      }
+    }
+  }
+}
+
+private fun <I : Any, O : Any> Worker<I, O>.asLauncher() = object : Launcher<I, Nothing, O> {
+  override fun launch(
+    initialState: I,
+    workflows: WorkflowPool
+  ): Workflow<@UnsafeVariance I, Nothing, O> =
+    GlobalScope.workflow(Dispatchers.Unconfined) { _, _ ->
+      call(initialState)
+    }
+}

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowPool.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowPool.kt
@@ -29,7 +29,7 @@ import kotlin.reflect.KClass
  * Creates a new [WorkflowPool].
  */
 @Suppress("FunctionName")
-fun WorkflowPool(): WorkflowPool = RealWorkflowPool()
+fun WorkflowPool(monitor: WorkflowPoolMonitor? = null): WorkflowPool = RealWorkflowPool(monitor)
 
 /**
  * Runs [Workflow] and [Worker]s on demand. Create by calling the `WorkflowPool` function.
@@ -76,6 +76,8 @@ interface WorkflowPool {
       other is Type<*, *, *> -> types.contentEquals(other.types)
       else -> false
     }
+
+    override fun toString(): String = "WorkflowPool.Type(${types.joinToString { it.java.name }})"
   }
 
   /**
@@ -103,8 +105,7 @@ interface WorkflowPool {
    * Unique identifier for a particular [Workflow] to be run by a [WorkflowPool].
    * See [Type.makeWorkflowId] for details.
    */
-  data class Id<S : Any, in E : Any, out O : Any>
-  internal constructor(
+  data class Id<S : Any, in E : Any, out O : Any>(
     val name: String,
     val workflowType: Type<S, E, O>
   )

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowPoolMonitor.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowPoolMonitor.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+/**
+ * TODO kdoc
+ */
+interface WorkflowPoolMonitor {
+  fun report(
+    pool: WorkflowPool,
+    event: WorkflowPoolMonitorEvent
+  )
+
+  companion object {
+    /**
+     * Returns a [WorkflowPoolMonitor] that forwards all events to all the passed [monitors].
+     */
+    fun merge(vararg monitors: WorkflowPoolMonitor): WorkflowPoolMonitor =
+      object : WorkflowPoolMonitor {
+        override fun report(
+          pool: WorkflowPool,
+          event: WorkflowPoolMonitorEvent
+        ) {
+          monitors.forEach { it.report(pool, event) }
+        }
+      }
+  }
+}
+
+/**
+ * Reports the event returned by [eventProvider] if the monitor is non-null.
+ */
+inline fun WorkflowPoolMonitor?.report(
+  pool: WorkflowPool,
+  eventProvider: () -> WorkflowPoolMonitorEvent
+) = this?.report(pool, eventProvider())

--- a/workflow-core/src/main/java/com/squareup/workflow/WorkflowPoolMonitorEvent.kt
+++ b/workflow-core/src/main/java/com/squareup/workflow/WorkflowPoolMonitorEvent.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Square Inc.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowPool.Id
+import com.squareup.workflow.WorkflowPool.Launcher
+import com.squareup.workflow.WorkflowPool.Type
+
+/**
+ * Events that can be reported by a [WorkflowPool].
+ *
+ * The sequence of possible events for a given workflow is as follows:
+ *  TODO flow chart
+ */
+sealed class WorkflowPoolMonitorEvent {
+
+  /**
+   * Emitted when a workflow is [registered][WorkflowPool.register] on a [WorkflowPool].
+   */
+  data class Registered(
+    val type: Type<*, *, *>,
+    val launcher: Launcher<*, *, *>
+  ) : WorkflowPoolMonitorEvent()
+
+  /**
+   * Emitted as soon as [WorkflowPool.awaitWorkflowUpdate] or [WorkflowPool.awaitWorkerResult] are
+   * called, before the update is actually dispatched.
+   */
+  data class UpdateRequested(
+    val id: Id<*, *, *>,
+    val state: Any
+  ) : WorkflowPoolMonitorEvent()
+
+  /**
+   * Emitted when the [WorkflowPool] launches a new instance of a workflow.
+   */
+  data class Launched(
+    val id: Id<*, *, *>,
+    val initialState: Any
+  ) : WorkflowPoolMonitorEvent()
+
+  /**
+   * Emitted every time a [Workflow] emits a new state.
+   */
+  data class StateChanged(
+    val id: Id<*, *, *>,
+    val newState: Any
+  ) : WorkflowPoolMonitorEvent()
+
+  /**
+   * Emitted every time an event is sent to the [Workflow].
+   */
+  data class ReceivedEvent(
+    val id: Id<*, *, *>,
+    val event: Any
+  ) : WorkflowPoolMonitorEvent()
+
+  /**
+   * Emitted when a [Workflow] completes.
+   *
+   * @see RemovedFromPool
+   */
+  data class Finished(
+    val id: Id<*, *, *>,
+    val result: Any
+  ) : WorkflowPoolMonitorEvent()
+
+  /**
+   * Emitted when the [WorkflowPool] is asked to abandon a workflow.
+   */
+  data class Abandoned(
+    val id: Id<*, *, *>
+  ) : WorkflowPoolMonitorEvent()
+
+  /**
+   * Emitted when the [WorkflowPool] removes a completed or abandoned [Workflow] from its pool.
+   */
+  data class RemovedFromPool(
+    val id: Id<*, *, *>
+  ) : WorkflowPoolMonitorEvent()
+}

--- a/workflow-core/src/test/java/com/squareup/workflow/RealWorkflowPoolMonitorIntegrationTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/RealWorkflowPoolMonitorIntegrationTest.kt
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowPool.Launcher
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Abandoned
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Finished
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Launched
+import com.squareup.workflow.WorkflowPoolMonitorEvent.ReceivedEvent
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Registered
+import com.squareup.workflow.WorkflowPoolMonitorEvent.RemovedFromPool
+import com.squareup.workflow.WorkflowPoolMonitorEvent.StateChanged
+import com.squareup.workflow.WorkflowPoolMonitorEvent.UpdateRequested
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.channels.Channel
+import kotlinx.coroutines.experimental.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.experimental.channels.toChannel
+import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.experimental.suspendCoroutine
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests that the correct events are reported to the [WorkflowPoolMonitor] when [RealWorkflowPool]
+ * goes about its business.
+ */
+@Suppress("DeferredResultUnused")
+class RealWorkflowPoolMonitorIntegrationTest : CoroutineScope {
+
+  private val monitor = TestWorkflowPoolMonitor()
+  private val pool = RealWorkflowPool(monitor)
+
+  override val coroutineContext: CoroutineContext
+    get() = Dispatchers.Unconfined
+
+  @BeforeTest fun setup() {
+    assertTrue(monitor.rawEvents.isEmpty())
+  }
+
+  @AfterTest fun `tear down`() {
+    assertTrue("all events have the same pool") {
+      monitor.rawEvents.all { it.pool === pool }
+    }
+  }
+
+  @Test fun `emits Registered on registration`() {
+    val launcher = object : Launcher<String, Unit, String> {
+      override fun launch(
+        initialState: String,
+        workflows: WorkflowPool
+      ) = workflow<String, Unit, String> { _, _ -> initialState }
+    }
+
+    pool.register(launcher)
+
+    monitor.assertEvents(Registered(launcher.workflowType, launcher))
+  }
+
+  @Test fun `emits Launched on workflow creation`() {
+    val launcher = object : Launcher<String, Unit, String> {
+      override fun launch(
+        initialState: String,
+        workflows: WorkflowPool
+      ) = workflow<String, Unit, String> { _, _ -> suspendCoroutine<Nothing> { } }
+    }
+    val handle = WorkflowPool.handle(launcher::class, "start")
+    pool.register(launcher)
+
+    pool.workflowUpdate(handle)
+
+    monitor.assertEventsEndsWith(Launched(handle.id, "start"))
+  }
+
+  @Test fun `emits Launched on worker creation`() {
+    val worker = worker<String, Unit> { suspendCoroutine<Nothing> { } }
+
+    pool.workerResult(worker, "start")
+
+    assertTrue(Launched(worker.workflowType.makeWorkflowId(), "start") in monitor.events)
+  }
+
+  @Test fun `emits UpdateRequested on update for workflow`() {
+    val launcher = object : Launcher<String, Unit, String> {
+      override fun launch(
+        initialState: String,
+        workflows: WorkflowPool
+      ) = workflow<String, Unit, String> { _, _ -> suspendCoroutine<Nothing> { } }
+    }
+    val handle = WorkflowPool.handle(launcher::class, "start")
+    pool.register(launcher)
+
+    pool.workflowUpdate(handle)
+
+    assertTrue(UpdateRequested(handle.id, handle.state) in monitor.events)
+  }
+
+  @Test fun `emits UpdateRequested on update for worker`() {
+    val worker = worker<String, Unit> { suspendCoroutine<Nothing> { } }
+
+    pool.workerResult(worker, "start")
+
+    assertTrue(UpdateRequested(worker.workflowType.makeWorkflowId(), "start") in monitor.events)
+  }
+
+  @Test fun `emits UpdateRequested before first workflow Launch`() {
+    val launcher = object : Launcher<String, Unit, String> {
+      override fun launch(
+        initialState: String,
+        workflows: WorkflowPool
+      ) = workflow<String, Unit, String> { _, _ -> suspendCoroutine<Nothing> { } }
+    }
+    val handle = WorkflowPool.handle(launcher::class, "start")
+    pool.register(launcher)
+
+    pool.workflowUpdate(handle)
+
+    monitor.assertEventsEndsWith(
+        UpdateRequested(handle.id, handle.state),
+        Launched(handle.id, handle.state)
+    )
+  }
+
+  @Test fun `initialization event order for worker`() {
+    val worker = worker<String, Unit> { suspendCoroutine<Nothing> { } }
+    val id = worker.workflowType.makeWorkflowId()
+
+    pool.workerResult(worker, "start")
+
+    val (update, register, launch) = monitor.events
+    update as UpdateRequested
+    register as Registered
+    launch as Launched
+    assertEquals(UpdateRequested(id, "start"), update)
+    assertEquals(worker.workflowType, register.type)
+    assertEquals(Launched(id, "start"), launch)
+  }
+
+  @Test fun `completion event order for workflow when finishes`() {
+    val launcher = object : Launcher<Unit, Unit, String> {
+      override fun launch(
+        initialState: Unit,
+        workflows: WorkflowPool
+      ): Workflow<Unit, Unit, String> = workflow { _, _ -> "done" }
+    }
+    val handle = WorkflowPool.handle(launcher::class)
+    val id = handle.id
+    pool.register(launcher)
+
+    pool.workflowUpdate(handle)
+
+    val (remove, finish, launch) = monitor.events.asReversed()
+    launch as Launched
+    finish as Finished
+    remove as RemovedFromPool
+    assertEquals(Finished(id, "done"), finish)
+    assertEquals(RemovedFromPool(id), remove)
+  }
+
+  @Test fun `completion event order for worker when finishes`() {
+    val worker = worker<String, String> { it }
+    val id = worker.workflowType.makeWorkflowId()
+
+    pool.workerResult(worker, "foo")
+
+    val (remove, finish, launch) = monitor.events.asReversed()
+    launch as Launched
+    finish as Finished
+    remove as RemovedFromPool
+    assertEquals(Finished(id, "foo"), finish)
+    assertEquals(RemovedFromPool(id), remove)
+  }
+
+  @Test fun `completion event order for workflow when abandoned`() {
+    val launcher = object : Launcher<Unit, Unit, String> {
+      override fun launch(
+        initialState: Unit,
+        workflows: WorkflowPool
+      ): Workflow<Unit, Unit, String> = workflow { _, _ -> suspendCoroutine {} }
+    }
+    val handle = WorkflowPool.handle(launcher::class)
+    val id = handle.id
+    pool.register(launcher)
+
+    pool.workflowUpdate(handle)
+    pool.abandonWorkflow(handle)
+
+    monitor.assertEventsEndsWith(Abandoned(id))
+
+    // TODO(https://github.com/square/workflow/issues/131) Abandoned workflows
+    // should be removed from the pool.
+    // monitor.assertEventsEndsWith(RemovedFromPool(id))
+  }
+
+  @Test fun `completion event order for worker when abandoned`() {
+    val worker = worker<String, String> { suspendCoroutine { } }
+    val id = worker.workflowType.makeWorkflowId()
+
+    pool.workerResult(worker, "foo")
+    pool.abandonWorker(worker)
+
+    monitor.assertEventsEndsWith(Abandoned(id))
+
+    // TODO(https://github.com/square/workflow/issues/131) Abandoned workflows
+    // should be removed from the pool.
+    // monitor.assertEventsEndsWith(RemovedFromPool(id))
+  }
+
+  @Test fun `emits StateChanged when workflow emits new state`() {
+    val states = Channel<String>(UNLIMITED)
+    val launcher = object : Launcher<String, String, Unit> {
+      override fun launch(
+        initialState: String,
+        workflows: WorkflowPool
+      ): Workflow<String, String, Unit> = workflow { state, _ ->
+        states.toChannel(state)
+      }
+    }
+    pool.register(launcher)
+    val handle = WorkflowPool.handle(launcher::class, "start")
+    val id = handle.id
+
+    states.offer("foo")
+    pool.workflowUpdate(handle)
+    monitor.assertEventsEndsWith(StateChanged(id, "foo"))
+
+    states.offer("bar")
+    pool.workflowUpdate(handle)
+    states.offer("baz")
+    pool.workflowUpdate(handle)
+    monitor.assertEventsEndsWith(
+        StateChanged(id, "foo"),
+        UpdateRequested(id, "start"),
+        StateChanged(id, "bar"),
+        UpdateRequested(id, "start"),
+        StateChanged(id, "baz")
+    )
+  }
+
+  @Test fun `emit ReceivedEvent when event is sent to running workflow`() {
+    val launcher = object : Launcher<Unit, String, Unit> {
+      override fun launch(
+        initialState: Unit,
+        workflows: WorkflowPool
+      ): Workflow<Unit, String, Unit> = workflow { _, _ ->
+        suspendCoroutine<Nothing> { }
+      }
+    }
+    val handle = WorkflowPool.handle(launcher::class)
+    val id = handle.id
+    pool.register(launcher)
+    pool.workflowUpdate(handle)
+
+    pool.input(handle)
+        .sendEvent("foo")
+    monitor.assertEventsEndsWith(ReceivedEvent(id, "foo"))
+
+    pool.input(handle)
+        .sendEvent("bar")
+    monitor.assertEventsEndsWith(ReceivedEvent(id, "bar"))
+  }
+
+  @Test fun `doesn't emit ReceivedEvent when event is sent to unstarted workflow`() {
+    val launcher = object : Launcher<Unit, String, Unit> {
+      override fun launch(
+        initialState: Unit,
+        workflows: WorkflowPool
+      ): Workflow<Unit, String, Unit> = workflow { _, _ ->
+        suspendCoroutine<Nothing> { }
+      }
+    }
+    val handle = WorkflowPool.handle(launcher::class)
+    pool.register(launcher)
+
+    pool.input(handle)
+        .sendEvent("foo")
+    assertFalse(monitor.events.any { it is ReceivedEvent })
+  }
+
+  @Test fun `doesn't emit ReceivedEvent when event is sent to completed workflow`() {
+    val launcher = object : Launcher<Unit, String, Unit> {
+      override fun launch(
+        initialState: Unit,
+        workflows: WorkflowPool
+      ): Workflow<Unit, String, Unit> = workflow { _, _ -> }
+    }
+    val handle = WorkflowPool.handle(launcher::class)
+    pool.register(launcher)
+    pool.workflowUpdate(handle)
+
+    pool.input(handle)
+        .sendEvent("foo")
+    assertFalse(monitor.events.any { it is ReceivedEvent })
+  }
+
+  private class TestWorkflowPoolMonitor : WorkflowPoolMonitor {
+
+    data class RecordedEvent(
+      val pool: WorkflowPool,
+      val event: WorkflowPoolMonitorEvent
+    )
+
+    val rawEvents = mutableListOf<RecordedEvent>()
+
+    val events get() = rawEvents.map { it.event }
+
+    fun assertEvents(vararg events: WorkflowPoolMonitorEvent) =
+      assertEquals(events.asList(), this.events)
+
+    fun assertEventsEndsWith(vararg events: WorkflowPoolMonitorEvent) =
+      assertEquals(events.asList(), this.events.takeLast(events.size))
+
+    override fun report(
+      pool: WorkflowPool,
+      event: WorkflowPoolMonitorEvent
+    ) {
+      rawEvents += RecordedEvent(pool, event)
+    }
+  }
+}

--- a/workflow-core/src/test/java/com/squareup/workflow/RealWorkflowPoolTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/RealWorkflowPoolTest.kt
@@ -62,7 +62,7 @@ class RealWorkflowPoolTest {
 
   private val myReactor = MyReactor()
 
-  private val pool = RealWorkflowPool().apply { register(myReactor) }
+  private val pool = RealWorkflowPool(null).apply { register(myReactor) }
 
   private fun handle(
     state: String = "",

--- a/workflow-core/src/test/java/com/squareup/workflow/RealWorkflowPoolTest.kt
+++ b/workflow-core/src/test/java/com/squareup/workflow/RealWorkflowPoolTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @Suppress("DeferredResultUnused", "MemberVisibilityCanBePrivate")
-class WorkflowPoolTest {
+class RealWorkflowPoolTest {
   companion object {
     const val NEW = "*NEW*"
     const val STOP = "*STOP*"
@@ -60,9 +60,9 @@ class WorkflowPoolTest {
     }
   }
 
-  val myReactor = MyReactor()
+  private val myReactor = MyReactor()
 
-  val pool = WorkflowPool().apply { register(myReactor) }
+  private val pool = RealWorkflowPool().apply { register(myReactor) }
 
   private fun handle(
     state: String = "",

--- a/workflow-rx2/src/main/java/com/squareup/workflow/rx2/EventSelectBuilder.kt
+++ b/workflow-rx2/src/main/java/com/squareup/workflow/rx2/EventSelectBuilder.kt
@@ -21,8 +21,9 @@ import com.squareup.workflow.Finished
 import com.squareup.workflow.Running
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowUpdate
 import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.WorkflowUpdate
+import com.squareup.workflow.awaitWorkerResult
 import io.reactivex.Single
 import io.reactivex.Single.just
 import kotlinx.coroutines.experimental.CoroutineScope

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/Rx2ReactorIntegrationTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/Rx2ReactorIntegrationTest.kt
@@ -24,6 +24,7 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowPool
 import com.squareup.workflow.WorkflowPool.Handle
 import com.squareup.workflow.WorkflowUpdate
+import com.squareup.workflow.abandonWorkflow
 import com.squareup.workflow.register
 import com.squareup.workflow.rx2.Rx2ReactorIntegrationTest.OuterEvent.Background
 import com.squareup.workflow.rx2.Rx2ReactorIntegrationTest.OuterEvent.Cancel

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/Rx2WorkflowPoolIntegrationTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/Rx2WorkflowPoolIntegrationTest.kt
@@ -21,9 +21,10 @@ import com.squareup.workflow.Finished
 import com.squareup.workflow.Reaction
 import com.squareup.workflow.Running
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowUpdate
 import com.squareup.workflow.WorkflowPool
 import com.squareup.workflow.WorkflowPool.Handle
+import com.squareup.workflow.WorkflowUpdate
+import com.squareup.workflow.abandonWorkflow
 import com.squareup.workflow.register
 import io.reactivex.Single
 import io.reactivex.observers.TestObserver

--- a/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkerIntegrationTest.kt
+++ b/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkerIntegrationTest.kt
@@ -17,6 +17,7 @@ package com.squareup.workflow.rx2
 
 import com.squareup.workflow.Worker
 import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.abandonWorker
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.SingleSubject
 import kotlinx.coroutines.experimental.channels.Channel

--- a/workflowpoolmonitor-tracing/README.md
+++ b/workflowpoolmonitor-tracing/README.md
@@ -1,0 +1,8 @@
+# workflowpoolmonitor-tracing
+
+Provides an implementation of `WorkflowPoolMonitor` that outputs a file compatible with
+Chrome's `chrome://tracing` viewer. The trace file format is described in [this doc][1].
+
+TODO usage
+
+ [1] https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU

--- a/workflowpoolmonitor-tracing/build.gradle
+++ b/workflowpoolmonitor-tracing/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Square Inc.
+ * Copyright 2019 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-include ':sample-android-app'
-include ':sample-auth-android'
-include ':sample-auth-common'
-include ':sample-game-android'
-include ':sample-game-common'
-include ':viewregistry-android'
-include ':viewregistry'
-include ':workflow-core'
-include ':workflow-rx2'
-include ':workflow-test'
-include ':workflowpoolmonitor-tracing'
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+apply plugin: 'com.vanniktech.maven.publish'
+
+sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_7
+
+kotlin.experimental.coroutines 'enable'
+
+dependencies {
+  compileOnly deps.annotations.intellij
+
+  api project(':workflow-core')
+  api deps.kotlin.stdLib.jdk6
+  api deps.kotlin.coroutines.core
+
+  implementation deps.kotlin.reflect
+  implementation deps.kotlin.moshi
+  implementation deps.moshi
+  
+  testImplementation deps.kotlin.test.jdk
+}

--- a/workflowpoolmonitor-tracing/gradle.properties
+++ b/workflowpoolmonitor-tracing/gradle.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2019 Square Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+POM_ARTIFACT_ID=workflowpoolmonitor-tracing
+POM_NAME=WorkflowPoolMonitor Tracing
+POM_PACKAGING=jar

--- a/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TraceEvent.kt
+++ b/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TraceEvent.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.monitoring.tracing
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.Json
+import com.squareup.moshi.ToJson
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Phase
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Scope
+
+internal data class TraceEvent(
+  val name: String,
+  @Json(name = "cat") val category: String? = null,
+  @Json(name = "ph") val phase: Phase,
+  @Json(name = "ts") val timestamp: Long,
+  @Json(name = "pid") val processId: Int,
+  @Json(name = "tid") val threadId: Int,
+  /** Only used for [Phase.INSTANT] events. */
+  @Json(name = "s") val scope: Scope? = null,
+  val args: Map<String, Any>? = null
+) {
+  enum class Phase(val code: Char) {
+    DURATION_BEGIN('B'),
+    DURATION_END('E'),
+    COMPLETE('X'),
+    INSTANT('i'),
+    COUNTER('C'),
+    ASYNC_BEGIN('b'),
+    ASYNC_INSTANT('n'),
+    ASYNC_END('e'),
+  }
+
+  enum class Scope(val code: Char) {
+    GLOBAL('g'),
+    PROCESS('p'),
+    THREAD('t')
+  }
+}
+
+internal object PhaseAdapter {
+  @ToJson fun toJson(phase: Phase) = phase.code
+  @FromJson fun fromJson(code: Char) = Phase.values().single { it.code == code }
+}
+
+internal object ScopeAdapter {
+  @ToJson fun toJson(scope: Scope) = scope.code
+  @FromJson fun fromJson(code: Char) = Scope.values().single { it.code == code }
+}

--- a/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TraceFile.kt
+++ b/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TraceFile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Square Inc.
+ * Copyright 2019 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-include ':sample-android-app'
-include ':sample-auth-android'
-include ':sample-auth-common'
-include ':sample-game-android'
-include ':sample-game-common'
-include ':viewregistry-android'
-include ':viewregistry'
-include ':workflow-core'
-include ':workflow-rx2'
-include ':workflow-test'
-include ':workflowpoolmonitor-tracing'
+package com.squareup.workflow.monitoring.tracing
+
+import com.squareup.moshi.Json
+
+internal data class TraceFile(
+  @Json(name = "traceEvents") val events: List<TraceEvent>,
+  val otherData: Map<String, Any> = emptyMap()
+)

--- a/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TracingWorkflowPoolMonitor.kt
+++ b/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TracingWorkflowPoolMonitor.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.monitoring.tracing
+
+import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.WorkflowPoolMonitor
+import com.squareup.workflow.WorkflowPoolMonitorEvent
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitorActor.Message
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitorActor.Message.ReportEvent
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitorActor.Message.WriteTrace
+import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.IO
+import kotlinx.coroutines.experimental.channels.Channel
+import kotlinx.coroutines.experimental.channels.actor
+import kotlinx.coroutines.experimental.withContext
+import okio.Okio.sink
+import okio.Sink
+import java.io.File
+import java.util.concurrent.TimeUnit.MICROSECONDS
+import java.util.concurrent.TimeUnit.NANOSECONDS
+
+/**
+ * A [WorkflowPoolMonitor] that collects events and can write out trace files compatible with
+ * Chrome's `chrome://tracing` viewer.
+ *
+ * @param microsecondClock Function that returns the current time in **micro**seconds (_not_
+ * milliseconds).
+ */
+class TracingWorkflowPoolMonitor(
+  private val microsecondClock: () -> Long = systemMicrosecondClock,
+  actorDispatcher: CoroutineDispatcher = Dispatchers.Default,
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : WorkflowPoolMonitor {
+
+  private val actor =
+    GlobalScope.actor<Message>(actorDispatcher, capacity = Channel.UNLIMITED) {
+      val actor = TracingWorkflowPoolMonitorActor(ioDispatcher)
+      for (message in channel) {
+        actor.onMessage(message)
+      }
+    }
+
+  /**
+   * Formats all the recorded events into a trace file and writes it to [sink].
+   *
+   * The actual writes are done on the `IO` dispatcher, so this method can safely be called from
+   * main UI threads.
+   */
+  suspend fun writeTraceFile(sink: Sink) {
+    val onComplete = CompletableDeferred<Unit>()
+    actor.offer(WriteTrace(sink, onComplete))
+    onComplete.await()
+  }
+
+  suspend fun writeTraceFile(file: File) = withContext(ioDispatcher) {
+    sink(file).use { sink ->
+      writeTraceFile(sink)
+    }
+  }
+
+  override fun report(
+    pool: WorkflowPool,
+    event: WorkflowPoolMonitorEvent
+  ) {
+    val timestamp = microsecondClock()
+    actor.offer(ReportEvent(timestamp, pool, event))
+  }
+
+  fun dispose() {
+    actor.close()
+  }
+
+  companion object {
+    /**
+     * Microsecond clock based on [System.nanoTime].
+     */
+    val systemMicrosecondClock = { MICROSECONDS.convert(System.nanoTime(), NANOSECONDS) }
+  }
+}

--- a/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TracingWorkflowPoolMonitorActor.kt
+++ b/workflowpoolmonitor-tracing/src/main/java/com/squareup/workflow/monitoring/tracing/TracingWorkflowPoolMonitorActor.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.monitoring.tracing
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi.Builder
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.WorkflowPool.Id
+import com.squareup.workflow.WorkflowPool.Launcher
+import com.squareup.workflow.WorkflowPool.Type
+import com.squareup.workflow.WorkflowPoolMonitorEvent
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Abandoned
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Finished
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Launched
+import com.squareup.workflow.WorkflowPoolMonitorEvent.ReceivedEvent
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Registered
+import com.squareup.workflow.WorkflowPoolMonitorEvent.RemovedFromPool
+import com.squareup.workflow.WorkflowPoolMonitorEvent.StateChanged
+import com.squareup.workflow.WorkflowPoolMonitorEvent.UpdateRequested
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Phase.DURATION_BEGIN
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Phase.DURATION_END
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Phase.INSTANT
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Scope.PROCESS
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Scope.THREAD
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitorActor.Message
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitorActor.Message.ReportEvent
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitorActor.Message.WriteTrace
+import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.experimental.withContext
+import okio.Okio.buffer
+import okio.Sink
+import org.jetbrains.annotations.TestOnly
+import java.util.LinkedList
+
+/**
+ * A typed actor that aggregates [TraceEvent]s and can write out formatted trace files.
+ *
+ * The use of the actor pattern allows all the work to be down on background threads, without
+ * worrying about explicit synchronization. Event reports and write requests are just sent to the
+ * actor's inbox as [Message]s, so event reporting has almost zero runtime cost on reporting thread.
+ * Also, the IO performed during trace file writes are automatically performed on a background
+ * thread.
+ */
+internal class TracingWorkflowPoolMonitorActor(
+  private val ioDispatcher: CoroutineDispatcher
+) {
+
+  sealed class Message {
+    /** @see TracingWorkflowPoolMonitor.report */
+    data class ReportEvent(
+      val timestamp: Long,
+      val pool: WorkflowPool,
+      val event: WorkflowPoolMonitorEvent
+    ) : Message()
+
+    /** @see TracingWorkflowPoolMonitor.writeTraceFile */
+    data class WriteTrace(
+      val sink: Sink,
+      val onComplete: CompletableDeferred<Unit>
+    ) : Message()
+  }
+
+  val adapter = buildMoshiAdapterForTraceFile()
+
+  private val processIdsByWorkflowPool = mutableMapOf<WorkflowPool, Int>()
+  private val threadIdsByType = mutableMapOf<Type<*, *, *>, Int>()
+  private val launcherNamesByType = mutableMapOf<Type<*, *, *>, String>()
+  private var nextProcessId = 0
+  private var nextThreadId = 0
+  private val traceEvents = LinkedList<TraceEvent>()
+
+  @TestOnly
+  internal fun peekTraceEvents(): List<TraceEvent> = traceEvents.toList()
+
+  suspend fun onMessage(message: Message) {
+    when (message) {
+
+      is ReportEvent -> {
+        traceEvents += createTraceEvent(message.timestamp, message.pool, message.event)
+      }
+
+      is WriteTrace -> {
+        try {
+          writeTraceEventsToSink(message.sink)
+          message.onComplete.complete(Unit)
+        } catch (e: Throwable) {
+          message.onComplete.completeExceptionally(e)
+        }
+      }
+    }
+  }
+
+  private fun createTraceEvent(
+    timestamp: Long,
+    pool: WorkflowPool,
+    event: WorkflowPoolMonitorEvent
+  ): TraceEvent {
+    val template = TraceEvent(
+        category = event.javaClass.simpleName,
+        timestamp = timestamp,
+        processId = pool.getProcessId(),
+        threadId = -1,
+        name = "",
+        phase = INSTANT
+    )
+    return when (event) {
+
+      is Registered -> template.copy(
+          name = getAndCacheLauncherName(event.launcher, event.type),
+          phase = INSTANT,
+          scope = PROCESS,
+          threadId = event.type.getThreadId(),
+          args = mapOf(
+              "type" to event.type.toString(),
+              "launcher" to event.launcher.toString()
+          )
+      )
+
+      // Starts a duration ended by Finished or Abandoned.
+      is Launched -> template.copy(
+          name = getRunningEventName(event.id),
+          phase = DURATION_BEGIN,
+          threadId = event.id.workflowType.getThreadId(),
+          args = mapOf("initial state" to event.initialState.toString())
+      )
+
+      is UpdateRequested -> template.copy(
+          name = getEventName(event.id) + " update requested",
+          phase = INSTANT,
+          scope = THREAD,
+          threadId = event.id.workflowType.getThreadId(),
+          args = mapOf("state" to event.state.toString())
+      )
+
+      is StateChanged -> template.copy(
+          name = getEventName(event.id) + " state changed",
+          phase = INSTANT,
+          scope = THREAD,
+          threadId = event.id.workflowType.getThreadId(),
+          args = mapOf("new state" to event.newState.toString())
+      )
+
+      is ReceivedEvent -> template.copy(
+          name = getEventName(event.id) + " received event",
+          phase = INSTANT,
+          scope = THREAD,
+          threadId = event.id.workflowType.getThreadId(),
+          args = mapOf("event" to event.event.toString())
+      )
+
+      // Ends the duration started by Launched (may also be ended by Abandoned).
+      is Finished -> template.copy(
+          name = getRunningEventName(event.id),
+          phase = DURATION_END,
+          threadId = event.id.workflowType.getThreadId(),
+          args = mapOf("result" to event.result.toString())
+      )
+
+      // Ends the duration started by Launched (may also be ended by Finished).
+      is Abandoned -> template.copy(
+          name = getRunningEventName(event.id),
+          phase = DURATION_END,
+          threadId = event.id.workflowType.getThreadId()
+      )
+
+      is RemovedFromPool -> template.copy(
+          name = "${getEventName(event.id)} removed from pool",
+          phase = INSTANT,
+          scope = THREAD,
+          threadId = event.id.workflowType.getThreadId()
+      )
+    }
+  }
+
+  private suspend fun writeTraceEventsToSink(sink: Sink) {
+    val traceFile = TraceFile(events = traceEvents)
+    withContext(ioDispatcher) {
+      val buffered = buffer(sink)
+      try {
+        adapter.toJson(buffered, traceFile)
+      } finally {
+        buffered.emit()
+      }
+    }
+  }
+
+  private fun WorkflowPool.getProcessId(): Int =
+    processIdsByWorkflowPool.getOrPut(this) { nextProcessId++ }
+
+  private fun Type<*, *, *>.getThreadId(): Int =
+    threadIdsByType.getOrPut(this) { nextThreadId++ }
+
+  private fun getAndCacheLauncherName(
+    launcher: Launcher<*, *, *>,
+    type: Type<*, *, *>
+  ): String = launcher.javaClass.name.also { launcherNamesByType[type] = it } + " launched"
+
+  private fun getRunningEventName(id: Id<*, *, *>) = "${getEventName(id)} running"
+  private fun getEventName(id: Id<*, *, *>) =
+    launcherNamesByType.getValue(id.workflowType) + "(${id.name})"
+}
+
+// Visible for testing.
+internal fun buildMoshiAdapterForTraceFile(): JsonAdapter<TraceFile> {
+  val moshi = Builder()
+      .add(PhaseAdapter)
+      .add(ScopeAdapter)
+      .add(KotlinJsonAdapterFactory())
+      .build()
+  return moshi.adapter(TraceFile::class.java)
+      .indent("  ")
+}

--- a/workflowpoolmonitor-tracing/src/test/java/com/squareup/workflow/monitoring/tracing/TracingWorkflowPoolMonitorActorTest.kt
+++ b/workflowpoolmonitor-tracing/src/test/java/com/squareup/workflow/monitoring/tracing/TracingWorkflowPoolMonitorActorTest.kt
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.monitoring.tracing
+
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.WorkflowPool
+import com.squareup.workflow.WorkflowPool.Id
+import com.squareup.workflow.WorkflowPool.Launcher
+import com.squareup.workflow.WorkflowPoolMonitorEvent
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Abandoned
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Finished
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Launched
+import com.squareup.workflow.WorkflowPoolMonitorEvent.ReceivedEvent
+import com.squareup.workflow.WorkflowPoolMonitorEvent.Registered
+import com.squareup.workflow.WorkflowPoolMonitorEvent.RemovedFromPool
+import com.squareup.workflow.WorkflowPoolMonitorEvent.StateChanged
+import com.squareup.workflow.WorkflowPoolMonitorEvent.UpdateRequested
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Phase.DURATION_BEGIN
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Phase.DURATION_END
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Phase.INSTANT
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Scope.PROCESS
+import com.squareup.workflow.monitoring.tracing.TraceEvent.Scope.THREAD
+import com.squareup.workflow.monitoring.tracing.TracingWorkflowPoolMonitorActor.Message.ReportEvent
+import com.squareup.workflow.workflowType
+import kotlinx.coroutines.experimental.Dispatchers
+import kotlinx.coroutines.experimental.runBlocking
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+private const val TIMESTAMP = 42L
+
+class TracingWorkflowPoolMonitorActorTest {
+  private val pool = WorkflowPool()
+  private val actor = TracingWorkflowPoolMonitorActor(Dispatchers.Unconfined)
+
+  @Test fun `Registered trace event`() {
+    assertTraceEquals(
+        Registered(NoopLauncher.workflowType, NoopLauncher),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher launched",
+            category = "Registered",
+            phase = INSTANT,
+            scope = PROCESS,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0,
+            args = mapOf(
+                "type" to NoopLauncher.typeString,
+                "launcher" to "NoopLauncher"
+            )
+        )
+    )
+  }
+
+  @Test fun `Launched trace event`() {
+    getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    assertTraceEquals(
+        Launched(NoopLauncher.makeId("name"), Foo),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher(name) running",
+            category = "Launched",
+            phase = DURATION_BEGIN,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0,
+            args = mapOf("initial state" to Foo.toString())
+        )
+    )
+  }
+
+  @Test fun `UpdateRequested trace event`() {
+    getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    assertTraceEquals(
+        UpdateRequested(NoopLauncher.makeId("name"), Foo),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher(name) update requested",
+            category = "UpdateRequested",
+            phase = INSTANT,
+            scope = THREAD,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0,
+            args = mapOf("state" to Foo.toString())
+        )
+    )
+  }
+
+  @Test fun `StateChanged trace event`() {
+    getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    assertTraceEquals(
+        StateChanged(NoopLauncher.makeId("name"), Foo),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher(name) state changed",
+            category = "StateChanged",
+            phase = INSTANT,
+            scope = THREAD,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0,
+            args = mapOf("new state" to Foo.toString())
+        )
+    )
+  }
+
+  @Test fun `ReceivedEvent trace event`() {
+    getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    assertTraceEquals(
+        ReceivedEvent(NoopLauncher.makeId("name"), Bar),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher(name) received event",
+            category = "ReceivedEvent",
+            phase = INSTANT,
+            scope = THREAD,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0,
+            args = mapOf("event" to Bar.toString())
+        )
+    )
+  }
+
+  @Test fun `Finished trace event`() {
+    getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    assertTraceEquals(
+        Finished(NoopLauncher.makeId("name"), Baz),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher(name) running",
+            category = "Finished",
+            phase = DURATION_END,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0,
+            args = mapOf("result" to Baz.toString())
+        )
+    )
+  }
+
+  @Test fun `Abandoned trace event`() {
+    getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    assertTraceEquals(
+        Abandoned(NoopLauncher.makeId("name")),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher(name) running",
+            category = "Abandoned",
+            phase = DURATION_END,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0
+        )
+    )
+  }
+
+  @Test fun `RemovedFromPool trace event`() {
+    getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    assertTraceEquals(
+        RemovedFromPool(NoopLauncher.makeId("name")),
+        TraceEvent(
+            name = "com.squareup.workflow.monitoring.tracing.NoopLauncher(name) removed from pool",
+            category = "RemovedFromPool",
+            phase = INSTANT,
+            scope = THREAD,
+            timestamp = TIMESTAMP,
+            processId = 0,
+            threadId = 0
+        )
+    )
+  }
+
+  @Test fun `processIds assigned to pools then reused`() {
+    val pool1 = WorkflowPool()
+    val pool2 = WorkflowPool()
+    val monitorEvent = Registered(NoopLauncher.workflowType, NoopLauncher)
+    assertEquals(0, getTraceEvent(monitorEvent, pool1).processId)
+    assertEquals(1, getTraceEvent(monitorEvent, pool2).processId)
+    assertEquals(0, getTraceEvent(monitorEvent, pool1).processId)
+  }
+
+  @Test fun `threadIds assigned by type`() {
+    // Launcher with a different type than NoopLauncher.
+    val launcherDifferentType = object : Launcher<String, String, String> {
+      override fun launch(
+        initialState: String,
+        workflows: WorkflowPool
+      ): Workflow<String, String, String> = fail("Shouldn't be called.")
+    }
+    val launcherWithSameType = object : Launcher<Foo, Bar, Baz> {
+      override fun launch(
+        initialState: Foo,
+        workflows: WorkflowPool
+      ): Workflow<Foo, Bar, Baz> = fail("Shouldn't be called.")
+    }
+    val event1 = getTraceEvent(Registered(NoopLauncher.workflowType, NoopLauncher))
+    val event2 =
+      getTraceEvent(Registered(launcherDifferentType.workflowType, launcherDifferentType))
+    val event3 = getTraceEvent(Registered(launcherWithSameType.workflowType, launcherWithSameType))
+
+    assertEquals(0, event1.threadId)
+    assertEquals(1, event2.threadId)
+    assertEquals(0, event3.threadId)
+  }
+
+  @Test fun `TraceFile adapter golden value`() {
+    val adapter = buildMoshiAdapterForTraceFile()
+    val buffer = Buffer()
+    adapter.toJson(
+        buffer,
+        TraceFile(
+            events = listOf(
+                TraceEvent(
+                    name = "name",
+                    category = "category",
+                    phase = INSTANT,
+                    scope = PROCESS,
+                    timestamp = TIMESTAMP,
+                    processId = 43,
+                    threadId = 44,
+                    args = mapOf("foo" to "bar", "baz" to 32)
+                )
+            ),
+            otherData = mapOf("other" to "data")
+        )
+    )
+
+    assertEquals(
+        """
+          {
+            "traceEvents": [
+              {
+                "name": "name",
+                "cat": "category",
+                "ph": "i",
+                "ts": 42,
+                "pid": 43,
+                "tid": 44,
+                "s": "p",
+                "args": {
+                  "foo": "bar",
+                  "baz": 32
+                }
+              }
+            ],
+            "otherData": {
+              "other": "data"
+            }
+          }
+        """.trimIndent(), buffer.readUtf8()
+    )
+  }
+
+  private fun assertTraceEquals(
+    event: WorkflowPoolMonitorEvent,
+    trace: TraceEvent
+  ) {
+    assertEquals(trace, getTraceEvent(event))
+  }
+
+  private fun getTraceEvent(
+    event: WorkflowPoolMonitorEvent,
+    pool: WorkflowPool = this.pool
+  ): TraceEvent = runBlocking {
+    actor.onMessage(ReportEvent(TIMESTAMP, pool, event))
+    return@runBlocking actor.peekTraceEvents()
+        .last()
+  }
+}
+
+private object Foo
+private object Bar
+private object Baz
+
+private object NoopLauncher : Launcher<Foo, Bar, Baz> {
+
+  val typeString = workflowType.toString()
+
+  override fun launch(
+    initialState: Foo,
+    workflows: WorkflowPool
+  ): Workflow<Foo, Bar, Baz> {
+    fail("Shouldn't be called.")
+  }
+
+  fun makeId(name: String = "") = Id(name, NoopLauncher.workflowType)
+
+  override fun toString(): String = "NoopLauncher"
+}


### PR DESCRIPTION
Introduces the concept of `WorkflowPoolMonitor`, an interface that can monitor `WorkflowPool` events such as state changes, events, etc.

Also introduces an implementation of that interface, `TracingWorkflowPoolMonitor`, that generates trace files compatible with Chrome's `chrome://tracing` viewer.

Closes #129.