### PR TITLE
Upgrade Android Gradle Plugin to latest version.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -15,7 +15,7 @@
  */
 buildscript {
   ext.versions = [
-      'agp': '3.2.1',
+      'agp': '3.3.2',
       'buildTools': '28.0.3',
       'compileSdk': '28',
       'lifecycle': '1.1.1',


### PR DESCRIPTION
Closes #115.

This blocks the Gradle 5 bump (#275).