### PR TITLE
Replace restoreState with a Snapshot param to initialState.

### DIFF
--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -53,7 +53,10 @@ interface AuthWorkflow : Workflow<Unit, String, BackStackScreen<*>>
 class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
     StatefulWorkflow<Unit, AuthState, String, BackStackScreen<*>>() {
 
-  override fun initialState(input: Unit): AuthState = LoginPrompt()
+  override fun initialState(
+    input: Unit,
+    snapshot: Snapshot?
+  ): AuthState = LoginPrompt()
 
   override fun compose(
     input: Unit,
@@ -122,11 +125,6 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
    * It'd be silly to restore an in progress login session, so saves nothing.
    */
   override fun snapshotState(state: AuthState): Snapshot = Snapshot.EMPTY
-
-  /**
-   * [snapshotState] saves nothing, so always start from the [initialState].
-   */
-  override fun restoreState(snapshot: Snapshot): AuthState = initialState(Unit)
 
   private val AuthResponse.isLoginFailure: Boolean
     get() = token.isEmpty() && errorMessage.isNotEmpty()

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -76,7 +76,11 @@ class RealRunGameWorkflow(
     StatefulWorkflow<Unit, RunGameState, RunGameResult,
         AlertContainerScreen<PanelContainerScreen<*, *>>>() {
 
-  override fun initialState(input: Unit): RunGameState = NewGame()
+  override fun initialState(
+    input: Unit,
+    snapshot: Snapshot?
+  ): RunGameState = snapshot?.let { RunGameState.fromSnapshot(snapshot.bytes) }
+      ?: NewGame()
 
   override fun compose(
     input: Unit,
@@ -180,10 +184,6 @@ class RealRunGameWorkflow(
   }
 
   override fun snapshotState(state: RunGameState): Snapshot = state.toSnapshot()
-
-  override fun restoreState(snapshot: Snapshot): RunGameState {
-    return RunGameState.fromSnapshot(snapshot.bytes)
-  }
 
   private fun nestedAlertsScreen(
     base: Any,

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -41,7 +41,10 @@ interface TakeTurnsWorkflow : Workflow<PlayerInfo, CompletedGame, GamePlayScreen
 class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
     StatefulWorkflow<PlayerInfo, Turn, CompletedGame, GamePlayScreen>() {
 
-  override fun initialState(input: PlayerInfo) = Turn()
+  override fun initialState(
+    input: PlayerInfo,
+    snapshot: Snapshot?
+  ): Turn = Turn()
 
   override fun compose(
     input: PlayerInfo,
@@ -76,5 +79,4 @@ class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
   }
 
   override fun snapshotState(state: Turn) = Snapshot.EMPTY
-  override fun restoreState(snapshot: Snapshot) = Turn()
 }

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
@@ -45,7 +45,11 @@ class MainWorkflow(
   private val runGameWorkflow: RunGameWorkflow
 ) : StatefulWorkflow<Unit, MainState, Unit, RootScreen>() {
 
-  override fun initialState(input: Unit): MainState = Authenticating
+  override fun initialState(
+    input: Unit,
+    snapshot: Snapshot?
+  ): MainState = snapshot?.let { MainState.fromSnapshot(snapshot.bytes) }
+      ?: Authenticating
 
   override fun compose(
     input: Unit,
@@ -63,8 +67,4 @@ class MainWorkflow(
   }
 
   override fun snapshotState(state: MainState): Snapshot = state.toSnapshot()
-
-  override fun restoreState(snapshot: Snapshot): MainState {
-    return MainState.fromSnapshot(snapshot.bytes)
-  }
 }

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -66,8 +66,17 @@ abstract class StatefulWorkflow<
   /**
    * Called from [WorkflowContext.compose] when the state machine is first started, to get the
    * initial state.
+   *
+   * @param snapshot
+   * If the workflow is being created fresh, [snapshot] will be null.
+   * If the workflow is being restored from a [Snapshot], [snapshot] will be the last value
+   * returned from [snapshotState], and implementations that return something other than
+   * [Snapshot.EMPTY] should create their initial state by parsing their snapshot.
    */
-  abstract fun initialState(input: InputT): StateT
+  abstract fun initialState(
+    input: InputT,
+    snapshot: Snapshot?
+  ): StateT
 
   /**
    * Called from [WorkflowContext.compose] instead of [initialState] when the workflow is already
@@ -119,19 +128,9 @@ abstract class StatefulWorkflow<
    * If the workflow does not have any state, or should always be started from scratch, return
    * [Snapshot.EMPTY] from this method.
    *
-   * @see restoreState
+   * @see initialState
    */
   abstract fun snapshotState(state: StateT): Snapshot
-
-  /**
-   * Deserialize a state value from a [Snapshot] previously created with [snapshotState].
-   *
-   * If the workflow should always be started from scratch, this method can just ignore the snapshot
-   * and return the initial state.
-   *
-   * @see snapshotState
-   */
-  abstract fun restoreState(snapshot: Snapshot): StateT
 
   /**
    * Satisfies the [Workflow] interface by returning `this`.

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -73,7 +73,10 @@ abstract class StatelessWorkflow<InputT : Any, OutputT : Any, RenderingT : Any> 
    */
   final override fun asStatefulWorkflow(): StatefulWorkflow<InputT, *, OutputT, RenderingT> =
     object : StatefulWorkflow<InputT, Unit, OutputT, RenderingT>() {
-      override fun initialState(input: InputT) = Unit
+      override fun initialState(
+        input: InputT,
+        snapshot: Snapshot?
+      ) = Unit
 
       @Suppress("UNCHECKED_CAST")
       override fun compose(
@@ -83,7 +86,6 @@ abstract class StatelessWorkflow<InputT : Any, OutputT : Any, RenderingT : Any> 
       ): RenderingT = compose(input, context as WorkflowContext<Nothing, OutputT>)
 
       override fun snapshotState(state: Unit) = Snapshot.EMPTY
-      override fun restoreState(snapshot: Snapshot) = Unit
     }
 }
 

--- a/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/RealWorkflowContextTest.kt
+++ b/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/RealWorkflowContextTest.kt
@@ -54,7 +54,10 @@ class RealWorkflowContextTest {
   }
 
   private class TestWorkflow : StatefulWorkflow<String, String, String, Rendering>() {
-    override fun initialState(input: String): String = fail()
+    override fun initialState(
+      input: String,
+      snapshot: Snapshot?
+    ): String = fail()
 
     override fun compose(
       input: String,
@@ -65,7 +68,6 @@ class RealWorkflowContextTest {
     }
 
     override fun snapshotState(state: String): Snapshot = fail()
-    override fun restoreState(snapshot: Snapshot): String = fail()
   }
 
   private class PoisonComposer<S : Any, O : Any> : Composer<S, O> {

--- a/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-host/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -43,7 +43,10 @@ class SubtreeManagerTest {
       val eventHandler: (String) -> Unit
     )
 
-    override fun initialState(input: String): String {
+    override fun initialState(
+      input: String,
+      snapshot: Snapshot?
+    ): String {
       started++
       return "initialState:$input"
     }
@@ -57,7 +60,6 @@ class SubtreeManagerTest {
     })
 
     override fun snapshotState(state: String) = fail()
-    override fun restoreState(snapshot: Snapshot) = fail()
   }
 
   private val context = Dispatchers.Unconfined

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
@@ -33,7 +33,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
-import kotlin.test.fail
 
 class SubscriptionsTest {
 
@@ -58,7 +57,10 @@ class SubscriptionsTest {
         .doOnSubscribe { subscriptions++ }
         .doOnDispose { disposals++ }
 
-    override fun initialState(input: Boolean): Boolean = input
+    override fun initialState(
+      input: Boolean,
+      snapshot: Snapshot?
+    ): Boolean = input
 
     override fun compose(
       input: Boolean,
@@ -72,7 +74,6 @@ class SubscriptionsTest {
     }
 
     override fun snapshotState(state: Boolean) = Snapshot.EMPTY
-    override fun restoreState(snapshot: Snapshot): Boolean = fail()
   }
 
   private val subject = PublishSubject.create<String>()

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
@@ -30,7 +30,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 class WorkflowContextsTest {
 
@@ -71,7 +70,10 @@ class WorkflowContextsTest {
         .doOnSubscribe { subscriptions++ }
         .doOnDispose { disposals++ }
     val workflow = object : StatefulWorkflow<Unit, Boolean, Nothing, Unit>() {
-      override fun initialState(input: Unit): Boolean = true
+      override fun initialState(
+        input: Unit,
+        snapshot: Snapshot?
+      ): Boolean = true
 
       override fun compose(
         input: Unit,
@@ -85,7 +87,6 @@ class WorkflowContextsTest {
       }
 
       override fun snapshotState(state: Boolean): Snapshot = Snapshot.EMPTY
-      override fun restoreState(snapshot: Snapshot): Boolean = fail("not expected")
     }
 
     assertEquals(0, subscriptions)

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
@@ -15,12 +15,12 @@
  */
 package com.squareup.workflow
 
-import com.squareup.workflow.util.ChannelUpdate.Closed
-import com.squareup.workflow.util.ChannelUpdate.Value
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.testing.testFromStart
 import com.squareup.workflow.util.ChannelUpdate
+import com.squareup.workflow.util.ChannelUpdate.Closed
+import com.squareup.workflow.util.ChannelUpdate.Value
 import kotlinx.coroutines.experimental.TimeoutCancellationException
 import kotlinx.coroutines.experimental.channels.Channel
 import kotlinx.coroutines.experimental.channels.ReceiveChannel
@@ -31,7 +31,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
-import kotlin.test.fail
 
 class ChannelSubscriptionsIntegrationTest {
 
@@ -56,7 +55,10 @@ class ChannelSubscriptionsIntegrationTest {
       channel.invokeOnClose { cancellations++ }
     }
 
-    override fun initialState(input: Boolean): Boolean = input
+    override fun initialState(
+      input: Boolean,
+      snapshot: Snapshot?
+    ): Boolean = input
 
     override fun compose(
       input: Boolean,
@@ -70,7 +72,6 @@ class ChannelSubscriptionsIntegrationTest {
     }
 
     override fun snapshotState(state: Boolean) = Snapshot.EMPTY
-    override fun restoreState(snapshot: Snapshot): Boolean = fail()
 
     private fun subscribe(): ReceiveChannel<String> {
       subscriptions++

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
@@ -43,7 +43,12 @@ internal class TreeWorkflow(
     }
   }
 
-  override fun initialState(input: String): String = input
+  override fun initialState(
+    input: String,
+    snapshot: Snapshot?
+  ): String = snapshot?.bytes?.parse {
+    it.readUtf8WithLength()
+  } ?: input
 
   override fun compose(
     input: String,
@@ -72,8 +77,4 @@ internal class TreeWorkflow(
     Snapshot.write {
       it.writeUtf8WithLength(state)
     }
-
-  override fun restoreState(snapshot: Snapshot): String = snapshot.bytes.parse {
-    it.readUtf8WithLength()
-  }
 }


### PR DESCRIPTION
This allows workflows to depend on their input to calculate their
state, even when being restored. It also reduces the entry points for
a workflow from two to one.

Closes #220.