### PR TITLE
Add support for listening to Flow streams.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/VeryExperimentalWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/VeryExperimentalWorkflow.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow
+
+import kotlin.Experimental.Level.ERROR
+import kotlin.annotation.AnnotationRetention.BINARY
+
+/**
+ * Marks Workflow APIs that are extremely likely to change in future versions, rely themselves on
+ * other unstable, experimental APIs, and SHOULD NOT be used in production code. Proceed with
+ * caution, and be ready to have the rug pulled out from under you.
+ */
+@MustBeDocumented
+@Retention(value = BINARY)
+@Experimental(level = ERROR)
+annotation class VeryExperimentalWorkflow

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -23,10 +23,13 @@ import com.squareup.workflow.Worker.Emitter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlin.reflect.KClass
 
 /**
@@ -274,6 +277,19 @@ inline fun <reified T> ReceiveChannel<T>.asWorker(
 }
 
 /**
+ * Returns a [Worker] that will, when performed, emit whatever this [Flow] receives.
+ *
+ * **Warning:** The Flow API is very immature and so any breaking changes there (including in
+ * transiently-included versions) will be compounded when layering Workflow APIs on top of it.
+ * This **SHOULD NOT** be used in production code.
+ */
+@VeryExperimentalWorkflow
+@FlowPreview
+inline fun <reified T> Flow<T>.asWorker(
+  key: String = ""
+): Worker<T> = create(key) { emitAll(this@asWorker) }
+
+/**
  * Emits whatever [channel] receives on this [Emitter].
  *
  * @param closeOnCancel
@@ -299,6 +315,19 @@ suspend inline fun <T> Emitter<T>.emitAll(
       emitOutput(value)
     }
   }
+}
+
+/**
+ * Emits everything from [flow] on this [Emitter].
+ *
+ * **Warning:** The Flow API is very immature and so any breaking changes there (including in
+ * transiently-included versions) will be compounded when layering Workflow APIs on top of it.
+ * This **SHOULD NOT** be used in production code.
+ */
+@VeryExperimentalWorkflow
+@FlowPreview
+suspend inline fun <T> Emitter<T>.emitAll(flow: Flow<T>) {
+  flow.collect { emitOutput(it) }
 }
 
 /**

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/FlowWorkersTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/FlowWorkersTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("EXPERIMENTAL_API_USAGE")
+
+package com.squareup.workflow
+
+import com.squareup.workflow.testing.test
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FlowWorkersTest {
+
+  private class ExpectedException : RuntimeException()
+
+  private val subject = Channel<String>(capacity = 1)
+  private var source = flow { subject.consumeEach { emit(it) } }
+
+  @UseExperimental(VeryExperimentalWorkflow::class)
+  private val worker by lazy { source.asWorker() }
+
+  @Test fun `flow emits`() {
+    worker.test {
+      subject.send("foo")
+      assertEquals("foo", nextOutput())
+
+      subject.send("bar")
+      assertEquals("bar", nextOutput())
+    }
+  }
+
+  @Test fun `flow finishes`() {
+    worker.test {
+      subject.close()
+      assertFinished()
+    }
+  }
+
+  @Test fun `flow finishes after emitting interleaved`() {
+    worker.test {
+      subject.send("foo")
+      assertEquals("foo", nextOutput())
+
+      subject.close()
+      assertFinished()
+    }
+  }
+
+  @Test fun `flow finishes after emitting grouped`() {
+    worker.test {
+      subject.send("foo")
+      subject.close()
+
+      assertEquals("foo", nextOutput())
+      assertFinished()
+    }
+  }
+
+  @Test fun `flow throws`() {
+    worker.test {
+      subject.close(ExpectedException())
+      assertTrue(getException() is ExpectedException)
+    }
+  }
+
+  @Test fun `flow is collected lazily`() {
+    var collections = 0
+    source = source.onCollect { collections++ }
+
+    assertEquals(0, collections)
+
+    worker.test {
+      assertEquals(1, collections)
+    }
+  }
+
+  @Test fun `flow is cancelled when worker cancelled`() {
+    var cancellations = 0
+    source = source.onCancel { cancellations++ }
+
+    assertEquals(0, cancellations)
+
+    worker.test {
+      assertEquals(0, cancellations)
+      cancelWorker()
+      assertEquals(1, cancellations)
+    }
+  }
+
+  private fun <T> Flow<T>.onCollect(action: suspend () -> Unit) = flow {
+    action()
+    collect { emit(it) }
+  }
+
+  private fun <T> Flow<T>.onCancel(action: suspend () -> Unit) = flow {
+    try {
+      collect { emit(it) }
+    } catch (e: CancellationException) {
+      action()
+      throw e
+    }
+  }
+}


### PR DESCRIPTION
Closes #280.

I'm not actually sure this is something we should merge. I'm worried it might make people feel more comfortable using the Flow API than they should be, even though our integration is also tagged with experimental annotations. However, having it in the code base lets us track API and behavior changes and ensure our integration feels natural as the API stabilizes.