### PR TITLE
Add extension on `Screen` to wrap as `AnyScreen` or passthrough if it already is

### DIFF
--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -16,3 +16,14 @@ public struct AnyScreen: Screen {
         return viewControllerBuilder(viewRegistry)
     }
 }
+
+
+extension Screen {
+    public func asAnyScreen() -> AnyScreen {
+        if let anyScreen = self as? AnyScreen {
+            return anyScreen
+        } else {
+            return AnyScreen(self)
+        }
+    }
+}

--- a/swift/WorkflowUI/Tests/AnyScreenTests.swift
+++ b/swift/WorkflowUI/Tests/AnyScreenTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import WorkflowUI
+
+
+class AnyScreenTests: XCTestCase {
+
+    func test_asAnyScreen_returns_same_screen_if_anyScreen() {
+        let screen = AnyScreen(ScreenA())
+
+        XCTAssertTrue(type(of: screen.wrappedScreen) == ScreenA.self)
+
+        // Wrapping again nests another AnyScreen.
+        let wrappedScreen = AnyScreen(screen)
+        XCTAssertFalse(type(of: wrappedScreen.wrappedScreen) == ScreenA.self)
+
+        let asAnyScreen = screen.asAnyScreen()
+        XCTAssertTrue(type(of: asAnyScreen.wrappedScreen) == ScreenA.self)
+
+    }
+}
+
+
+fileprivate struct ScreenA: Screen {}


### PR DESCRIPTION
While converting over some containers view controllers, I found that often I would either have to explicitly check if something was already an AnyScreen, or be specific with the generic passed in, ie:

```
struct ContainerScreen {
  var displayedScreen: AnyScreen

  public init<ScreenType: Screen>(displayedScreen: ScreenType) {
    self.displayedScreen = AnyScreen(displayedScreen) // non-ideal, since it might already be an AnyScreen.
  // OR
    if let anyScreen = displayedScreen as? AnyScreen {
      self.displayedScreen = anyScreen
    } else {
      self.displayedScreen = AnyScreen(displayedScreen) // non-ideal, since it might already be an AnyScreen.
    }
  }
}
```

Adding this extension on screen allows it to become:
```
  public init(displayedScreen: Screen) {
    self.displayedScreen = displayedScreen.asAnyScreen() // If it already is, this is a nop, otherwise wrap it.
  }
```

This is also useful for a case where we need to pass along an `AnyScreen` out of a compose method (where two or more children will return different screens) using chaining.

```
compose(...) -> AnyScreen {
  switch state {
    case first:
      // FirstChildWorkflow's Rendering is "FirstScreen"
      return FirstChildWorkflow().rendered(with: context).asAnyScreen()
    case second:
      // SecondChildWorkflow's Rendering is "SecondScreen"
      return SecondChildWorkflow().rendered(with: context).asAnyScreen()
  }
}
```