### PR TITLE
Made LifecycleWorker methods non-suspending.

### DIFF
--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
@@ -35,7 +35,7 @@ class LifecycleWorkerTest {
   @Test fun `onStart called immediately`() {
     var onStartCalled = false
     val worker = object : LifecycleWorker() {
-      override suspend fun onStarted() {
+      override fun onStarted() {
         onStartCalled = true
       }
     }
@@ -55,7 +55,7 @@ class LifecycleWorkerTest {
   @Test fun `onCancelled called on cancel`() {
     var onCancelledCalled = false
     val worker = object : LifecycleWorker() {
-      override suspend fun onCancelled() {
+      override fun onCancelled() {
         onCancelledCalled = true
       }
     }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -55,7 +55,7 @@ class WorkerCompositionIntegrationTest {
   @Test fun `worker cancelled when dropped`() {
     var cancelled = false
     val worker = object : LifecycleWorker() {
-      override suspend fun onCancelled() {
+      override fun onCancelled() {
         cancelled = true
       }
     }
@@ -74,11 +74,11 @@ class WorkerCompositionIntegrationTest {
     var starts = 0
     var stops = 0
     val worker = object : LifecycleWorker() {
-      override suspend fun onStarted() {
+      override fun onStarted() {
         starts++
       }
 
-      override suspend fun onCancelled() {
+      override fun onCancelled() {
         stops++
       }
     }
@@ -104,11 +104,11 @@ class WorkerCompositionIntegrationTest {
     var starts = 0
     var stops = 0
     val worker = object : LifecycleWorker() {
-      override suspend fun onStarted() {
+      override fun onStarted() {
         starts++
       }
 
-      override suspend fun onCancelled() {
+      override fun onCancelled() {
         stops++
       }
     }


### PR DESCRIPTION
Don't have a use case for them being suspending, and making them suspending
might encourage more work to be done there than is appropriate.

Also improved docs.