### PR TITLE
ModalContainer play nice with Android view persistence.

### DIFF
--- a/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/authworkflow/SecondFactorCoordinator.kt
+++ b/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/authworkflow/SecondFactorCoordinator.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.sample.authworkflow
 
+import android.support.v7.widget.Toolbar
 import android.view.View
 import android.widget.Button
 import android.widget.EditText
@@ -23,6 +24,7 @@ import com.squareup.coordinators.Coordinator
 import com.squareup.sample.tictactoe.R
 import com.squareup.viewregistry.LayoutBinding
 import com.squareup.viewregistry.ViewBinding
+import com.squareup.viewregistry.setBackHandler
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 
@@ -30,6 +32,7 @@ internal class SecondFactorCoordinator(private val screens: Observable<out Secon
     Coordinator() {
   private val subs = CompositeDisposable()
 
+  private lateinit var toolbar: Toolbar
   private lateinit var error: TextView
   private lateinit var secondFactor: EditText
   private lateinit var button: Button
@@ -37,11 +40,12 @@ internal class SecondFactorCoordinator(private val screens: Observable<out Secon
   override fun attach(view: View) {
     super.attach(view)
 
+    toolbar = view.findViewById(R.id.second_factor_toolbar)
     error = view.findViewById(R.id.second_factor_error_message)
     secondFactor = view.findViewById(R.id.second_factor)
     button = view.findViewById(R.id.second_factor_submit_button)
 
-    subs.add(screens.subscribe { this.update(it) })
+    subs.add(screens.subscribe { this.update(it, view) })
   }
 
   override fun detach(view: View) {
@@ -49,7 +53,13 @@ internal class SecondFactorCoordinator(private val screens: Observable<out Secon
     super.detach(view)
   }
 
-  private fun update(screen: SecondFactorScreen) {
+  private fun update(
+    screen: SecondFactorScreen,
+    view: View
+  ) {
+    view.setBackHandler { screen.cancel() }
+    toolbar.setNavigationOnClickListener { screen.cancel() }
+
     error.text = screen.errorMessage
 
     button.setOnClickListener {

--- a/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/panel/PanelContainer.kt
+++ b/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/panel/PanelContainer.kt
@@ -39,6 +39,7 @@ import kotlin.math.min
  */
 object PanelContainer : ViewBinding<PanelContainerScreen<*, *>>
 by ModalContainer.forContainerScreen(
+    R.id.tic_tac_workflow_panel_container,
     modalDecorator = { panelBody ->
       PanelBodyWrapper(panelBody.context).apply { addView(panelBody) }
     })

--- a/kotlin/samples/tictactoe/android/src/main/res/layout/second_factor_layout.xml
+++ b/kotlin/samples/tictactoe/android/src/main/res/layout/second_factor_layout.xml
@@ -18,8 +18,16 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     >
+  <android.support.v7.widget.Toolbar
+      android:id="@+id/second_factor_toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      app:navigationIcon="?attr/homeAsUpIndicator"
+      app:title="Enter Second Factor"
+      />
 
   <TextView
       android:id="@+id/second_factor_error_message"

--- a/kotlin/samples/tictactoe/android/src/main/res/values/ids.xml
+++ b/kotlin/samples/tictactoe/android/src/main/res/values/ids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2017 Square Inc.
+  ~ Copyright 2019 Square Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,12 +15,6 @@
   ~ limitations under the License.
   -->
 <resources>
-  <!-- View Tag used for back button handlers. See HandlesBack.Helper -->
-  <item type="id" name="workflow_back_handler"/>
-  <!-- View Tag holding the BackStackScreen.Key associated with a view. -->
-  <item type="id" name="workflow_back_stack_key"/>
-  <!-- ID used by AlertContainer to opt in to view persistence. -->
-  <item type="id" name="workflow_alert_container"/>
-  <!-- ID used by BackStackContainer to opt in to view persistence. -->
-  <item type="id" name="workflow_back_stack_container"/>
+  <!-- ID used by PanelContainer to opt in to view persistence. -->
+  <item type="id" name="tic_tac_workflow_panel_container"/>
 </resources>

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthEvent.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthEvent.kt
@@ -26,3 +26,5 @@ data class SubmitLogin(
 ) : AuthEvent()
 
 data class SubmitSecondFactor(val secondFactor: String) : AuthEvent()
+
+object CancelSecondFactor : AuthEvent()

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthReactor.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthReactor.kt
@@ -74,6 +74,7 @@ class AuthReactor(
       is Authorizing -> doLogin(state.event)
       is SecondFactorPrompt -> events.select {
         onEvent<SubmitSecondFactor> { EnterState(AuthorizingSecondFactor(state.tempToken, it)) }
+        onEvent<CancelSecondFactor> { EnterState(LoginPrompt()) }
       }
       is AuthorizingSecondFactor -> doSecondFactor(state)
     }

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthRenderer.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthRenderer.kt
@@ -29,15 +29,21 @@ object AuthRenderer : Renderer<AuthState, AuthEvent, BackStackScreen<*>> {
     state: AuthState,
     workflow: WorkflowInput<AuthEvent>,
     workflows: WorkflowPool
-  ): BackStackScreen<*> = BackStackScreen(
-      when (state) {
-        is LoginPrompt -> LoginScreen(state.errorMessage, workflow::sendEvent)
+  ): BackStackScreen<*> =
+    when (state) {
+      is LoginPrompt -> BackStackScreen(LoginScreen(state.errorMessage, workflow::sendEvent))
 
-        is Authorizing -> AuthorizingScreen("Logging in…")
+      is Authorizing -> BackStackScreen(AuthorizingScreen("Logging in…"))
 
-        is AuthorizingSecondFactor -> AuthorizingScreen("Submitting one time token…")
+      // We give this one a uniquing key so that it pushes rather than pops
+      // the first Authorizing screen.
+      is AuthorizingSecondFactor -> BackStackScreen(
+          AuthorizingScreen("Submitting one time token…"),
+          "2fa"
+      )
 
-        is SecondFactorPrompt -> SecondFactorScreen(state.errorMessage, workflow::sendEvent)
-      }
-  )
+      is SecondFactorPrompt -> BackStackScreen(
+          SecondFactorScreen(state.errorMessage, workflow::sendEvent)
+      )
+    }
 }

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/SecondFactorScreen.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/SecondFactorScreen.kt
@@ -17,5 +17,9 @@ package com.squareup.sample.authworkflow
 
 data class SecondFactorScreen(
   val errorMessage: String,
-  val submit: (SubmitSecondFactor) -> Unit
-)
+  private val onEvent: (AuthEvent) -> Unit
+) {
+  fun submit(event: SubmitSecondFactor) = onEvent(event)
+
+  fun cancel() = onEvent(CancelSecondFactor)
+}

--- a/kotlin/viewregistry-android/src/main/java/com/squareup/viewregistry/AlertContainer.kt
+++ b/kotlin/viewregistry-android/src/main/java/com/squareup/viewregistry/AlertContainer.kt
@@ -80,6 +80,7 @@ internal class AlertContainer
       type = AlertContainerScreen::class.java,
       builder = { screens, viewRegistry, context, _ ->
         AlertContainer(context, dialogThemeResId = dialogThemeResId).apply {
+          id = R.id.workflow_alert_container
           layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
           takeScreens(screens, viewRegistry)
         }

--- a/kotlin/viewregistry-android/src/main/java/com/squareup/viewregistry/ModalViewContainer.kt
+++ b/kotlin/viewregistry-android/src/main/java/com/squareup/viewregistry/ModalViewContainer.kt
@@ -17,6 +17,7 @@ package com.squareup.viewregistry
 
 import android.app.Dialog
 import android.content.Context
+import android.support.annotation.IdRes
 import android.support.annotation.StyleRes
 import android.util.AttributeSet
 import android.view.View
@@ -62,6 +63,7 @@ internal class ModalViewContainer
   }
 
   class Binding<H : HasModals<*, *>>(
+    @IdRes id: Int,
     type: Class<H>,
     @StyleRes dialogThemeResId: Int = 0,
     modalDecorator: (View) -> View = { it }
@@ -74,6 +76,7 @@ internal class ModalViewContainer
             modalDecorator = modalDecorator,
             dialogThemeResId = dialogThemeResId
         ).apply {
+          this.id = id
           layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
           takeScreens(screens, viewRegistry)
         }

--- a/kotlin/viewregistry-android/src/main/java/com/squareup/viewregistry/backstack/BackStackContainer.kt
+++ b/kotlin/viewregistry-android/src/main/java/com/squareup/viewregistry/backstack/BackStackContainer.kt
@@ -25,6 +25,7 @@ import android.widget.FrameLayout
 import com.squareup.viewregistry.BackStackScreen
 import com.squareup.viewregistry.BuilderBinding
 import com.squareup.viewregistry.HandlesBack
+import com.squareup.viewregistry.R
 import com.squareup.viewregistry.ViewBinding
 import com.squareup.viewregistry.ViewRegistry
 import com.squareup.viewregistry.backstack.ViewStateStack.SavedState
@@ -114,6 +115,7 @@ class BackStackContainer(
       type = BackStackScreen::class.java,
       builder = { screens, viewRegistry, context, _ ->
         BackStackContainer(context).apply {
+          id = R.id.workflow_back_stack_container
           layoutParams = (ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
           takeScreens(screens, viewRegistry)
         }


### PR DESCRIPTION
ModalContainer now implements `onSaveInstanceState()` and `onRestoreInstanceState()`.
Holds onto the most recently restored state, and applies it to the first shown base
view and dialog stacks.

Note also that ModalContainer subclasses and BackStackContainer must have their
`View.id` set in order to participate in view persistence.

Gives the 2fa screen a back button so that we can exercise popping
BackStackContainer again.

Closes #145