### PR TITLE
[kotlin] Rename compose and composeChild to render and renderChild.

### DIFF
--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/Screen.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/Screen.kt
@@ -84,7 +84,7 @@ class Screen<D : Any, E : Any>(
      *
      *    myWorkflow.getState()
      *        .map(wfState -> wfState.state[SOME_LAYER]!!)
-     *        .compose(key.filter())
+     *        .render(key.filter())
      */
     fun filter(): ObservableTransformer<AnyScreen, Screen<D, E>> =
       ObservableTransformer { observable -> observable.ofKeyType(this) }

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/EventChannel.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/EventChannel.kt
@@ -72,7 +72,7 @@ fun <E : Any> ReceiveChannel<E>.asEventChannel() = object : EventChannel<E> {
    *
    * This method will throw if called multiple times before either:
    * 1. an acceptable event is sent.
-   * 2. the returned `Single` is unsubscribed from. This allows you to compose the resulting single
+   * 2. the returned `Single` is unsubscribed from. This allows you to render the resulting single
    *    with other `Single`s that will preempt our emitting (e.g. timing out waiting for an event).
    *
    * If the workflow is abandoned while waiting for an event, the single will never complete. It will

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -60,7 +60,7 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
     scope: CoroutineScope
   ): AuthState = LoginPrompt()
 
-  override fun compose(
+  override fun render(
     input: Unit,
     state: AuthState,
     context: WorkflowContext<AuthState, String>

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -85,7 +85,7 @@ class RealRunGameWorkflow(
   ): RunGameState = snapshot?.let { RunGameState.fromSnapshot(snapshot.bytes) }
       ?: NewGame()
 
-  override fun compose(
+  override fun render(
     input: Unit,
     state: RunGameState,
     context: WorkflowContext<RunGameState, RunGameResult>
@@ -108,10 +108,10 @@ class RealRunGameWorkflow(
       }
 
       is Playing -> {
-        // context.composeChild starts takeTurnsWorkflow, or keeps it running if it was
-        // already going. TakeTurnsWorkflow.compose is immediately called,
+        // context.renderChild starts takeTurnsWorkflow, or keeps it running if it was
+        // already going. TakeTurnsWorkflow.render is immediately called,
         // and the GamePlayScreen it renders is immediately returned.
-        val takeTurnsScreen = context.composeChild(takeTurnsWorkflow, state.playerInfo) { output ->
+        val takeTurnsScreen = context.renderChild(takeTurnsWorkflow, state.playerInfo) { output ->
           when (output.ending) {
             Quitted -> enterState(MaybeQuitting(output, state.playerInfo))
             else -> enterState(GameOver(state.playerInfo, output))

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -48,7 +48,7 @@ class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
     scope: CoroutineScope
   ): Turn = Turn()
 
-  override fun compose(
+  override fun render(
     input: PlayerInfo,
     state: Turn,
     context: WorkflowContext<Turn, CompletedGame>

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
@@ -28,7 +28,7 @@ import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.WorkflowContext
-import com.squareup.workflow.composeChild
+import com.squareup.workflow.renderChild
 import com.squareup.workflow.ui.AlertContainerScreen
 import kotlinx.coroutines.CoroutineScope
 
@@ -55,19 +55,19 @@ class MainWorkflow(
   ): MainState = snapshot?.let { MainState.fromSnapshot(snapshot.bytes) }
       ?: Authenticating
 
-  override fun compose(
+  override fun render(
     input: Unit,
     state: MainState,
     context: WorkflowContext<MainState, Unit>
   ): RunGameScreen = when (state) {
     is Authenticating -> {
-      val authScreen = context.composeChild(authWorkflow) { enterState(RunningGame) }
+      val authScreen = context.renderChild(authWorkflow) { enterState(RunningGame) }
       val emptyGameScreen = GamePlayScreen()
 
       AlertContainerScreen(authScreen.asPanelOver(emptyGameScreen))
     }
 
-    is RunningGame -> context.composeChild(runGameWorkflow) { enterState(Authenticating) }
+    is RunningGame -> context.renderChild(runGameWorkflow) { enterState(Authenticating) }
   }
 
   override fun snapshotState(state: MainState): Snapshot = state.toSnapshot()

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.CoroutineScope
 
 /**
  * A composable, stateful object that can [handle events][WorkflowContext.onEvent],
- * [delegate to children][WorkflowContext.composeChild], [subscribe][onReceive] to arbitrary streams from
+ * [delegate to children][WorkflowContext.renderChild], [subscribe][onReceive] to arbitrary streams from
  * the outside world, and be [saved][snapshotState] to a serialized form to be restored later.
  *
  * The basic purpose of a `Workflow` is to take some [input][InputT] and return a
@@ -51,7 +51,7 @@ import kotlinx.coroutines.CoroutineScope
  * to its parent.
  * May be [Nothing] if the workflow doesn't need to emit anything.
  *
- * @param RenderingT The value returned to this workflow's parent during [composition][compose].
+ * @param RenderingT The value returned to this workflow's parent during [composition][render].
  * Typically represents a "view" of this workflow's input, current state, and children's renderings.
  * A workflow that represents a UI component may use a view model as its rendering type.
  *
@@ -65,7 +65,7 @@ abstract class StatefulWorkflow<
     > : Workflow<InputT, OutputT, RenderingT> {
 
   /**
-   * Called from [WorkflowContext.composeChild] when the state machine is first started, to get the
+   * Called from [WorkflowContext.renderChild] when the state machine is first started, to get the
    * initial state.
    *
    * @param snapshot
@@ -85,7 +85,7 @@ abstract class StatefulWorkflow<
   ): StateT
 
   /**
-   * Called from [WorkflowContext.composeChild] instead of [initialState] when the workflow is already
+   * Called from [WorkflowContext.renderChild] instead of [initialState] when the workflow is already
    * running. This allows the workflow to detect changes in input, and possibly change its state in
    * response. This method is called eagerly: `old` and `new` might be the same value, so it is up
    * to implementing code to perform any diffing if desired.
@@ -107,7 +107,7 @@ abstract class StatefulWorkflow<
    *    - Emits an output.
    *
    * **Never call this method directly.** To nest the rendering of a child workflow in your own,
-   * pass the child and any required input to [WorkflowContext.composeChild].
+   * pass the child and any required input to [WorkflowContext.renderChild].
    *
    * This method *should not* have any side effects, and in particular should not do anything that
    * blocks the current thread. It may be called multiple times for the same state. It must do all its
@@ -116,7 +116,7 @@ abstract class StatefulWorkflow<
    * _† This method is guaranteed to be called *at least* once for every state, but may be called
    * multiple times. Allowing this method to be invoked multiple times makes the internals simpler._
    */
-  abstract fun compose(
+  abstract fun render(
     input: InputT,
     state: StateT,
     context: WorkflowContext<StateT, OutputT>

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -17,7 +17,7 @@ package com.squareup.workflow
 
 /**
  * A composable, optionally-stateful object that can [handle events][WorkflowContext.onEvent],
- * [delegate to children][WorkflowContext.composeChild], [subscribe][onReceive] to arbitrary streams from
+ * [delegate to children][WorkflowContext.renderChild], [subscribe][onReceive] to arbitrary streams from
  * the outside world.
  *
  * The basic purpose of a `Workflow` is to take some [input][InputT] and return a
@@ -53,7 +53,7 @@ package com.squareup.workflow
  *
  * ## Interacting with Events and Other Workflows
  *
- * All workflows are passed a [WorkflowContext] in their compose methods. This context allows the
+ * All workflows are passed a [WorkflowContext] in their render methods. This context allows the
  * workflow to interact with the outside world by doing things like listening for events,
  * subscribing to streams of data, rendering child workflows, and performing cleanup when the
  * workflow is about to be torn down by its parent. See the documentation on [WorkflowContext] for
@@ -67,7 +67,7 @@ package com.squareup.workflow
  * to its parent.
  * May be [Nothing] if the workflow doesn't need to emit anything.
  *
- * @param RenderingT The value returned to this workflow's parent during [composition][composeChild].
+ * @param RenderingT The value returned to this workflow's parent during [composition][renderChild].
  * Typically represents a "view" of this workflow's input, current state, and children's renderings.
  * A workflow that represents a UI component may use a view model as its rendering type.
  *
@@ -78,7 +78,7 @@ interface Workflow<in InputT : Any, out OutputT : Any, out RenderingT : Any> {
 
   /**
    * Provides a [StatefulWorkflow] view of this workflow. Necessary because [StatefulWorkflow] is
-   * the common API required for [WorkflowContext.composeChild] to do its work.
+   * the common API required for [WorkflowContext.renderChild] to do its work.
    */
   fun asStatefulWorkflow(): StatefulWorkflow<InputT, *, OutputT, RenderingT>
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -25,7 +25,7 @@ import kotlin.reflect.KType
 
 /**
  * An immutable description of the things a [Workflow] would like to do as the result of calling its
- * `compose` method. A `Behavior` is built up by calling methods on a
+ * `render` method. A `Behavior` is built up by calling methods on a
  * [WorkflowContext][com.squareup.workflow.WorkflowContext] ([RealWorkflowContext] in particular).
  *
  * @see RealWorkflowContext

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealWorkflowContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealWorkflowContext.kt
@@ -31,11 +31,11 @@ import kotlin.reflect.KType
  * An implementation of [WorkflowContext] that builds a [Behavior] via [buildBehavior].
  */
 internal class RealWorkflowContext<StateT : Any, OutputT : Any>(
-  private val composer: Composer<StateT, OutputT>
+  private val renderer: Renderer<StateT, OutputT>
 ) : WorkflowContext<StateT, OutputT> {
 
-  interface Composer<StateT : Any, in OutputT : Any> {
-    fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any> compose(
+  interface Renderer<StateT : Any, in OutputT : Any> {
+    fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any> render(
       case: WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT>,
       child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
       id: WorkflowId<ChildInputT, ChildOutputT, ChildRenderingT>,
@@ -80,7 +80,7 @@ internal class RealWorkflowContext<StateT : Any, OutputT : Any>(
 
   // @formatter:off
   override fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
-      composeChild(
+      renderChild(
         child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
         input: ChildInputT,
         key: String,
@@ -92,7 +92,7 @@ internal class RealWorkflowContext<StateT : Any, OutputT : Any>(
     val case: WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT> =
       WorkflowOutputCase(child, id, input, handler)
     childCases += case
-    return composer.compose(case, child, id, input)
+    return renderer.render(case, child, id, input)
   }
 
   override fun onTeardown(handler: () -> Unit) {
@@ -115,6 +115,6 @@ internal class RealWorkflowContext<StateT : Any, OutputT : Any>(
   }
 
   private fun checkNotFrozen() = check(!frozen) {
-    "WorkflowContext cannot be used after compose method returns."
+    "WorkflowContext cannot be used after render method returns."
   }
 }

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
@@ -32,7 +32,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal class SubtreeManager<StateT : Any, OutputT : Any>(
   private val contextForChildren: CoroutineContext
-) : RealWorkflowContext.Composer<StateT, OutputT> {
+) : RealWorkflowContext.Renderer<StateT, OutputT> {
 
   /**
    * When this manager's host is restored from a snapshot, its children snapshots are extracted into
@@ -53,18 +53,18 @@ internal class SubtreeManager<StateT : Any, OutputT : Any>(
 
   // @formatter:off
   override fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
-      compose(
+      render(
         case: WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT>,
         child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
         id: WorkflowId<ChildInputT, ChildOutputT, ChildRenderingT>,
         input: ChildInputT
       ): ChildRenderingT {
   // @formatter:on
-    // Start tracking this case so we can be ready to compose it.
+    // Start tracking this case so we can be ready to render it.
     @Suppress("UNCHECKED_CAST")
     val childNode = hostLifetimeTracker.ensure(case) as
         WorkflowNode<ChildInputT, *, ChildOutputT, ChildRenderingT>
-    return childNode.compose(child.asStatefulWorkflow(), input)
+    return childNode.render(child.asStatefulWorkflow(), input)
   }
 
   /**

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -99,14 +99,14 @@ internal class WorkflowNode<InputT : Any, StateT : Any, OutputT : Any, Rendering
   /**
    * Walk the tree of workflows, rendering each one and using
    * [WorkflowContext][com.squareup.workflow.WorkflowContext] to give its children a chance to
-   * compose themselves and aggregate those child renderings.
+   * render themselves and aggregate those child renderings.
    */
   @Suppress("UNCHECKED_CAST")
-  fun compose(
+  fun render(
     workflow: StatefulWorkflow<InputT, *, OutputT, RenderingT>,
     input: InputT
   ): RenderingT =
-    composeWithStateType(workflow as StatefulWorkflow<InputT, StateT, OutputT, RenderingT>, input)
+    renderWithStateType(workflow as StatefulWorkflow<InputT, StateT, OutputT, RenderingT>, input)
 
   /**
    * Walk the tree of state machines again, this time gathering snapshots and aggregating them
@@ -125,7 +125,7 @@ internal class WorkflowNode<InputT : Any, StateT : Any, OutputT : Any, Rendering
    *
    * Walk the tree of state machines, asking each one to wait for its next event. If something happen
    * that results in an output, that output is returned. Null means something happened that requires
-   * a re-compose, e.g. my state changed or a child state changed.
+   * a re-render, e.g. my state changed or a child state changed.
    *
    * It is an error to call this method after calling [cancel].
    */
@@ -179,17 +179,17 @@ internal class WorkflowNode<InputT : Any, StateT : Any, OutputT : Any, Rendering
   }
 
   /**
-   * Contains the actual logic for [compose], after we've casted the passed-in [Workflow]'s
+   * Contains the actual logic for [render], after we've casted the passed-in [Workflow]'s
    * state type to our `StateT`.
    */
-  private fun composeWithStateType(
+  private fun renderWithStateType(
     workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
     input: InputT
   ): RenderingT {
     updateInputAndState(workflow, input)
 
     val context = RealWorkflowContext(subtreeManager)
-    val rendering = workflow.compose(input, state, context)
+    val rendering = workflow.render(input, state, context)
 
     behavior = context.buildBehavior()
         .apply {

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -55,7 +55,7 @@ class SubtreeManagerTest {
       return "initialState:$input"
     }
 
-    override fun compose(
+    override fun render(
       input: String,
       state: String,
       context: WorkflowContext<String, String>
@@ -68,37 +68,37 @@ class SubtreeManagerTest {
 
   private val context = Dispatchers.Unconfined
 
-  @Test fun `compose starts new child`() {
+  @Test fun `render starts new child`() {
     val manager = SubtreeManager<String, String>(context)
     val workflow = TestWorkflow()
     val id = workflow.id()
     val input = "input"
     val case = WorkflowOutputCase<String, String, String, String>(workflow, id, input) { fail() }
 
-    manager.compose(case, workflow, id, input)
+    manager.render(case, workflow, id, input)
     assertEquals(1, workflow.started)
   }
 
-  @Test fun `compose doesn't start existing child`() {
+  @Test fun `render doesn't start existing child`() {
     val manager = SubtreeManager<String, String>(context)
     val workflow = TestWorkflow()
     val id = workflow.id()
     val input = "input"
     val case = WorkflowOutputCase<String, String, String, String>(workflow, id, input) { fail() }
 
-    manager.compose(case, workflow, id, input)
-    manager.compose(case, workflow, id, input)
+    manager.render(case, workflow, id, input)
+    manager.render(case, workflow, id, input)
     assertEquals(1, workflow.started)
   }
 
-  @Test fun `compose returns child rendering`() {
+  @Test fun `render returns child rendering`() {
     val manager = SubtreeManager<String, String>(context)
     val workflow = TestWorkflow()
     val id = workflow.id()
     val input = "input"
     val case = WorkflowOutputCase<String, String, String, String>(workflow, id, input) { fail() }
 
-    val (composeInput, composeState) = manager.compose(case, workflow, id, input)
+    val (composeInput, composeState) = manager.render(case, workflow, id, input)
     assertEquals("input", composeInput)
     assertEquals("initialState:input", composeState)
   }
@@ -114,7 +114,7 @@ class SubtreeManagerTest {
 
     // Initialize the child so tickChildren has something to work with, and so that we can send
     // an event to trigger an output.
-    val (_, _, eventHandler) = manager.compose(case, workflow, id, "input")
+    val (_, _, eventHandler) = manager.render(case, workflow, id, "input")
 
     runBlocking {
       val tickOutput = async {

--- a/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/WorkflowContexts.kt
+++ b/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/WorkflowContexts.kt
@@ -34,7 +34,7 @@ import kotlin.reflect.KType
  * This allows us to use this method to, for example, wait for a response from a service call while
  * also moving between states in response to UI events. (Use [key] if you need to work simultaneously
  * with several `Single`s of the same type.)
- * The subscription will be disposed when `compose` returns without passing a single of the same
+ * The subscription will be disposed when `render` returns without passing a single of the same
  * type and with the same key to this method.
  *
  * @param key An optional string key that is used to distinguish between subscriptions of the same
@@ -57,7 +57,7 @@ inline fun <reified T : Any, StateT : Any, OutputT : Any> WorkflowContext<StateT
  * This allows us to use this method to, for example, wait for a response from a service call while
  * also moving between states in response to UI events. (Use [key] if you need to work simultaneously
  * with several `Single`s of the same type.)
- * The subscription will be disposed when `compose` returns without passing a single of the same
+ * The subscription will be disposed when `render` returns without passing a single of the same
  * type and with the same key to this method.
  *
  * @param type The [KType] that represents both the type of data source (e.g. `ReceiveChannel` or
@@ -78,7 +78,7 @@ fun <T : Any, StateT : Any, OutputT : Any> WorkflowContext<StateT, OutputT>.onSu
  * This allows us to use this method to, for example, monitor a stream of values emitted by a single
  * hot observable over a series of state transitions. (Use [key] if you need to work simultaneously
  * with several `Observable`s of the same type.)
- * The subscription will be disposed when `compose` returns without passing an observable of the
+ * The subscription will be disposed when `render` returns without passing an observable of the
  * same type and with the same key to this method.
  *
  * @param key An optional string key that is used to distinguish between subscriptions of the same
@@ -101,7 +101,7 @@ inline fun <reified T : Any, StateT : Any, OutputT : Any> WorkflowContext<StateT
  * This allows us to use this method to, for example, monitor a stream of values emitted by a single
  * hot observable over a series of state transitions. (Use [key] if you need to work simultaneously
  * with several `Observable`s of the same type.)
- * The subscription will be disposed when `compose` returns without passing an observable of the
+ * The subscription will be disposed when `render` returns without passing an observable of the
  * same type and with the same key to this method.
  *
  * @param type The [KType] that represents both the type of data source (e.g. `ReceiveChannel` or

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
@@ -42,7 +42,7 @@ class SubscriptionsTest {
    *
    * The initial value for the state is taken from the input. After that, the input is ignored.
    *
-   * [compose] returns a setter that will change the subscription state.
+   * [render] returns a setter that will change the subscription state.
    */
   private class SubscriberWorkflow(
     subject: Observable<String>
@@ -64,7 +64,7 @@ class SubscriptionsTest {
       scope: CoroutineScope
     ): Boolean = input
 
-    override fun compose(
+    override fun render(
       input: Boolean,
       state: Boolean,
       context: WorkflowContext<Boolean, ChannelUpdate<String>>

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
@@ -81,7 +81,7 @@ class WorkflowContextsTest {
         scope: CoroutineScope
       ): Boolean = true
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Boolean,
         context: WorkflowContext<Boolean, Nothing>

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
@@ -42,7 +42,7 @@ class ChannelSubscriptionsIntegrationTest {
    *
    * The initial value for the state is taken from the input. After that, the input is ignored.
    *
-   * [compose] returns a setter that will change the subscription state.
+   * [render] returns a setter that will change the subscription state.
    */
   private class SubscriberWorkflow(
     private val channel: Channel<String>
@@ -64,7 +64,7 @@ class ChannelSubscriptionsIntegrationTest {
       scope: CoroutineScope
     ): Boolean = input
 
-    override fun compose(
+    override fun render(
       input: Boolean,
       state: Boolean,
       context: WorkflowContext<Boolean, ChannelUpdate<String>>

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/CompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/CompositionIntegrationTest.kt
@@ -81,7 +81,7 @@ class CompositionIntegrationTest {
     }
   }
 
-  @Test fun `compose fails when duplicate child key`() {
+  @Test fun `render fails when duplicate child key`() {
     val root = TreeWorkflow(
         "root",
         TreeWorkflow("leaf"),
@@ -109,7 +109,7 @@ class CompositionIntegrationTest {
       context.onTeardown { teardowns += "child2" }
     }
     // A workflow that will render child1 and child2 until its rendering is invoked, at which point
-    // it will compose neither of them, which should trigger the teardown callbacks.
+    // it will render neither of them, which should trigger the teardown callbacks.
     val root = object : StatefulWorkflow<Unit, Boolean, Nothing, () -> Unit>() {
       override fun initialState(
         input: Unit,
@@ -117,14 +117,14 @@ class CompositionIntegrationTest {
         scope: CoroutineScope
       ): Boolean = true
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Boolean,
         context: WorkflowContext<Boolean, Nothing>
       ): () -> Unit {
         if (state) {
-          context.composeChild(child1, key = "child1")
-          context.composeChild(child2, key = "child2")
+          context.renderChild(child1, key = "child1")
+          context.renderChild(child2, key = "child2")
         }
         return context.onEvent<Unit> { enterState(false) }::invoke
       }
@@ -152,11 +152,11 @@ class CompositionIntegrationTest {
       context.onTeardown { teardowns += "grandchild" }
     }
     val child = Workflow.stateless<Nothing, Unit> { context ->
-      context.composeChild(grandchild)
+      context.renderChild(grandchild)
       context.onTeardown { teardowns += "child" }
     }
     // A workflow that will render child1 and child2 until its rendering is invoked, at which point
-    // it will compose neither of them, which should trigger the teardown callbacks.
+    // it will render neither of them, which should trigger the teardown callbacks.
     val root = object : StatefulWorkflow<Unit, Boolean, Nothing, () -> Unit>() {
       override fun initialState(
         input: Unit,
@@ -164,13 +164,13 @@ class CompositionIntegrationTest {
         scope: CoroutineScope
       ): Boolean = true
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Boolean,
         context: WorkflowContext<Boolean, Nothing>
       ): () -> Unit {
         if (state) {
-          context.composeChild(child)
+          context.renderChild(child)
         }
         return context.onEvent<Unit> { enterState(false) }::invoke
       }
@@ -206,7 +206,7 @@ class CompositionIntegrationTest {
         }
       }
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Unit,
         context: WorkflowContext<Unit, Nothing>
@@ -217,7 +217,7 @@ class CompositionIntegrationTest {
     }
 
     // A workflow that will render child until its rendering is invoked, at which point
-    // it will compose neither of them, which should trigger the scope to be cancelled.
+    // it will render neither of them, which should trigger the scope to be cancelled.
     val root = object : StatefulWorkflow<Unit, Boolean, Nothing, (Boolean) -> Unit>() {
       override fun initialState(
         input: Unit,
@@ -225,13 +225,13 @@ class CompositionIntegrationTest {
         scope: CoroutineScope
       ): Boolean = false
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Boolean,
         context: WorkflowContext<Boolean, Nothing>
       ): (Boolean) -> Unit {
         if (state) {
-          context.composeChild(child)
+          context.renderChild(child)
         }
         return context.onEvent<Boolean> { enterState(it) }::invoke
       }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
@@ -52,14 +52,14 @@ internal class TreeWorkflow(
     it.readUtf8WithLength()
   } ?: input
 
-  override fun compose(
+  override fun render(
     input: String,
     state: String,
     context: WorkflowContext<String, Nothing>
   ): Rendering {
     val childRenderings = children
         .mapIndexed { index, child ->
-          val childRendering = context.composeChild(child, "$input[$index]", child.name)
+          val childRendering = context.renderChild(child, "$input[$index]", child.name)
           Pair(child.name, childRendering)
         }
         .toMap()

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowTesterTest.kt
@@ -41,7 +41,7 @@ class WorkflowTesterTest {
     }
   }
 
-  @Test fun `propagates exception when workflow throws from compose`() {
+  @Test fun `propagates exception when workflow throws from render`() {
     val workflow = Workflow.stateless<Unit, Unit> {
       throw ExpectedException()
     }
@@ -90,7 +90,7 @@ class WorkflowTesterTest {
         throw ExpectedException()
       }
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Unit,
         context: WorkflowContext<Unit, Nothing>
@@ -120,7 +120,7 @@ class WorkflowTesterTest {
         // Noop
       }
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Unit,
         context: WorkflowContext<Unit, Nothing>
@@ -151,7 +151,7 @@ class WorkflowTesterTest {
         }
       }
 
-      override fun compose(
+      override fun render(
         input: Unit,
         state: Unit,
         context: WorkflowContext<Unit, Nothing>


### PR DESCRIPTION
Closes #265.