### PR TITLE
Updated compose in template to return an explicit Screen

### DIFF
--- a/swift/Tooling/Templates/Workflow (Verbose).xctemplate/___FILEBASENAME___Workflow.swift
+++ b/swift/Tooling/Templates/Workflow (Verbose).xctemplate/___FILEBASENAME___Workflow.swift
@@ -79,8 +79,8 @@ extension ___VARIABLE_productName___Workflow {
 
 extension ___VARIABLE_productName___Workflow {
 
-    func compose(state: ___VARIABLE_productName___Workflow.State, context: WorkflowContext<___VARIABLE_productName___Workflow>) -> Screen {
-        #warning("Don't forget your compose implementation!")
-        fatalError()
+    func compose(state: ___VARIABLE_productName___Workflow.State, context: WorkflowContext<___VARIABLE_productName___Workflow>) -> String {
+        #warning("Don't forget your compose implementation and to return the correct rendering type!")
+        return "This is likely not the rendering that you want to return"
     }
 }


### PR DESCRIPTION
A compose method can no longer return `Screen`, but must return a typed screen.
Updates the template to reflect this.

This means that the result of using the template will *not* compile until the screen returned from compose is one that is an actual type. However, I think it's a faster loop to finding this out than to have it be Screen and then be surprised by compiler errors later on.

Resolves #270