### PR TITLE
Fix for WorkflowHost.Factory not using baseContext.

### DIFF
--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
@@ -41,9 +41,6 @@ class MainWorkflowTest {
 
     MainWorkflow(authWorkflow, runGameWorkflow()).testFromStart { tester ->
       tester.withNextRendering { screen ->
-        assertThat(screen.panels).containsOnly(DEFAULT_AUTH)
-      }
-      tester.withNextRendering { screen ->
         assertThat(screen.panels).isEmpty()
         assertThat(screen.body).isEqualTo(DEFAULT_RUN_GAME)
       }

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/SubscriptionsTest.kt
@@ -169,8 +169,6 @@ class SubscriptionsTest {
 
   @Test fun `observable reports emissions`() {
     workflow.testFromStart(true) { host ->
-      // Get the next rendering to unblock the pipeline so the subscription can actually occur.
-      host.awaitNextRendering()
       assertFalse(host.hasOutput)
 
       subject.onNext("hello")
@@ -185,8 +183,6 @@ class SubscriptionsTest {
 
   @Test fun `observable reports close`() {
     workflow.testFromStart(true) { host ->
-      // Get the next rendering to unblock the pipeline so the subscription can actually occur.
-      host.awaitNextRendering()
       assertFalse(host.hasOutput)
 
       subject.onComplete()
@@ -202,8 +198,6 @@ class SubscriptionsTest {
 
   @Test fun `observable reports close after emission`() {
     workflow.testFromStart(true) { host ->
-      // Get the next rendering to unblock the pipeline so the subscription can actually occur.
-      host.awaitNextRendering()
       assertFalse(host.hasOutput)
 
       subject.onNext("foo")

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/WorkflowContextsTest.kt
@@ -52,14 +52,12 @@ class WorkflowContextsTest {
     assertFalse(disposed.isCompleted)
 
     workflow.testFromStart { host ->
-      host.awaitNextRendering()
       runBlocking { subscribed.await() }
       assertFalse(disposed.isCompleted)
       assertFalse(host.hasOutput)
 
       singleSubject.onSuccess("done!")
 
-      host.awaitNextRendering()
       assertTrue(host.hasOutput)
       assertEquals("done!", host.awaitNextOutput())
       assertFalse(disposed.isCompleted)
@@ -99,14 +97,12 @@ class WorkflowContextsTest {
     assertFalse(disposed.isCompleted)
 
     workflow.testFromStart { host ->
-      host.awaitNextRendering()
       runBlocking { subscribed.await() }
       assertFalse(disposed.isCompleted)
       assertFalse(host.hasOutput)
 
       doClose()
 
-      host.awaitNextRendering()
       runBlocking { disposed.await() }
     }
   }

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTesting.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTesting.kt
@@ -21,7 +21,6 @@ import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowHost
-import com.squareup.workflow.WorkflowHost.Factory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -101,7 +100,7 @@ fun <StateT : Any, OutputT : Any, RenderingT : Any>
 private fun <T, I : Any, O : Any, R : Any> test(
   testBlock: (WorkflowTester<I, O, R>) -> T,
   baseContext: CoroutineContext,
-  starter: (Factory) -> WorkflowHost<I, O, R>
+  starter: (WorkflowHost.Factory) -> WorkflowHost<I, O, R>
 ): T {
   val context = Dispatchers.Unconfined + baseContext + Job(parent = baseContext[Job])
   val host = WorkflowHost.Factory(context)

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/ChannelSubscriptionsIntegrationTest.kt
@@ -105,9 +105,7 @@ class ChannelSubscriptionsIntegrationTest {
         assertEquals(1, workflow.subscriptions)
         assertEquals(0, workflow.cancellations)
         setSubscribed(false)
-      }
 
-      host.withNextRendering {
         assertEquals(1, workflow.subscriptions)
         assertEquals(1, workflow.cancellations)
       }
@@ -120,9 +118,7 @@ class ChannelSubscriptionsIntegrationTest {
         assertEquals(1, workflow.subscriptions)
         assertEquals(0, workflow.cancellations)
         setSubscribed(false)
-      }
 
-      host.withNextRendering {
         assertEquals(1, workflow.subscriptions)
         assertEquals(1, workflow.cancellations)
       }


### PR DESCRIPTION
Commit cf3ae7bfa5f1d3778d057d5d200ee4126ba4cf58 accidentally stopped including
`baseContext` in the context for the workflow loop coroutine. This caused everything
not passing a dispatcher into `run` directly to default to the `Default` dispatcher,
which made a lot of things suddenly happen a lot lazier, and forced us to add a bunch
of additional calls in unit tests.

This PR adds `baseContext` back in, and also adds a default `CoroutineName` element
to aid in debugging.