### PR TITLE
[RFC] Add SideEffect to Workflow

### DIFF
--- a/swift/Tooling/Templates/Workflow (Verbose).xctemplate/___FILEBASENAME___Workflow.swift
+++ b/swift/Tooling/Templates/Workflow (Verbose).xctemplate/___FILEBASENAME___Workflow.swift
@@ -24,11 +24,11 @@ extension ___VARIABLE_productName___Workflow {
 
     }
 
-    func makeInitialState() -> ___VARIABLE_productName___Workflow.State {
+    func makeInitialState(context: inout SideEffectContext<___VARIABLE_productName___Workflow>) -> ___VARIABLE_productName___Workflow.State {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: ___VARIABLE_productName___Workflow, state: inout State) {
+    func workflowDidChange(from previousWorkflow: ___VARIABLE_productName___Workflow, state: inout State, context: inout SideEffectContext<___VARIABLE_productName___Workflow>) {
 
     }
 }
@@ -42,7 +42,7 @@ extension ___VARIABLE_productName___Workflow {
 
         typealias WorkflowType = ___VARIABLE_productName___Workflow
 
-        func apply(toState state: inout ___VARIABLE_productName___Workflow.State) -> ___VARIABLE_productName___Workflow.Output? {
+        func apply(toState state: inout ___VARIABLE_productName___Workflow.State, context: inout SideEffectContext<___VARIABLE_productName___Workflow>) -> ___VARIABLE_productName___Workflow.Output? {
 
             switch self {
                 // Update state and produce an optional output based on which action was received.

--- a/swift/Workflow/Sources/SideEffectContext.swift
+++ b/swift/Workflow/Sources/SideEffectContext.swift
@@ -1,0 +1,23 @@
+/// `SideEffectContext` collects side effects from a Workflow starting,
+/// changing, or a `WorkflowAction` being applied.
+///
+/// This type only collects side effects, which are then performed by the
+/// workflow runtime via the workflow’s `perform(sideEffect:)`.
+public struct SideEffectContext<WorkflowType> where WorkflowType: Workflow {
+
+    /// The side effects requested into this context
+    var sideEffects: [WorkflowType.SideEffect]
+
+    /// Creates an empty side effect context
+    init() {
+        sideEffects = []
+    }
+
+    /// Requests the given side effect. During runtime, after an update pass
+    /// infrastructure will perform this side effect via the workflow’s
+    /// `perform(sideEffect:)`
+    public mutating func perform(sideEffect: WorkflowType.SideEffect) {
+        sideEffects.append(sideEffect)
+    }
+
+}

--- a/swift/Workflow/Sources/WorkflowContext.swift
+++ b/swift/Workflow/Sources/WorkflowContext.swift
@@ -119,7 +119,7 @@ extension WorkflowContext {
     public func makeSink<Event>(of eventType: Event.Type, onEvent: @escaping (Event, inout WorkflowType.State) -> WorkflowType.Output?) -> Sink<Event> {
         return makeSink(of: AnyWorkflowAction.self)
             .contraMap { event in
-                return AnyWorkflowAction<WorkflowType> { state in
+                return AnyWorkflowAction<WorkflowType> { state, context in
                     return onEvent(event, &state)
                 }
             }
@@ -135,7 +135,7 @@ extension WorkflowContext {
 
     public func awaitResult<W>(for worker: W, onOutput: @escaping (W.Output, inout WorkflowType.State) -> WorkflowType.Output?) where W: Worker {
         awaitResult(for: worker) { output in
-            return AnyWorkflowAction<WorkflowType> { state in
+            return AnyWorkflowAction<WorkflowType> { state, context in
                 return onOutput(output, &state)
             }
         }

--- a/swift/Workflow/Tests/AnyWorkflowTests.swift
+++ b/swift/Workflow/Tests/AnyWorkflowTests.swift
@@ -36,11 +36,11 @@ extension PassthroughWorkflow {
 
     struct State {}
 
-    func makeInitialState() -> State {
+    func makeInitialState(context: inout SideEffectContext<PassthroughWorkflow>) -> State {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: PassthroughWorkflow<Rendering>, state: inout State) {
+    func workflowDidChange(from previousWorkflow: PassthroughWorkflow<Rendering>, state: inout State, context: inout SideEffectContext<PassthroughWorkflow>) {
 
     }
 
@@ -62,11 +62,11 @@ extension SimpleWorkflow {
 
     struct State {}
 
-    func makeInitialState() -> State {
+    func makeInitialState(context: inout SideEffectContext<SimpleWorkflow>) -> State {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: SimpleWorkflow, state: inout State) {
+    func workflowDidChange(from previousWorkflow: SimpleWorkflow, state: inout State, context: inout SideEffectContext<SimpleWorkflow>) {
 
     }
 

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -116,11 +116,11 @@ fileprivate struct ParentWorkflow: Workflow {
     typealias Event = TestWorkflow.Output
     typealias Output = Never
 
-    func makeInitialState() -> State {
+    func makeInitialState(context: inout SideEffectContext<ParentWorkflow>) -> ParentWorkflow.State {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: ParentWorkflow, state: inout State) {
+    func workflowDidChange(from previousWorkflow: ParentWorkflow, state: inout State, context: inout SideEffectContext<ParentWorkflow>) {
 
     }
 
@@ -143,7 +143,7 @@ fileprivate struct TestWorkflow: Workflow {
         case changeState
         case sendOutput
 
-        func apply(toState state: inout TestWorkflow.State) -> TestWorkflow.Output? {
+        func apply(toState state: inout TestWorkflow.State, context: inout SideEffectContext<TestWorkflow>) -> TestWorkflow.Output? {
             switch self {
             case .changeState:
                 switch state {
@@ -161,11 +161,11 @@ fileprivate struct TestWorkflow: Workflow {
         case helloWorld
     }
 
-    func makeInitialState() -> State {
+    func makeInitialState(context: inout SideEffectContext<TestWorkflow>) -> State {
         return .foo
     }
 
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {
+    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State, context: inout SideEffectContext<TestWorkflow>) {
 
     }
 

--- a/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -91,18 +91,18 @@ fileprivate struct MockWorkflow: Workflow {
 
     typealias Output = Int
 
-    func makeInitialState() -> State {
+    func makeInitialState(context: inout SideEffectContext<MockWorkflow>) -> State {
         return 0
     }
 
-    func workflowDidChange(from previousWorkflow: MockWorkflow, state: inout State) {
+    func workflowDidChange(from previousWorkflow: MockWorkflow, state: inout State, context: inout SideEffectContext<MockWorkflow>) {
 
     }
 
     func compose(state: State, context: WorkflowContext<MockWorkflow>) -> TestScreen {
 
         context.subscribe(signal: subscription.map { output in
-            return AnyWorkflowAction { state in
+            return AnyWorkflowAction { state, context in
                 state = output
                 return output
             }


### PR DESCRIPTION
There are cases where side effect work does not have a lifetime or meaningful completion. The common example in my workflows has been logging. These are typically closely tied to `WorkflowAction` events (but also occasionally would like to happen when a workflow starts or updates).

Some ways of representing these in today’s `Workflow`s are:

1. Make an action hold some sort of `logger`
```swift
struct MyWorkflow: Workflow {

    var logger: Logger
    // …

    struct Action: WorkflowAction {

        enum Event {
            case tappedButton
            case tappedOtherButton
        }

        var event: Event
        var logger: Logger

        func apply(toState state: inout State) -> Output? {
            switch event {
            case .tappedButton:
                logger.log(.buttonTap)
                state.awesome = .yes
                return nil
            case .tappedOtherButton:
                logger.log(.otherButtonTap)
                state.awesome = .evenMoreSo
                return nil
            }
        }
    }
}
```

2. As a `Worker`
```swift
struct MyWorkflow: Workflow {

    var logger: Logger
    // …
 
    struct State {
        // …
        var pendingLogs: [Logger.Event]
    }

    struct Action: WorkflowAction {
        case tappedButton
        case tappedOtherButton

        func apply(toState state: inout State) -> Output? {
            switch self {
            case .tappedButton:
                state.pendingLogs.append(.tappedButton)
                state.awesome = .yes
                return nil
            case .tappedOtherButton:
                state.pendingLogs.append(.tappedOtherButton)
                state.awesome = .evenMoreSo
                return nil
            }
        }
    }

    struct LogWorker: Worker {

        typealias Output = Void

        var logger: Logger
        var event: Logger.Event

        func run() -> SignalProducer<Void, NoError> {
            return SignalProducer({
                logger.log(event: event)
            })
        }

    }

    struct LogCompleteAction: WorkflowAction {

        var event: Logger.Event

        func apply(toState state: inout State) -> Output? {
            guard let index = state.pendingLogs.firstIndex(of: event) else {
                return nil
            }
            state.pendingLogs.remove(at: index)
            return nil
        }

    }

    func compose(state: State, context: WorkflowContext<MyWorkflow>) -> Rendering {
        for event in state.pendingLogs {
            context.awaitResult(
               for: LogWorker(
                    logger: logger,
                    event: event),
               outputMap: { _ in
                    return LogCompleteAction(event: event)
                })
        }

        // …

        return MyScreen()
    }
}
```

3. Hand a `logger` to the screen and let UI do the logging.

---

Of these, 1 is my current preferred current approach. But, it makes otherwise-pure `Actions` have hidden side effects. And that’s not something I’d like to encourage. (It’s also a little cumbersome because code that used to read `sink.send(.signInTapped)` now reads `sink.send(Action(logger: logger, event: .signInTapped`). 2 to me is the most “correct” place for effects to live, but is _quite_ cumbersome and verbose. 3 is “easy”, but encourages passing pointers into the outside world into Screens and prevents us from verifying these effects in my workflow tests.

This PR represents a proposal to formalize `SideEffect` as part of the Workflow API. Translating example 1 would produce:

```swift

struct MyWorkflow: Workflow {

    var logger: Logger
    // …

    enum SideEffect {
        case log(Logger.Event)
    }

    func perform(sideEffect: SideEffect) {
        switch sideEffect {
        case .log(let event):
            logger.log(event)
        }
    }

    struct Action: WorkflowAction {

        case tappedButton
        case tappedOtherButton

        func apply(toState state: inout State, context: inout SideEffectContext<MyWorkflow>) -> Output? {
            switch event {
            case .tappedButton:
                context.perform(sideEffect: .log(.buttonTap))
                state.awesome = .yes
                return nil
            case .tappedOtherButton:
                context.perform(sideEffect: .log(.otherButtonTap))
                state.awesome = .evenMoreSo
                return nil
            }
        }
    }

}


```