### PR TITLE
[#269] Invalidate WorkflowContext after `render` is called

### DIFF
--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -41,6 +41,8 @@ extension WorkflowNode {
 
             /// Pass the context into the closure to allow a render to take place
             let rendering = actions(wrapped)
+            
+            wrapped.invalidate()
 
             /// After the render is complete, assign children using *only the children that were used during the render
             /// pass.* This means that any pre-existing children that were *not* used during the render pass are removed

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -102,6 +102,23 @@ final class SubtreeManagerTests: XCTestCase {
 
         XCTAssertEqual(changeCount, 2)
     }
+    
+    func test_invalidatesContextAfterRender() {
+        let manager = WorkflowNode<ParentWorkflow>.SubtreeManager()
+        
+        var escapingContext: WorkflowContext<ParentWorkflow>! = nil
+        
+        _ = manager.render { context -> TestViewModel in
+            XCTAssertTrue(context.isValid)
+            escapingContext = context
+            return context.render(
+                workflow: TestWorkflow(),
+                key: "",
+                outputMap: { _ in AnyWorkflowAction.identity })
+        }
+        
+        XCTAssertFalse(escapingContext.isValid)
+    }
 
 }
 


### PR DESCRIPTION
This immediately explodes (via `fatalError`) if a `WorkflowContext` is used after `render` returns.

This fixes #269 