### PR TITLE
Revert "Bumps kotlin version to 1.2.71"

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -34,7 +34,7 @@ buildscript {
       'hamcrest': '1.3',
       'intellijAnnotations': '13.0',
       'junit': '4.12',
-      'kotlin': '1.2.71',
+      'kotlin': '1.2.61',
       'kotlinCoroutines': '0.26.1',
       'ktlintPlugin': '5.1.0',
       'mavenPublishPlugin': '0.6.0',


### PR DESCRIPTION
This reverts the kotlin version change in commit 8fe6d9d75fdf7a5ddf840d72964d0e5496444ab6.

Turns out 1.2.71 has a bug that causes desugaring to fail on Android.
Supposed to be fixed in 1.3.

We upgraded to 1.2.71 to fix an issue with mismatched transitive deps
internally, a problem to which we've found a different workaround until
we can upgrade to 1.3 (#35).