### PR TITLE
Fix SubtreeManager not saving new case handlers.

### DIFF
--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
@@ -98,7 +98,6 @@ internal class SubtreeManager<StateT : Any, OutputT : Any>(
   fun createChildrenSnapshot(): Snapshot {
     return Snapshot.write { sink ->
       val childSnapshots = hostLifetimeTracker.lifetimes
-          .entries
           .map { (case, host) -> host.id to host.snapshot(case.workflow.asStatefulWorkflow()) }
       sink.writeInt(childSnapshots.size)
       for ((id, snapshot) in childSnapshots) {

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/LifetimeTrackerTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/LifetimeTrackerTest.kt
@@ -20,10 +20,14 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class LifetimeTrackerTest {
+
+  private data class TestFactory(
+    val key: String,
+    val value: String = ""
+  )
 
   private inner class TestDisposable(val name: String) {
     var disposed = false
@@ -41,11 +45,11 @@ class LifetimeTrackerTest {
   }
 
   private var disposableCount = 0
-  private val tracker = LifetimeTracker(
-      getKey = { it },
-      start = ::TestDisposable,
+  private val tracker = LifetimeTracker<TestFactory, String, TestDisposable>(
+      getKey = { it.key },
+      start = { TestDisposable(it.key) },
       dispose = { factory, disposable ->
-        assertEquals(factory, disposable.name)
+        assertEquals(factory.key, disposable.name)
         disposable.dispose()
       }
   )
@@ -60,41 +64,41 @@ class LifetimeTrackerTest {
   }
 
   @Test fun `ensure starts new factory`() {
-    tracker.ensure("foo")
+    tracker.ensure(TestFactory("foo"))
     assertEquals(1, disposableCount)
-    assertEquals("foo", tracker.lifetimes.getValue("foo").name)
+    assertEquals("foo", tracker.lifetimes.getByKey("foo").name)
 
-    tracker.ensure("bar")
+    tracker.ensure(TestFactory("bar"))
     assertEquals(2, disposableCount)
-    assertEquals("foo", tracker.lifetimes.getValue("foo").name)
-    assertEquals("bar", tracker.lifetimes.getValue("bar").name)
+    assertEquals("foo", tracker.lifetimes.getByKey("foo").name)
+    assertEquals("bar", tracker.lifetimes.getByKey("bar").name)
   }
 
   @Test fun `track starts new factories`() {
-    tracker.track(listOf("foo"))
+    tracker.track(listOf(TestFactory("foo")))
     assertEquals(1, disposableCount)
-    assertEquals("foo", tracker.lifetimes.getValue("foo").name)
+    assertEquals("foo", tracker.lifetimes.getByKey("foo").name)
 
-    tracker.track(listOf("foo", "bar", "baz"))
+    tracker.track(listOf(TestFactory("foo"), TestFactory("bar"), TestFactory("baz")))
     assertEquals(3, disposableCount)
-    assertEquals("foo", tracker.lifetimes.getValue("foo").name)
-    assertEquals("bar", tracker.lifetimes.getValue("bar").name)
-    assertEquals("baz", tracker.lifetimes.getValue("baz").name)
+    assertEquals("foo", tracker.lifetimes.getByKey("foo").name)
+    assertEquals("bar", tracker.lifetimes.getByKey("bar").name)
+    assertEquals("baz", tracker.lifetimes.getByKey("baz").name)
   }
 
   @Test fun `track disposes missing factories`() {
-    tracker.track(listOf("foo"))
+    tracker.track(listOf(TestFactory("foo")))
     assertEquals(1, disposableCount)
-    assertTrue("foo" in tracker.lifetimes)
+    assertEquals(1, tracker.lifetimes.count { (f, _) -> f.key == "foo" })
 
-    tracker.track(listOf("bar"))
+    tracker.track(listOf(TestFactory("bar")))
     assertEquals(1, disposableCount)
-    assertFalse("foo" in tracker.lifetimes)
+    assertEquals(0, tracker.lifetimes.count { (f, _) -> f.key == "foo" })
   }
 
   @Test fun `track throws on two duplicate keys`() {
     val error = assertFailsWith<IllegalArgumentException> {
-      tracker.track(listOf("dup", "dup"))
+      tracker.track(listOf(TestFactory("dup"), TestFactory("dup")))
     }
     assertTrue("Expected all keys to be unique. Duplicates:" in error.message!!)
     assertTrue("2×dup" in error.message!!)
@@ -102,16 +106,39 @@ class LifetimeTrackerTest {
 
   @Test fun `track throws on three duplicate keys`() {
     val error = assertFailsWith<IllegalArgumentException> {
-      tracker.track(listOf("dup", "dup", "dup"))
+      tracker.track(listOf(TestFactory("dup"), TestFactory("dup"), TestFactory("dup")))
     }
     assertTrue("3×dup" in error.message!!)
   }
 
   @Test fun `track throws on multiple sets of duplicate keys`() {
     val error = assertFailsWith<IllegalArgumentException> {
-      tracker.track(listOf("dup1", "dup2", "dup1", "dup2"))
+      tracker.track(
+          listOf(TestFactory("dup1"), TestFactory("dup2"), TestFactory("dup1"), TestFactory("dup2"))
+      )
     }
     assertTrue("2×dup1" in error.message!!)
     assertTrue("2×dup2" in error.message!!)
   }
+
+  // See https://github.com/square/workflow/issues/261.
+  @Test fun `ensure updates factory`() {
+    tracker.ensure(TestFactory("foo", "initial value"))
+    assertEquals("initial value", tracker.lifetimes.single().first.value)
+
+    tracker.ensure(TestFactory("foo", "updated value"))
+    assertEquals("updated value", tracker.lifetimes.single().first.value)
+  }
+
+  // See https://github.com/square/workflow/issues/261.
+  @Test fun `track updates factory`() {
+    tracker.track(listOf(TestFactory("foo", "initial value")))
+    assertEquals("initial value", tracker.lifetimes.single().first.value)
+
+    tracker.track(listOf(TestFactory("foo", "updated value")))
+    assertEquals("updated value", tracker.lifetimes.single().first.value)
+  }
+
+  private fun List<Pair<TestFactory, TestDisposable>>.getByKey(key: String) =
+    single { (factory, _) -> factory.key == key }.second
 }


### PR DESCRIPTION
`SubtreeManager` is responsible for managing a `WorkflowNode`'s child `Workflow`s.
It uses `LifetimeTracker` to track children across render passes, start new ones,
and cancel old ones. It stores the `WorkflowOutputCase` as the `LifetimeTracker`'s
`Factory` type – "factories" have keys for deduping, and are used to create new
"disposables" when new ones are tracked. The `WorkflowOutputCase` also stores the
`handler` lambda that defines how to map a child workflow's output to a parent
`WorkflowAction`. This handler is re-created on every render pass (because it
closes over the workflow's state), and so the `LifetimeTracker` should always be
storing the most recent _instance_ of the `WorkflowOutputCase`. However, previously
it would only store the first factory for a given key. This meant that if a child
was rendered over multiple render passes, and the state changed between those passes,
when the child emitted an output after the state change it the handler lambda would
be stale and thus have a reference to the wrong state.

This change fixes the issue by making `LifetimeTracker` always replace the `FactoryT`
for a given `KeyT` on every call to `ensure` or `track`.

Fixes #261.