### PR TITLE
Factor out a common parent interface for StatelessWorkflow and Workflow (now StatefulWorkflow).

### DIFF
--- a/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/mainactivity/MainComponent.kt
+++ b/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/mainactivity/MainComponent.kt
@@ -16,9 +16,12 @@
 package com.squareup.sample.mainactivity
 
 import com.squareup.sample.authworkflow.AuthService
+import com.squareup.sample.authworkflow.AuthWorkflow
 import com.squareup.sample.authworkflow.RealAuthWorkflow
 import com.squareup.sample.gameworkflow.RealGameLog
 import com.squareup.sample.gameworkflow.RealRunGameWorkflow
+import com.squareup.sample.gameworkflow.RealTakeTurnsWorkflow
+import com.squareup.sample.gameworkflow.RunGameWorkflow
 import com.squareup.sample.gameworkflow.TakeTurnsWorkflow
 import com.squareup.sample.mainworkflow.MainWorkflow
 import com.squareup.sample.mainworkflow.RootScreen
@@ -42,13 +45,13 @@ internal class MainComponent {
 
   private fun mainWorkflow() = MainWorkflow(authWorkflow(), gameWorkflow())
 
-  private fun authWorkflow() = RealAuthWorkflow(authService)
+  private fun authWorkflow(): AuthWorkflow = RealAuthWorkflow(authService)
 
   private fun gameLog() = RealGameLog(mainThread())
 
-  private fun gameWorkflow() = RealRunGameWorkflow(takeTurnsWorkflow(), gameLog())
+  private fun gameWorkflow(): RunGameWorkflow = RealRunGameWorkflow(takeTurnsWorkflow(), gameLog())
 
-  private fun takeTurnsWorkflow() = TakeTurnsWorkflow()
+  private fun takeTurnsWorkflow(): TakeTurnsWorkflow = RealTakeTurnsWorkflow()
 
   private fun workflowHost(snapshot: Snapshot?) = workflowHostFactory.run(mainWorkflow(), snapshot)
 

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -27,6 +27,7 @@ import com.squareup.sample.authworkflow.SecondFactorScreen.Event.CancelSecondFac
 import com.squareup.sample.authworkflow.SecondFactorScreen.Event.SubmitSecondFactor
 import com.squareup.viewregistry.BackStackScreen
 import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
@@ -37,7 +38,7 @@ import com.squareup.workflow.rx2.onSuccess
  * We define this otherwise redundant interface to keep composite workflows
  * that build on [AuthWorkflow] decoupled from it, for ease of testing.
  */
-interface AuthWorkflow : Workflow<Unit, AuthState, String, BackStackScreen<*>>
+interface AuthWorkflow : Workflow<Unit, String, BackStackScreen<*>>
 
 /**
  * Runs a set of login screens and pretends to produce an auth token,
@@ -49,7 +50,8 @@ interface AuthWorkflow : Workflow<Unit, AuthState, String, BackStackScreen<*>>
  * Includes a 2fa path for email addresses that include the string "2fa".
  * Token is "1234".
  */
-class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow {
+class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
+    StatefulWorkflow<Unit, AuthState, String, BackStackScreen<*>>() {
 
   override fun initialState(input: Unit): AuthState = LoginPrompt()
 

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -44,6 +44,7 @@ import com.squareup.viewregistry.AlertScreen.Event.ButtonClicked
 import com.squareup.viewregistry.AlertScreen.Event.Canceled
 import com.squareup.workflow.EventHandler
 import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
@@ -61,7 +62,7 @@ enum class RunGameResult {
  * that build on [RunGameWorkflow] decoupled from it, for ease of testing.
  */
 interface RunGameWorkflow :
-    Workflow<Unit, RunGameState, RunGameResult, AlertContainerScreen<PanelContainerScreen<*, *>>>
+    Workflow<Unit, RunGameResult, AlertContainerScreen<PanelContainerScreen<*, *>>>
 
 /**
  * Runs the screens around a Tic Tac Toe game: prompts for player names, runs a
@@ -71,7 +72,9 @@ interface RunGameWorkflow :
 class RealRunGameWorkflow(
   private val takeTurnsWorkflow: TakeTurnsWorkflow,
   private val gameLog: GameLog
-) : RunGameWorkflow {
+) : RunGameWorkflow,
+    StatefulWorkflow<Unit, RunGameState, RunGameResult,
+        AlertContainerScreen<PanelContainerScreen<*, *>>>() {
 
   override fun initialState(input: Unit): RunGameState = NewGame()
 

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -21,12 +21,15 @@ import com.squareup.sample.gameworkflow.Ending.Victory
 import com.squareup.sample.gameworkflow.GamePlayScreen.Event.Quit
 import com.squareup.sample.gameworkflow.GamePlayScreen.Event.TakeSquare
 import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.WorkflowAction.Companion.noop
 import com.squareup.workflow.WorkflowContext
+
+interface TakeTurnsWorkflow : Workflow<PlayerInfo, CompletedGame, GamePlayScreen>
 
 /**
  * Models the turns of a Tic Tac Toe game, alternating between [Player.X]
@@ -35,7 +38,8 @@ import com.squareup.workflow.WorkflowContext
  *
  * http://go/sf-taketurns
  */
-class TakeTurnsWorkflow : Workflow<PlayerInfo, Turn, CompletedGame, GamePlayScreen> {
+class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
+    StatefulWorkflow<PlayerInfo, Turn, CompletedGame, GamePlayScreen>() {
 
   override fun initialState(input: PlayerInfo) = Turn()
 

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
@@ -25,6 +25,7 @@ import com.squareup.sample.panel.PanelContainerScreen
 import com.squareup.sample.panel.asPanelOver
 import com.squareup.viewregistry.AlertContainerScreen
 import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.WorkflowContext
@@ -42,7 +43,7 @@ typealias RootScreen = AlertContainerScreen<PanelContainerScreen<*, *>>
 class MainWorkflow(
   private val authWorkflow: AuthWorkflow,
   private val runGameWorkflow: RunGameWorkflow
-) : Workflow<Unit, MainState, Unit, RootScreen> {
+) : StatefulWorkflow<Unit, MainState, Unit, RootScreen>() {
 
   override fun initialState(input: Unit): MainState = Authenticating
 

--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
@@ -36,7 +36,7 @@ class TakeTurnsWorkflowTest {
   }
 
   @Test fun startsGameWithGivenNames() {
-    TakeTurnsWorkflow().testFromStart(PlayerInfo("higgledy", "piggledy")) { workflow ->
+    RealTakeTurnsWorkflow().testFromStart(PlayerInfo("higgledy", "piggledy")) { workflow ->
       val (x, o) = workflow.awaitNextRendering().playerInfo
 
       Assertions.assertThat(x)
@@ -47,7 +47,7 @@ class TakeTurnsWorkflowTest {
   }
 
   @Test fun xWins() {
-    TakeTurnsWorkflow().testFromStart(PlayerInfo("higgledy", "piggledy")) { workflow ->
+    RealTakeTurnsWorkflow().testFromStart(PlayerInfo("higgledy", "piggledy")) { workflow ->
       workflow.takeSquare(TakeSquare(0, 0))
       workflow.takeSquare(TakeSquare(1, 0))
       workflow.takeSquare(TakeSquare(0, 1))

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+/**
+ * A composable, stateful object that can [handle events][WorkflowContext.onEvent],
+ * [delegate to children][WorkflowContext.compose], [subscribe][onReceive] to arbitrary streams from
+ * the outside world, and be [saved][snapshotState] to a serialized form to be
+ * [restored][restoreState] later.
+ *
+ * The basic purpose of a `Workflow` is to take some [input][InputT] and return a
+ * [rendering][RenderingT]. To that end, a workflow may keep track of internal [state][StateT],
+ * recursively ask other workflows to render themselves, subscribe to data streams from the outside
+ * world, and handle events both from its [renderings][WorkflowContext.onEvent] and from workflows
+ * it's delegated to (its "children"). A `Workflow` may also emit [output events][OutputT] up to its
+ * parent `Workflow`.
+ *
+ * Workflows form a tree, where each workflow can have zero or more child workflows. Child workflows
+ * are started as necessary whenever another workflow asks for them, and are cleaned up automatically
+ * when they're no longer needed. [Input][InputT] propagates down the tree, [outputs][OutputT] and
+ * [renderings][RenderingT] propagate up the tree.
+ *
+ * @param InputT Typically a data class that is used to pass configuration information or bits of
+ * state that the workflow can always get from its parent and needn't duplicate in its own state.
+ * May be [Unit] if the workflow does not need any input data.
+ *
+ * @param StateT Typically a data class that contains all of the internal state for this workflow.
+ * The state is seeded via [input][InputT] in [initialState]. It can be [serialized][snapshotState]
+ * and later used to [restore][restoreState] the workflow. **Implementations of the `Workflow`
+ * interface should not generally contain their own state directly.** They may inject objects like
+ * instances of their child workflows, or network clients, but should not contain directly mutable
+ * state. This is the only type parameter that a parent workflow needn't care about for its children,
+ * and may just use star (`*`) instead of specifying it. May be [Unit] if the workflow does not have
+ * any internal state (see [StatelessWorkflow]).
+ *
+ * @param OutputT Typically a sealed class that represents "events" that this workflow can send
+ * to its parent.
+ * May be [Nothing] if the workflow doesn't need to emit anything.
+ *
+ * @param RenderingT The value returned to this workflow's parent during [composition][compose].
+ * Typically represents a "view" of this workflow's input, current state, and children's renderings.
+ * A workflow that represents a UI component may use a view model as its rendering type.
+ *
+ * @see StatelessWorkflow
+ */
+abstract class StatefulWorkflow<
+    in InputT : Any,
+    StateT : Any,
+    out OutputT : Any,
+    out RenderingT : Any
+    > : Workflow<InputT, OutputT, RenderingT> {
+
+  /**
+   * Called from [WorkflowContext.compose] when the state machine is first started, to get the
+   * initial state.
+   */
+  abstract fun initialState(input: InputT): StateT
+
+  /**
+   * Called from [WorkflowContext.compose] instead of [initialState] when the workflow is already
+   * running. This allows the workflow to detect changes in input, and possibly change its state in
+   * response. This method is called eagerly: `old` and `new` might be the same value, so it is up
+   * to implementing code to perform any diffing if desired.
+   *
+   * Default implementation does nothing.
+   */
+  open fun onInputChanged(
+    old: InputT,
+    new: InputT,
+    state: StateT
+  ): StateT = state
+
+  /**
+   * Called at least once† any time one of the following things happens:
+   *  - This workflow's [input] changes (via the parent passing a different one in).
+   *  - This workflow's [state] changes.
+   *  - A descendant (immediate or transitive child) workflow:
+   *    - Changes its internal state.
+   *    - Emits an output.
+   *
+   * **Never call this method directly.** To nest the rendering of a child workflow in your own,
+   * pass the child and any required input to [WorkflowContext.compose].
+   *
+   * This method *should not* have any side effects, and in particular should not do anything that
+   * blocks the current thread. It may be called multiple times for the same state. It must do all its
+   * work by calling methods on [context].
+   *
+   * _† This method is guaranteed to be called *at least* once for every state, but may be called
+   * multiple times. Allowing this method to be invoked multiple times makes the internals simpler._
+   */
+  abstract fun compose(
+    input: InputT,
+    state: StateT,
+    context: WorkflowContext<StateT, OutputT>
+  ): RenderingT
+
+  /**
+   * Called whenever the state changes to generate a new [Snapshot] of the state.
+   *
+   * **Snapshots must be lazy.**
+   *
+   * Serialization must not be done at the time this method is called,
+   * since the state will be snapshotted frequently but the serialized form may only be needed very
+   * rarely.
+   *
+   * If the workflow does not have any state, or should always be started from scratch, return
+   * [Snapshot.EMPTY] from this method.
+   *
+   * @see restoreState
+   */
+  abstract fun snapshotState(state: StateT): Snapshot
+
+  /**
+   * Deserialize a state value from a [Snapshot] previously created with [snapshotState].
+   *
+   * If the workflow should always be started from scratch, this method can just ignore the snapshot
+   * and return the initial state.
+   *
+   * @see snapshotState
+   */
+  abstract fun restoreState(snapshot: Snapshot): StateT
+
+  /**
+   * Satisfies the [Workflow] interface by returning `this`.
+   */
+  final override fun asStatefulWorkflow(): StatefulWorkflow<InputT, StateT, OutputT, RenderingT> =
+    this
+}

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -16,15 +16,80 @@
 package com.squareup.workflow
 
 /**
- * A [Workflow] that has no state.
+ * A composable object that can [handle events][WorkflowContext.onEvent],
+ * [delegate to children][WorkflowContext.compose], and [subscribe][onReceive] to arbitrary streams
+ * from the outside world.
+ *
+ * The basic purpose of a `Workflow` is to take some [input][InputT] and return a
+ * [rendering][RenderingT]. To that end, a workflow may recursively ask other workflows to render
+ * themselves, subscribe to data streams from the outside world, and handle events both from its
+ * [renderings][WorkflowContext.onEvent] and from workflows it's delegated to (its "children"). A
+ * `Workflow` may also emit [output events][OutputT] up to its parent `Workflow`.
+ *
+ * Workflows form a tree, where each workflow can have zero or more child workflows. Child workflows
+ * are started as necessary whenever another workflow asks for them, and are cleaned up automatically
+ * when they're no longer needed. [Input][InputT] propagates down the tree, [outputs][OutputT] and
+ * [renderings][RenderingT] propagate up the tree.
+ *
+ * @param InputT Typically a data class that is used to pass configuration information or bits of
+ * state that the workflow can always get from its parent and needn't duplicate in its own state.
+ * May be [Unit] if the workflow does not need any input data.
+ *
+ * @param OutputT Typically a sealed class that represents "events" that this workflow can send
+ * to its parent.
+ * May be [Nothing] if the workflow doesn't need to emit anything.
+ *
+ * @param RenderingT The value returned to this workflow's parent during [composition][compose].
+ * Typically represents a "view" of this workflow's input, current state, and children's renderings.
+ * A workflow that represents a UI component may use a view model as its rendering type.
+ *
+ * @see StatefulWorkflow
  */
-typealias StatelessWorkflow<InputT, OutputT, RenderingT> =
-    Workflow<InputT, Unit, OutputT, RenderingT>
+abstract class StatelessWorkflow<InputT : Any, OutputT : Any, RenderingT : Any> :
+    Workflow<InputT, OutputT, RenderingT> {
+
+  /**
+   * Called at least once any time one of the following things happens:
+   *  - This workflow's [input] changes (via the parent passing a different one in).
+   *  - A descendant (immediate or transitive child) workflow:
+   *    - Changes its internal state.
+   *    - Emits an output.
+   *
+   * **Never call this method directly.** To get the rendering from a child workflow, pass the child
+   * and any required input to [WorkflowContext.compose].
+   *
+   * This method *should not* have any side effects, and in particular should not do anything that
+   * blocks the current thread. It may be called multiple times for the same state. It must do all its
+   * work by calling methods on [context].
+   */
+  abstract fun compose(
+    input: InputT,
+    context: WorkflowContext<Nothing, OutputT>
+  ): RenderingT
+
+  /**
+   * Satisfies the [Workflow] interface by wrapping `this` in a [StatefulWorkflow] with `Unit`
+   * state.
+   */
+  final override fun asStatefulWorkflow(): StatefulWorkflow<InputT, *, OutputT, RenderingT> =
+    object : StatefulWorkflow<InputT, Unit, OutputT, RenderingT>() {
+      override fun initialState(input: InputT) = Unit
+
+      @Suppress("UNCHECKED_CAST")
+      override fun compose(
+        input: InputT,
+        state: Unit,
+        context: WorkflowContext<Unit, OutputT>
+      ): RenderingT = compose(input, context as WorkflowContext<Nothing, OutputT>)
+
+      override fun snapshotState(state: Unit) = Snapshot.EMPTY
+      override fun restoreState(snapshot: Snapshot) = Unit
+    }
+}
 
 /**
- * A convenience function to implement a [Workflow] that doesn't have any internal state. Such a
- * workflow doesn't need to worry about initial state or snapshotting, so the entire workflow can
- * be defined as a single [compose][Workflow.compose] function.
+ * A convenience function to implement [StatelessWorkflow] by just passing the
+ * [compose][StatelessWorkflow.compose] function as a lambda.
  *
  * Note that while a stateless workflow doesn't have any _internal_ state of its own, it may use
  * [input][InputT] received from its parent, and it may compose child workflows that do have their own
@@ -34,20 +99,14 @@ typealias StatelessWorkflow<InputT, OutputT, RenderingT> =
 fun <InputT : Any, OutputT : Any, RenderingT : Any> StatelessWorkflow(
   compose: (
     input: InputT,
-    context: WorkflowContext<Unit, OutputT>
+    context: WorkflowContext<Nothing, OutputT>
   ) -> RenderingT
 ): StatelessWorkflow<InputT, OutputT, RenderingT> =
-  object : Workflow<InputT, Unit, OutputT, RenderingT> {
-    override fun initialState(input: InputT) = Unit
-
+  object : StatelessWorkflow<InputT, OutputT, RenderingT>() {
     override fun compose(
       input: InputT,
-      state: Unit,
-      context: WorkflowContext<Unit, OutputT>
-    ): RenderingT = compose(input, context)
-
-    override fun snapshotState(state: Unit) = Snapshot.EMPTY
-    override fun restoreState(snapshot: Snapshot) = Unit
+      context: WorkflowContext<Nothing, OutputT>
+    ): RenderingT = compose.invoke(input, context)
   }
 
 /**
@@ -55,8 +114,8 @@ fun <InputT : Any, OutputT : Any, RenderingT : Any> StatelessWorkflow(
  */
 @Suppress("FunctionName")
 fun <OutputT : Any, RenderingT : Any> StatelessWorkflow(
-  compose: (context: WorkflowContext<Unit, OutputT>) -> RenderingT
+  compose: (context: WorkflowContext<Nothing, OutputT>) -> RenderingT
 ): StatelessWorkflow<Unit, OutputT, RenderingT> =
-  StatelessWorkflow { _: Unit, context: WorkflowContext<Unit, OutputT> ->
+  StatelessWorkflow { _: Unit, context: WorkflowContext<Nothing, OutputT> ->
     compose(context)
   }

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -18,33 +18,42 @@ package com.squareup.workflow
 /**
  * A composable, optionally-stateful object that can [handle events][WorkflowContext.onEvent],
  * [delegate to children][WorkflowContext.compose], [subscribe][onReceive] to arbitrary streams from
- * the outside world, and be [saved][snapshotState] to a serialized form to be
- * [restored][restoreState] later.
+ * the outside world.
  *
  * The basic purpose of a `Workflow` is to take some [input][InputT] and return a
- * [rendering][RenderingT]. To that end, a workflow may keep track of internal [state][StateT],
- * recursively ask other workflows to render themselves, subscribe to data streams from the outside
- * world, and handle events both from its [renderings][WorkflowContext.onEvent] and from workflows
- * it's delegated to (its "children"). A `Workflow` may also emit [output events][OutputT] up to its
- * parent `Workflow`.
+ * [rendering][RenderingT]. To that end, a workflow may keep track of internal
+ * [state][StatefulWorkflow], recursively ask other workflows to render themselves, subscribe to
+ * data streams from the outside world, and handle events both from its
+ * [renderings][WorkflowContext.onEvent] and from workflows it's delegated to (its "children"). A
+ * `Workflow` may also emit [output events][OutputT] up to its parent `Workflow`.
  *
  * Workflows form a tree, where each workflow can have zero or more child workflows. Child workflows
- * are started as necessary whenever another workflow asks for them, and are cleaned up automatically
- * when they're no longer needed. [Input][InputT] propagates down the tree, [outputs][OutputT] and
- * [renderings][RenderingT] propagate up the tree.
+ * are started as necessary whenever another workflow asks for them, and are cleaned up
+ * automatically when they're no longer needed. [Input][InputT] propagates down the tree,
+ * [outputs][OutputT] and [renderings][RenderingT] propagate up the tree.
+ *
+ * ## Implementing `Workflow`
+ *
+ * The [Workflow] interface is useful as a facade for your API. You can publish an interface that
+ * extends `Workflow`, and keep the implementation (e.g. is your workflow state*ful* or
+ * state*less* a private implementation detail.
+ *
+ * ### [Stateful Workflows][StatefulWorkflow]
+ *
+ * If your workflow needs to keep track of internal state, implement the [StatefulWorkflow]
+ * interface. That interface has an additional type parameter, `StateT`, and allows you to specify
+ * [how to create the initial state][StatefulWorkflow.initialState] and how to
+ * [snapshot][StatefulWorkflow.snapshotState]/[restore][StatefulWorkflow.restoreState] your state.
+ *
+ * ### [Stateless Workflows][StatelessWorkflow]
+ *
+ * If your workflow simply needs to delegate to other workflows, maybe transforming inputs, outputs,
+ * or renderings, implement the [StatelessWorkflow] interface, or simply pass a lambda to the
+ * `StatelessWorkflow` function.
  *
  * @param InputT Typically a data class that is used to pass configuration information or bits of
  * state that the workflow can always get from its parent and needn't duplicate in its own state.
  * May be [Unit] if the workflow does not need any input data.
- *
- * @param StateT Typically a data class that contains all of the internal state for this workflow.
- * The state is seeded via [input][InputT] in [initialState]. It can be [serialized][snapshotState]
- * and later used to [restore][restoreState] the workflow. **Implementations of the `Workflow`
- * interface should not generally contain their own state directly.** They may inject objects like
- * instances of their child workflows, or network clients, but should not contain directly mutable
- * state. This is the only type parameter that a parent workflow needn't care about for its children,
- * and may just use star (`*`) instead of specifying it. May be [Unit] if the workflow does not have
- * any internal state (see [StatelessWorkflow]).
  *
  * @param OutputT Typically a sealed class that represents "events" that this workflow can send
  * to its parent.
@@ -53,72 +62,15 @@ package com.squareup.workflow
  * @param RenderingT The value returned to this workflow's parent during [composition][compose].
  * Typically represents a "view" of this workflow's input, current state, and children's renderings.
  * A workflow that represents a UI component may use a view model as its rendering type.
+ *
+ * @see StatefulWorkflow
+ * @see StatelessWorkflow
  */
-interface Workflow<in InputT : Any, StateT : Any, out OutputT : Any, out RenderingT : Any> {
+interface Workflow<in InputT : Any, out OutputT : Any, out RenderingT : Any> {
 
   /**
-   * Called when the state machine is first started to get the initial state.
+   * Provides a [StatefulWorkflow] view of this workflow. Necessary because [StatefulWorkflow] is
+   * the common API required for [WorkflowContext.compose] to do its work.
    */
-  fun initialState(input: InputT): StateT
-
-  /**
-   * Called whenever [WorkflowContext.compose] is about to get a new [input][InputT] value, to allow
-   * the workflow to modify its state in response. This method is called eagerly: `old` and `new` might
-   * be the same value, so it is up to implementing code to perform any diffing if desired.
-   *
-   * Default implementation does nothing.
-   */
-  fun onInputChanged(
-    old: InputT,
-    new: InputT,
-    state: StateT
-  ): StateT = state
-
-  /**
-   * Called at least once† any time one of the following things happens:
-   *  - This workflow's [input] changes (via the parent passing a different one in).
-   *  - This workflow's [state] changes.
-   *  - A child workflow's state changes.
-   *
-   * **Never call this method directly.** To get the rendering from a child workflow, pass the child
-   * and any required input to [WorkflowContext.compose].
-   *
-   * This method *should not* have any side effects, and in particular should not do anything that
-   * blocks the current thread. It may be called multiple times for the same state. It must do all its
-   * work by calling methods on [context].
-   *
-   * _† This method is guaranteed to be called *at least* once for every state, but may be called
-   * multiple times. Allowing this method to be invoked multiple times makes the internals simpler._
-   */
-  fun compose(
-    input: InputT,
-    state: StateT,
-    context: WorkflowContext<StateT, OutputT>
-  ): RenderingT
-
-  /**
-   * Called whenever the state changes to generate a new [Snapshot] of the state.
-   *
-   * **Snapshots must be lazy.**
-   *
-   * Serialization must not be done at the time this method is called,
-   * since the state will be snapshotted frequently but the serialized form may only be needed very
-   * rarely.
-   *
-   * If the workflow does not have any state, or should always be started from scratch, return
-   * [Snapshot.EMPTY] from this method.
-   *
-   * @see restoreState
-   */
-  fun snapshotState(state: StateT): Snapshot
-
-  /**
-   * Deserialize a state value from a [Snapshot] previously created with [snapshotState].
-   *
-   * If the workflow should always be started from scratch, this method can just ignore the snapshot
-   * and return the initial state.
-   *
-   * @see snapshotState
-   */
-  fun restoreState(snapshot: Snapshot): StateT
+  fun asStatefulWorkflow(): StatefulWorkflow<InputT, *, OutputT, RenderingT>
 }

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowContext.kt
@@ -27,7 +27,7 @@ import kotlin.reflect.KType
 
 /**
  * Facilities for a [Workflow] to interact with other [Workflow]s and the outside world from inside
- * a [compose][Workflow.compose] function.
+ * a `compose` function.
  *
  * ## Handling Events
  *
@@ -117,8 +117,8 @@ interface WorkflowContext<StateT : Any, in OutputT : Any> {
    * @param key An optional string key that is used to distinguish between workflows of the same
    * type.
    */
-  fun <ChildInputT : Any, ChildStateT : Any, ChildOutputT : Any, ChildRenderingT : Any> compose(
-    child: Workflow<ChildInputT, ChildStateT, ChildOutputT, ChildRenderingT>,
+  fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any> compose(
+    child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
     input: ChildInputT,
     key: String = "",
     handler: (ChildOutputT) -> WorkflowAction<StateT, OutputT>
@@ -156,12 +156,12 @@ inline fun <StateT : Any, OutputT : Any, reified T> WorkflowContext<StateT, Outp
 /**
  * Convenience alias of [WorkflowContext.compose] for workflows that don't take input.
  */
-fun <StateT : Any, OutputT : Any, ChildStateT : Any, ChildOutputT : Any, ChildRenderingT : Any>
+fun <StateT : Any, OutputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
     WorkflowContext<StateT, OutputT>.compose(
 // Intellij refuses to format this parameter list correctly because of the weird line break,
 // and detekt will complain about it.
 // @formatter:off
-      child: Workflow<Unit, ChildStateT, ChildOutputT, ChildRenderingT>,
+      child: Workflow<Unit, ChildOutputT, ChildRenderingT>,
       key: String = "",
       handler: (ChildOutputT) -> WorkflowAction<StateT, OutputT>
     ): ChildRenderingT = compose(child, Unit, key, handler)
@@ -170,12 +170,12 @@ fun <StateT : Any, OutputT : Any, ChildStateT : Any, ChildOutputT : Any, ChildRe
 /**
  * Convenience alias of [WorkflowContext.compose] for workflows that don't take input or emit output.
  */
-fun <InputT : Any, StateT : Any, OutputT : Any, ChildStateT : Any, ChildRenderingT : Any>
+fun <InputT : Any, StateT : Any, OutputT : Any, ChildRenderingT : Any>
     WorkflowContext<StateT, OutputT>.compose(
 // Intellij refuses to format this parameter list correctly because of the weird line break,
 // and detekt will complain about it.
 // @formatter:off
-      child: Workflow<InputT, ChildStateT, Nothing, ChildRenderingT>,
+      child: Workflow<InputT, Nothing, ChildRenderingT>,
       input: InputT,
       key: String = ""
     ): ChildRenderingT = compose(child, input, key) { WorkflowAction.noop() }
@@ -184,12 +184,12 @@ fun <InputT : Any, StateT : Any, OutputT : Any, ChildStateT : Any, ChildRenderin
 /**
  * Convenience alias of [WorkflowContext.compose] for workflows that don't take input or emit output.
  */
-fun <StateT : Any, OutputT : Any, ChildStateT : Any, ChildRenderingT : Any>
+fun <StateT : Any, OutputT : Any, ChildRenderingT : Any>
     WorkflowContext<StateT, OutputT>.compose(
 // Intellij refuses to format this parameter list correctly because of the weird line break,
 // and detekt will complain about it.
 // @formatter:off
-      child: Workflow<Unit, ChildStateT, Nothing, ChildRenderingT>,
+      child: Workflow<Unit, Nothing, ChildRenderingT>,
       key: String = ""
     ): ChildRenderingT = compose(child, Unit, key) { WorkflowAction.noop() }
 // @formatter:on
@@ -197,7 +197,7 @@ fun <StateT : Any, OutputT : Any, ChildStateT : Any, ChildRenderingT : Any>
 /**
  * Will wait for [deferred] to complete, then pass its value to [handler]. Once the handler has been
  * invoked for a given deferred+key, it will not be invoked again until an invocation of
- * [Workflow.compose] that does _not_ call this method with that deferred+[key].
+ * `compose` that does _not_ call this method with that deferred+[key].
  *
  * @param key An optional string key that is used to distinguish between subscriptions of the same
  * type.
@@ -216,7 +216,7 @@ inline fun <reified T, StateT : Any, OutputT : Any> WorkflowContext<StateT, Outp
 /**
  * Will wait for [deferred] to complete, then pass its value to [handler]. Once the handler has been
  * invoked for a given deferred+key, it will not be invoked again until an invocation of
- * [Workflow.compose] that does _not_ call this method with that deferred+[key].
+ * `compose` that does _not_ call this method with that deferred+[key].
  *
  * @param type The [KType] that represents both the type of data source (e.g. `Deferred`) and the
  * element type [T].

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflows.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflows.kt
@@ -24,26 +24,10 @@ import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 // and detekt will complain about it.
 // @formatter:off
 fun <InputT : Any, OutputT : Any, FromRenderingT : Any, ToRenderingT : Any>
-    Workflow<InputT, *, OutputT, FromRenderingT>.mapRendering(
+    Workflow<InputT, OutputT, FromRenderingT>.mapRendering(
       transform: (FromRenderingT) -> ToRenderingT
-    ): StatelessWorkflow<InputT, OutputT, ToRenderingT> = StatelessWorkflow { input, context ->
+    ): Workflow<InputT, OutputT, ToRenderingT> = StatelessWorkflow { input, context ->
 // @formatter:on
   context.compose(this@mapRendering, input) { emitOutput(it) }
       .let(transform)
 }
-
-/**
- * Returns a rendering that directly delegates to this [Workflow] but masks its state type.
- *
- * Useful for exposing a stateful workflow as part of a public API when you don't want your state
- * type to be public.
- */
-// Intellij refuses to format this parameter list correctly because of the weird line break,
-// and detekt will complain about it.
-// @formatter:off
-fun <InputT : Any, OutputT : Any, RenderingT : Any>
-    Workflow<InputT, *, OutputT, RenderingT>.hideState():
-    StatelessWorkflow<InputT, OutputT, RenderingT> = StatelessWorkflow { input, context ->
-      context.compose(this@hideState, input) { emitOutput(it) }
-    }
-// @formatter:on

--- a/kotlin/workflow-host/src/main/java/com/squareup/workflow/WorkflowHost.kt
+++ b/kotlin/workflow-host/src/main/java/com/squareup/workflow/WorkflowHost.kt
@@ -70,15 +70,15 @@ interface WorkflowHost<out OutputT : Any, out RenderingT : Any> {
      * @param context The [CoroutineContext] used to run the workflow tree. Added to the [Factory]'s
      * context.
      */
-    fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any> run(
-      workflow: Workflow<InputT, StateT, OutputT, RenderingT>,
+    fun <InputT : Any, OutputT : Any, RenderingT : Any> run(
+      workflow: Workflow<InputT, OutputT, RenderingT>,
       input: InputT,
       snapshot: Snapshot? = null,
       context: CoroutineContext = EmptyCoroutineContext
     ): WorkflowHost<OutputT, RenderingT> = run(workflow.id(), workflow, input, snapshot, context)
 
-    fun <StateT : Any, OutputT : Any, RenderingT : Any> run(
-      workflow: Workflow<Unit, StateT, OutputT, RenderingT>,
+    fun <OutputT : Any, RenderingT : Any> run(
+      workflow: Workflow<Unit, OutputT, RenderingT>,
       snapshot: Snapshot? = null,
       context: CoroutineContext = EmptyCoroutineContext
     ): WorkflowHost<OutputT, RenderingT> = run(workflow.id(), workflow, Unit, snapshot, context)
@@ -93,26 +93,34 @@ interface WorkflowHost<out OutputT : Any, out RenderingT : Any> {
      */
     @TestOnly
     fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any> runTestFromState(
-      workflow: Workflow<InputT, StateT, OutputT, RenderingT>,
+      workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
       input: InputT,
       initialState: StateT
     ): WorkflowHost<OutputT, RenderingT> {
       val workflowId = workflow.id()
       return object : WorkflowHost<OutputT, RenderingT> {
         val node = WorkflowNode(workflowId, workflow, input, null, baseContext, initialState)
-        override val updates: ReceiveChannel<Update<OutputT, RenderingT>> = node.start(workflow, input)
+        override val updates: ReceiveChannel<Update<OutputT, RenderingT>> =
+          node.start(workflow, input)
       }
     }
 
-    internal fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any> run(
-      id: WorkflowId<InputT, StateT, OutputT, RenderingT>,
-      workflow: Workflow<InputT, StateT, OutputT, RenderingT>,
+    internal fun <InputT : Any, OutputT : Any, RenderingT : Any> run(
+      id: WorkflowId<InputT, OutputT, RenderingT>,
+      workflow: Workflow<InputT, OutputT, RenderingT>,
       input: InputT,
       snapshot: Snapshot?,
       context: CoroutineContext
     ): WorkflowHost<OutputT, RenderingT> = object : WorkflowHost<OutputT, RenderingT> {
-      val node = WorkflowNode(id, workflow, input, snapshot, baseContext + context)
-      override val updates: ReceiveChannel<Update<OutputT, RenderingT>> = node.start(workflow, input)
+      val node = WorkflowNode(
+          id = id,
+          workflow = workflow.asStatefulWorkflow(),
+          initialInput = input,
+          snapshot = snapshot,
+          baseContext = baseContext + context
+      )
+      override val updates: ReceiveChannel<Update<OutputT, RenderingT>> =
+        node.start(workflow.asStatefulWorkflow(), input)
     }
   }
 }
@@ -120,8 +128,8 @@ interface WorkflowHost<out OutputT : Any, out RenderingT : Any> {
 /**
  * Starts the coroutine that runs the coroutine loop.
  */
-internal fun <I : Any, S : Any, O : Any, R : Any> WorkflowNode<I, S, O, R>.start(
-  workflow: Workflow<I, S, O, R>,
+internal fun <I : Any, O : Any, R : Any> WorkflowNode<I, *, O, R>.start(
+  workflow: StatefulWorkflow<I, *, O, R>,
   input: I
 ): ReceiveChannel<Update<O, R>> = produce(capacity = 0) {
   try {

--- a/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -25,7 +25,7 @@ import kotlin.reflect.KType
 
 /**
  * An immutable description of the things a [Workflow] would like to do as the result of calling its
- * [Workflow.compose] method. A `Behavior` is built up by calling methods on a
+ * `compose` method. A `Behavior` is built up by calling methods on a
  * [WorkflowContext][com.squareup.workflow.WorkflowContext] ([RealWorkflowContext] in particular).
  *
  * @see RealWorkflowContext
@@ -43,8 +43,8 @@ internal data class Behavior<StateT : Any, out OutputT : Any>(
       ParentStateT : Any,
       out ParentOutputT : Any
       >(
-        val workflow: Workflow<*, *, ChildOutputT, *>,
-        val id: WorkflowId<ChildInputT, *, ChildOutputT, *>,
+        val workflow: Workflow<*, ChildOutputT, *>,
+        val id: WorkflowId<ChildInputT, ChildOutputT, *>,
         val input: ChildInputT,
         val handler: (ChildOutputT) -> WorkflowAction<ParentStateT, ParentOutputT>
       ) {

--- a/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/RealWorkflowContext.kt
+++ b/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/RealWorkflowContext.kt
@@ -35,10 +35,10 @@ internal class RealWorkflowContext<StateT : Any, OutputT : Any>(
 ) : WorkflowContext<StateT, OutputT> {
 
   interface Composer<StateT : Any, in OutputT : Any> {
-    fun <ChildInputT : Any, ChildStateT : Any, ChildOutputT : Any, ChildRenderingT : Any> compose(
+    fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any> compose(
       case: WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT>,
-      child: Workflow<ChildInputT, ChildStateT, ChildOutputT, ChildRenderingT>,
-      id: WorkflowId<ChildInputT, ChildStateT, ChildOutputT, ChildRenderingT>,
+      child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
+      id: WorkflowId<ChildInputT, ChildOutputT, ChildRenderingT>,
       input: ChildInputT
     ): ChildRenderingT
   }
@@ -73,9 +73,9 @@ internal class RealWorkflowContext<StateT : Any, OutputT : Any>(
   }
 
   // @formatter:off
-  override fun <ChildInputT : Any, ChildStateT : Any, ChildOutputT : Any, ChildRenderingT : Any>
+  override fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
       compose(
-        child: Workflow<ChildInputT, ChildStateT, ChildOutputT, ChildRenderingT>,
+        child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
         input: ChildInputT,
         key: String,
         handler: (ChildOutputT) -> WorkflowAction<StateT, OutputT>

--- a/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
+++ b/kotlin/workflow-host/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
@@ -15,44 +15,44 @@
  */
 package com.squareup.workflow.internal
 
+import com.squareup.workflow.Workflow
 import com.squareup.workflow.parse
 import com.squareup.workflow.readUtf8WithLength
-import com.squareup.workflow.Workflow
 import com.squareup.workflow.writeUtf8WithLength
 import okio.Buffer
 import okio.ByteString
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
-internal typealias AnyId = WorkflowId<*, *, *, *>
+internal typealias AnyId = WorkflowId<*, *, *>
 
 /**
  * Value type that can be used to distinguish between different workflows of different types or
  * the same type (in that case using a [name]).
  */
-internal data class WorkflowId<in InputT : Any, StateT : Any, out OutputT : Any, out RenderingT : Any>
+internal data class WorkflowId<in InputT : Any, out OutputT : Any, out RenderingT : Any>
 @PublishedApi
 internal constructor(
-  internal val type: KClass<out Workflow<InputT, StateT, OutputT, RenderingT>>,
+  internal val type: KClass<out Workflow<InputT, OutputT, RenderingT>>,
   internal val name: String = ""
 )
 
 @Suppress("unused")
-internal fun <W : Workflow<P, S, O, R>, P : Any, S : Any, O : Any, R : Any>
-    W.id(key: String = ""): WorkflowId<P, S, O, R> =
+internal fun <W : Workflow<P, O, R>, P : Any, O : Any, R : Any>
+    W.id(key: String = ""): WorkflowId<P, O, R> =
   WorkflowId(this::class, key)
 
-internal fun WorkflowId<*, *, *, *>.toByteString(): ByteString = Buffer()
+internal fun WorkflowId<*, *, *>.toByteString(): ByteString = Buffer()
     .also { sink ->
       sink.writeUtf8WithLength(type.jvmName)
       sink.writeUtf8WithLength(name)
     }
     .readByteString()
 
-internal fun restoreId(bytes: ByteString): WorkflowId<*, *, *, *> = bytes.parse { source ->
+internal fun restoreId(bytes: ByteString): WorkflowId<*, *, *> = bytes.parse { source ->
   val typeName = source.readUtf8WithLength()
   @Suppress("UNCHECKED_CAST")
-  val type = Class.forName(typeName) as Class<out Workflow<Nothing, Any, Any, Any>>
+  val type = Class.forName(typeName) as Class<out Workflow<Nothing, Any, Any>>
   val name = source.readUtf8WithLength()
   return WorkflowId(type.kotlin, name)
 }

--- a/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -16,10 +16,10 @@
 package com.squareup.workflow.internal
 
 import com.squareup.workflow.Snapshot
-import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowContext
+import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
+import com.squareup.workflow.WorkflowContext
 import com.squareup.workflow.internal.Behavior.WorkflowOutputCase
 import com.squareup.workflow.internal.SubtreeManagerTest.TestWorkflow.Rendering
 import kotlinx.coroutines.experimental.Dispatchers
@@ -33,7 +33,7 @@ import kotlin.test.fail
 
 class SubtreeManagerTest {
 
-  private class TestWorkflow : Workflow<String, String, String, Rendering> {
+  private class TestWorkflow : StatefulWorkflow<String, String, String, Rendering>() {
 
     var started = 0
 

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
@@ -16,14 +16,14 @@
 package com.squareup.workflow.rx2
 
 import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.WorkflowAction.Companion.emitOutput
+import com.squareup.workflow.WorkflowAction.Companion.enterState
+import com.squareup.workflow.WorkflowContext
+import com.squareup.workflow.testing.testFromStart
 import com.squareup.workflow.util.ChannelUpdate
 import com.squareup.workflow.util.ChannelUpdate.Closed
 import com.squareup.workflow.util.ChannelUpdate.Value
-import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowContext
-import com.squareup.workflow.WorkflowAction.Companion.emitOutput
-import com.squareup.workflow.WorkflowAction.Companion.enterState
-import com.squareup.workflow.testing.testFromStart
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.experimental.TimeoutCancellationException
@@ -46,7 +46,7 @@ class SubscriptionsTest {
    */
   private class SubscriberWorkflow(
     subject: Observable<String>
-  ) : Workflow<Boolean, Boolean, ChannelUpdate<String>, (setSubscribed: Boolean) -> Unit> {
+  ) : StatefulWorkflow<Boolean, Boolean, ChannelUpdate<String>, (Boolean) -> Unit>() {
 
     var subscriptions = 0
       private set

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
@@ -17,8 +17,8 @@ package com.squareup.workflow.rx2
 
 import com.squareup.workflow.EventHandler
 import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.StatelessWorkflow
-import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.WorkflowAction.Companion.noop
@@ -70,7 +70,7 @@ class WorkflowContextsTest {
     val single = singleSubject
         .doOnSubscribe { subscriptions++ }
         .doOnDispose { disposals++ }
-    val workflow = object : Workflow<Unit, Boolean, Nothing, Unit> {
+    val workflow = object : StatefulWorkflow<Unit, Boolean, Nothing, Unit>() {
       override fun initialState(input: Unit): Boolean = true
 
       override fun compose(

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTesting.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTesting.kt
@@ -16,6 +16,7 @@
 package com.squareup.workflow.testing
 
 import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowHost
 import com.squareup.workflow.WorkflowHost.Factory
@@ -34,7 +35,7 @@ import kotlin.coroutines.experimental.EmptyCoroutineContext
 // @formatter:off
 @TestOnly
 fun <T, InputT : Any, OutputT : Any, RenderingT : Any>
-    Workflow<InputT, *, OutputT, RenderingT>.testFromStart(
+    Workflow<InputT, OutputT, RenderingT>.testFromStart(
       input: InputT,
       snapshot: Snapshot? = null,
       context: CoroutineContext = EmptyCoroutineContext,
@@ -48,7 +49,7 @@ fun <T, InputT : Any, OutputT : Any, RenderingT : Any>
  * All workflow-related coroutines are cancelled when the block exits.
  */
 @TestOnly
-fun <T, OutputT : Any, RenderingT : Any> Workflow<Unit, *, OutputT, RenderingT>.testFromStart(
+fun <T, OutputT : Any, RenderingT : Any> Workflow<Unit, OutputT, RenderingT>.testFromStart(
   snapshot: Snapshot? = null,
   context: CoroutineContext = EmptyCoroutineContext,
   block: (WorkflowTester<OutputT, RenderingT>) -> T
@@ -56,15 +57,15 @@ fun <T, OutputT : Any, RenderingT : Any> Workflow<Unit, *, OutputT, RenderingT>.
 
 /**
  * Creates a [WorkflowTester] to run this workflow for unit testing.
- * [Workflow.initialState] is not called. Instead, the workflow is started from the given
- * [initialState].
+ * If the workflow is [stateful][StatefulWorkflow], [initialState][StatefulWorkflow.initialState]
+ * is not called. Instead, the workflow is started from the given [initialState].
  *
  * All workflow-related coroutines are cancelled when the block exits.
  */
 // @formatter:off
 @TestOnly
 fun <T, InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any>
-    Workflow<InputT, StateT, OutputT, RenderingT>.testFromState(
+    StatefulWorkflow<InputT, StateT, OutputT, RenderingT>.testFromState(
       input: InputT,
       initialState: StateT,
       context: CoroutineContext = EmptyCoroutineContext,
@@ -74,15 +75,15 @@ fun <T, InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any>
 
 /**
  * Creates a [WorkflowTester] to run this workflow for unit testing.
- * [Workflow.initialState] is not called. Instead, the workflow is started from the given
- * [initialState].
+ * If the workflow is [stateful][StatefulWorkflow], [initialState][StatefulWorkflow.initialState]
+ * is not called. Instead, the workflow is started from the given [initialState].
  *
  * All workflow-related coroutines are cancelled when the block exits.
  */
 // @formatter:off
 @TestOnly
 fun <StateT : Any, OutputT : Any, RenderingT : Any>
-    Workflow<Unit, StateT, OutputT, RenderingT>.testFromState(
+    StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.testFromState(
       initialState: StateT,
       context: CoroutineContext = EmptyCoroutineContext,
       block: (WorkflowTester<OutputT, RenderingT>) -> Unit

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
@@ -44,7 +44,7 @@ class ChannelSubscriptionsIntegrationTest {
    */
   private class SubscriberWorkflow(
     private val channel: Channel<String>
-  ) : Workflow<Boolean, Boolean, ChannelUpdate<String>, (setSubscribed: Boolean) -> Unit> {
+  ) : StatefulWorkflow<Boolean, Boolean, ChannelUpdate<String>, (Boolean) -> Unit>() {
 
     var subscriptions = 0
       private set

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
@@ -23,7 +23,7 @@ import com.squareup.workflow.TreeWorkflow.Rendering
 internal class TreeWorkflow(
   private val name: String,
   private vararg val children: TreeWorkflow
-) : Workflow<String, String, Nothing, Rendering> {
+) : StatefulWorkflow<String, String, Nothing, Rendering>() {
 
   class Rendering(
     val data: String,

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowTesterTest.kt
@@ -72,7 +72,7 @@ class WorkflowTesterTest {
   }
 
   @Test fun `propagates exception when workflow throws from initial state`() {
-    val workflow = object : Workflow<Unit, Unit, Nothing, Unit> {
+    val workflow = object : StatefulWorkflow<Unit, Unit, Nothing, Unit>() {
       override fun initialState(input: Unit) {
         throw ExpectedException()
       }
@@ -102,7 +102,7 @@ class WorkflowTesterTest {
   }
 
   @Test fun `propagates exception when workflow throws from snapshot state`() {
-    val workflow = object : Workflow<Unit, Unit, Nothing, Unit> {
+    val workflow = object : StatefulWorkflow<Unit, Unit, Nothing, Unit>() {
       override fun initialState(input: Unit) {
         // Noop
       }
@@ -132,7 +132,7 @@ class WorkflowTesterTest {
   }
 
   @Test fun `propagates exception when workflow throws from restore state`() {
-    val workflow = object : Workflow<Unit, Unit, Nothing, Unit> {
+    val workflow = object : StatefulWorkflow<Unit, Unit, Nothing, Unit>() {
       override fun initialState(input: Unit) {
       }
 


### PR DESCRIPTION
tl;dr:
 - `Workflow` -> `StatefulWorkflow`
 - `Workflow` is an interface, `StatefulWorkflow` and `StatelessWorkflow` are abstract classes
   that both implement `Workflow`.

This change makes it much easier for consumers of this library to define public APIs with private
implementations. The public API is an interface that extends `Workflow`. The private
implementation is a class that subclasses either `StatefulWorkflow` or `StatelessWorkflow`,
depending on whether it needs to keep track of any state. Either way, the workflow's state type
is kept as a completely private concern.


`interface Workflow<I, O, R>`
-----------------------------

This is the main currency of this library. `Workflow`s can compose
other `Workflow`s. A `Workflow` is anything that can be expressed as a `StatefulWorkflow`.
It has a single method, `asStatefulWorkflow()`, that is responsible for expressing the
workflow in terms of a `StatefulWorkflow` – a workflow that has an internal state. This
commit renames what used to be `Workflow` to `StatefulWorkflow`.


`abstract class StatefulWorkflow<I, S, O, R>`
---------------------------------------------

This is what you subclass to write a `Workflow` that has internal state that persists
as long as the workflow is active in its parent. It knows about things like initial state
and snapshotting/restoring.


`abstract class StatelessWorkflow<I, O, R>`
-------------------------------------------

This is what you subclass to get a `Workflow` that only has a single `compose` method.
It can compose children workflows, transform inputs/outputs/renderings up/down the tree,
and listen to external events and subscriptions, but it has no state.

Closes #213.

Based on #214 

[Internal discussion](https://square.slack.com/archives/CE470RL5T/p1553704080224400)