### PR TITLE
Revert kotlin stdlib bump from jdk6 to jdk7.

### DIFF
--- a/kotlin/workflow-core/build.gradle
+++ b/kotlin/workflow-core/build.gradle
@@ -25,7 +25,7 @@ kotlin.experimental.coroutines 'enable'
 dependencies {
   compileOnly deps.annotations.intellij
 
-  api deps.kotlin.stdLib.jdk7
+  api deps.kotlin.stdLib.jdk6
   api deps.kotlin.coroutines.core
   // For Snapshot.
   api deps.okio

--- a/kotlin/workflow-host/build.gradle
+++ b/kotlin/workflow-host/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   compileOnly deps.annotations.intellij
 
   api project(':workflow-core')
-  api deps.kotlin.stdLib.jdk7
+  api deps.kotlin.stdLib.jdk6
   api deps.kotlin.coroutines.core
 
   implementation deps.kotlin.reflect

--- a/kotlin/workflow-rx2/build.gradle
+++ b/kotlin/workflow-rx2/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   compileOnly deps.annotations.intellij
 
   api project(':workflow-core')
-  api deps.kotlin.stdLib.jdk7
+  api deps.kotlin.stdLib.jdk6
   api deps.kotlin.coroutines.core
   api deps.rxjava2.rxjava2
 

--- a/kotlin/workflow-testing/build.gradle
+++ b/kotlin/workflow-testing/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   compileOnly deps.annotations.intellij
 
   api project(':workflow-core')
-  api deps.kotlin.stdLib.jdk7
+  api deps.kotlin.stdLib.jdk6
 
   implementation project(':workflow-host')
   implementation deps.kotlin.reflect


### PR DESCRIPTION
I had bumped it when importing the rewrite, for no particular reason, but don't want to
change transitive deps in 0.8.0 because there's enough things going on.