### PR TITLE
Effects are no longer responsible for saving the outgoing view.

### DIFF
--- a/viewregistry-android/src/main/java/com/squareup/viewregistry/BackStackEffect.kt
+++ b/viewregistry-android/src/main/java/com/squareup/viewregistry/BackStackEffect.kt
@@ -3,7 +3,7 @@ package com.squareup.viewregistry
 import android.support.transition.Scene
 import android.view.View
 import android.view.ViewGroup
-import com.squareup.viewregistry.ViewStateStack.UpdateTools
+import com.squareup.viewregistry.ViewStateStack.Direction
 import io.reactivex.Observable
 import kotlin.reflect.jvm.jvmName
 
@@ -37,6 +37,9 @@ interface BackStackEffect {
    *
    *  - You can use [buildWrappedView] or [buildWrappedScene] to give the new view
    *    its expected stream of properly typed screen objects.
+   *
+   *  - You must call [setUpNewView] on the incoming view before it is attached
+   *    to the window.
    */
   fun execute(
     from: View,
@@ -44,7 +47,8 @@ interface BackStackEffect {
     screens: Observable<out BackStackScreen<*>>,
     viewRegistry: ViewRegistry,
     container: ViewGroup,
-    tools: UpdateTools
+    setUpNewView: (View) -> Unit,
+    direction: Direction
   )
 }
 

--- a/viewregistry-android/src/main/java/com/squareup/viewregistry/BackStackFrameLayout.kt
+++ b/viewregistry-android/src/main/java/com/squareup/viewregistry/BackStackFrameLayout.kt
@@ -60,10 +60,25 @@ class BackStackFrameLayout(
 
     showing
         ?.let {
+          updateTools.saveOldView(it)
           viewRegistry.getEffect(it.backStackKey, newScreen.key, updateTools.direction)
-              .execute(it, newScreen, screens, viewRegistry, this, updateTools)
+              .execute(
+                  from = it,
+                  to = newScreen,
+                  screens = screens,
+                  viewRegistry = viewRegistry,
+                  container = this,
+                  setUpNewView = updateTools::setUpNewView,
+                  direction = updateTools.direction
+              )
         }
-        ?: NoEffect.execute(this, newScreen, screens, viewRegistry, updateTools)
+        ?: NoEffect.execute(
+            newScreen,
+            screens,
+            viewRegistry,
+            this,
+            updateTools::setUpNewView
+        )
   }
 
   override fun onBackPressed(): Boolean {

--- a/viewregistry-android/src/main/java/com/squareup/viewregistry/NoEffect.kt
+++ b/viewregistry-android/src/main/java/com/squareup/viewregistry/NoEffect.kt
@@ -4,7 +4,6 @@ import android.view.View
 import android.view.ViewGroup
 import com.squareup.viewregistry.BackStackScreen.Key
 import com.squareup.viewregistry.ViewStateStack.Direction
-import com.squareup.viewregistry.ViewStateStack.UpdateTools
 import io.reactivex.Observable
 import kotlin.reflect.KClass
 
@@ -40,10 +39,10 @@ class NoEffect(
     screens: Observable<out BackStackScreen<*>>,
     viewRegistry: ViewRegistry,
     container: ViewGroup,
-    tools: UpdateTools
+    setUpNewView: (View) -> Unit,
+    direction: Direction
   ) {
-    tools.saveOldView(from)
-    execute(container, to, screens, viewRegistry, tools)
+    execute(to, screens, viewRegistry, container, setUpNewView)
   }
 
   companion object : BackStackEffect by NoEffect() {
@@ -52,15 +51,15 @@ class NoEffect(
      * Empties [container] and makes [to] its only child.
      */
     fun execute(
-      container: ViewGroup,
       to: BackStackScreen<*>,
       screens: Observable<out BackStackScreen<*>>,
       viewRegistry: ViewRegistry,
-      tools: UpdateTools
+      container: ViewGroup,
+      setUpNewView: (View) -> Unit
     ) {
       container.removeAllViews()
       val newView = to.buildWrappedView(screens, viewRegistry, container)
-          .apply { tools.setUpNewView(this) }
+          .apply { setUpNewView(this) }
       container.addView(newView)
     }
   }

--- a/viewregistry-android/src/main/java/com/squareup/viewregistry/PushPopEffect.kt
+++ b/viewregistry-android/src/main/java/com/squareup/viewregistry/PushPopEffect.kt
@@ -7,8 +7,8 @@ import android.support.transition.TransitionSet
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import com.squareup.viewregistry.ViewStateStack.Direction
 import com.squareup.viewregistry.ViewStateStack.Direction.PUSH
-import com.squareup.viewregistry.ViewStateStack.UpdateTools
 import io.reactivex.Observable
 
 /**
@@ -24,18 +24,17 @@ object PushPopEffect : BackStackEffect {
     screens: Observable<out BackStackScreen<*>>,
     viewRegistry: ViewRegistry,
     container: ViewGroup,
-    tools: UpdateTools
+    setUpNewView: (View) -> Unit,
+    direction: Direction
   ) {
     val newScene = to
         .buildWrappedScene(screens, viewRegistry, container) { scene ->
           scene.viewOrNull()
-              ?.let { tools.setUpNewView(it) }
+              ?.let { setUpNewView(it) }
         }
 
-    tools.saveOldView(from)
-
-    val outEdge = if (tools.direction == PUSH) Gravity.START else Gravity.END
-    val inEdge = if (tools.direction == PUSH) Gravity.END else Gravity.START
+    val outEdge = if (direction == PUSH) Gravity.START else Gravity.END
+    val inEdge = if (direction == PUSH) Gravity.END else Gravity.START
 
     val outSet = TransitionSet()
         .addTransition(Slide(outEdge).addTarget(from))


### PR DESCRIPTION
One less mistake for effect authors to make becomes one more mistake for
container authors -- we're probably going to write more effects than
containers.

Closes #134.