### PR TITLE
Update ReactiveSwift to 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ matrix:
         - gem update --system
         - gem install bundler
       script:
+        - bundle exec pod repo update
         - bundle exec pod lib lint Workflow.podspec --allow-warnings
     - language: swift
       name: "Swift - SPM (Xcode 10.1)"

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Workflow"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "4.0.0")
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "5.0.0")
     ],
     targets: [
         .target(

--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'swift/Workflow/Sources/*.swift'
 
-  s.dependency 'ReactiveSwift'
+  s.dependency 'ReactiveSwift', '~> 5.0.0'
   s.dependency 'Result'
  
   s.test_spec 'Tests' do |test_spec|


### PR DESCRIPTION
ReactiveSwift 5.0.0 adds Swift 5 support (meaning that we can adopt Xcode 10.2 without a bunch of warnings coming out of our dependencies)