### PR TITLE
Rename makeSink to onEvent, make EventHandler type.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/EventHandler.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/EventHandler.kt
@@ -1,0 +1,38 @@
+package com.squareup.workflow
+
+/**
+ * Wraps a function that handles an event of type [EventT]. Implements the raw function type
+ * `(EventT) -> Unit`, so instances can be invoked and passed around as functions.
+ *
+ * This type differs from a typical function reference in how it defines equality. All instances
+ * of this class are considered equal (and have the same hashcode), which means they can be stored
+ * in data classes and the event handlers will be ignored. This makes it much easier to write
+ * test assertions for [Workflow] renderings that include event handlers, since you can compare
+ * entire rendering types at once and not field-by-field.
+ */
+class EventHandler<in EventT>(private val handler: (EventT) -> Unit) : (EventT) -> Unit {
+
+  override fun invoke(event: EventT) = handler(event)
+
+  /**
+   * Returns `true` iff `other` is an [EventHandler] – all [EventHandler]s are considered equal.
+   */
+  override fun equals(other: Any?): Boolean = when {
+    other === this -> true
+    other is EventHandler<*> -> true
+    else -> false
+  }
+
+  /**
+   * All [EventHandler]s have the same hashcode, since they are all equal.
+   */
+  override fun hashCode(): Int = 0
+
+  override fun toString(): String = "EventHandler@${super.hashCode()}"
+}
+
+/**
+ * [EventHandler]s of type `Unit` are effectively no-arg functions, so this override lets you
+ * invoke them without passing the `Unit` argument.
+ */
+operator fun EventHandler<Unit>.invoke() = invoke(Unit)

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -16,7 +16,7 @@
 package com.squareup.workflow
 
 /**
- * A composable, optionally-stateful object that can [handle events][WorkflowContext.makeSink],
+ * A composable, optionally-stateful object that can [handle events][WorkflowContext.onEvent],
  * [delegate to children][WorkflowContext.compose], [subscribe][onReceive] to arbitrary streams from
  * the outside world, and be [saved][snapshotState] to a serialized form to be
  * [restored][restoreState] later.
@@ -24,7 +24,7 @@ package com.squareup.workflow
  * The basic purpose of a `Workflow` is to take some [input][InputT] and return a
  * [rendering][RenderingT]. To that end, a workflow may keep track of internal [state][StateT],
  * recursively ask other workflows to render themselves, subscribe to data streams from the outside
- * world, and handle events both from its [renderings][WorkflowContext.makeSink] and from workflows
+ * world, and handle events both from its [renderings][WorkflowContext.onEvent] and from workflows
  * it's delegated to (its "children"). A `Workflow` may also emit [output events][OutputT] up to its
  * parent `Workflow`.
  *

--- a/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/RealWorkflowContext.kt
+++ b/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/RealWorkflowContext.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.workflow.internal
 
+import com.squareup.workflow.EventHandler
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowContext
@@ -46,9 +47,9 @@ internal class RealWorkflowContext<StateT : Any, OutputT : Any>(
   private val subscriptionCases = mutableListOf<SubscriptionCase<*, StateT, OutputT>>()
   private val childCases = mutableListOf<WorkflowOutputCase<*, *, StateT, OutputT>>()
 
-  override fun <EventT : Any> makeSink(handler: (EventT) -> WorkflowAction<StateT, OutputT>):
-      (EventT) -> Unit {
-    return { event ->
+  override fun <EventT : Any> onEvent(handler: (EventT) -> WorkflowAction<StateT, OutputT>):
+      EventHandler<EventT> {
+    return EventHandler { event ->
       // Run the handler synchronously, so we only have to emit the resulting action and don't need the
       // update channel to be generic on each event type.
       val update = handler(event)

--- a/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/RealWorkflowContextTest.kt
+++ b/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/RealWorkflowContextTest.kt
@@ -79,7 +79,7 @@ class RealWorkflowContextTest {
   @Test fun `make sink completes update`() {
     val context = RealWorkflowContext<String, String>(PoisonComposer())
     val expectedUpdate = noop<String, String>()
-    val handler = context.makeSink<String> { expectedUpdate }
+    val handler = context.onEvent<String> { expectedUpdate }
     assertFalse(context.buildBehavior().nextActionFromEvent.isCompleted)
 
     handler("")
@@ -92,7 +92,7 @@ class RealWorkflowContextTest {
 
   @Test fun `make sink gets event`() {
     val context = RealWorkflowContext<String, String>(PoisonComposer())
-    val handler = context.makeSink<String> { event -> emitOutput(event) }
+    val handler = context.onEvent<String> { event -> emitOutput(event) }
 
     handler("foo")
 

--- a/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -52,7 +52,7 @@ class SubtreeManagerTest {
       input: String,
       state: String,
       context: WorkflowContext<String, String>
-    ): Rendering = Rendering(input, state, context.makeSink {
+    ): Rendering = Rendering(input, state, context.onEvent {
       emitOutput("workflow output:$it")
     })
 

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
@@ -68,7 +68,7 @@ class SubscriptionsTest {
       if (state) {
         context.onNext(observable) { update -> emitOutput(update) }
       }
-      return context.makeSink { subscribe -> enterState(subscribe) }
+      return context.onEvent { subscribe -> enterState(subscribe) }
     }
 
     override fun snapshotState(state: Boolean) = Snapshot.EMPTY

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
@@ -15,14 +15,15 @@
  */
 package com.squareup.workflow.rx2
 
+import com.squareup.workflow.EventHandler
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatelessWorkflow
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowContext
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.WorkflowAction.Companion.noop
-import com.squareup.workflow.makeUnitSink
+import com.squareup.workflow.WorkflowContext
+import com.squareup.workflow.invoke
 import com.squareup.workflow.testing.testFromStart
 import io.reactivex.subjects.SingleSubject
 import kotlin.test.Test
@@ -64,7 +65,7 @@ class WorkflowContextsTest {
   @Test fun `onSuccess unsubscribes`() {
     var subscriptions = 0
     var disposals = 0
-    lateinit var doClose: () -> Unit
+    lateinit var doClose: EventHandler<Unit>
     val singleSubject = SingleSubject.create<Unit>()
     val single = singleSubject
         .doOnSubscribe { subscriptions++ }
@@ -79,7 +80,7 @@ class WorkflowContextsTest {
       ) {
         if (state) {
           context.onSuccess(single) { noop() }
-          doClose = context.makeUnitSink { enterState(false) }
+          doClose = context.onEvent { enterState(false) }
         }
       }
 

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
@@ -66,7 +66,7 @@ class ChannelSubscriptionsIntegrationTest {
       if (state) {
         context.onReceive({ subscribe() }) { update -> emitOutput(update) }
       }
-      return context.makeSink { subscribe -> enterState(subscribe) }
+      return context.onEvent { subscribe -> enterState(subscribe) }
     }
 
     override fun snapshotState(state: Boolean) = Snapshot.EMPTY

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
@@ -59,7 +59,7 @@ internal class TreeWorkflow(
 
     return Rendering(
         data = "$name:$state",
-        setData = context.makeSink { newState ->
+        setData = context.onEvent { newState ->
           WorkflowAction.enterState(
               newState
           )


### PR DESCRIPTION
This also means we can get rid of the separate `makeUnitSink` function, because we can
just define an override `invoke` for `EventHandler<Unit>`.

Closes #206 and closes #203.