### PR TITLE
Remove non-nullable restriction from InputT, StateT, and RenderingT.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -38,7 +38,7 @@ import com.squareup.workflow.WorkflowAction.Companion.noop
  *
  * See [renderChild].
  */
-interface RenderContext<StateT : Any, in OutputT : Any> {
+interface RenderContext<StateT, in OutputT : Any> {
 
   /**
    * Given a function that takes an [event][EventT] and can mutate the state or emit an output,

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -59,7 +59,7 @@ import kotlinx.coroutines.CoroutineScope
  */
 abstract class StatefulWorkflow<
     in InputT,
-    StateT : Any,
+    StateT,
     out OutputT : Any,
     out RenderingT
     > : Workflow<InputT, OutputT, RenderingT> {

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -58,7 +58,7 @@ import kotlinx.coroutines.CoroutineScope
  * @see StatelessWorkflow
  */
 abstract class StatefulWorkflow<
-    in InputT : Any,
+    in InputT,
     StateT : Any,
     out OutputT : Any,
     out RenderingT

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -61,7 +61,7 @@ abstract class StatefulWorkflow<
     in InputT : Any,
     StateT : Any,
     out OutputT : Any,
-    out RenderingT : Any
+    out RenderingT
     > : Workflow<InputT, OutputT, RenderingT> {
 
   /**

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -34,7 +34,7 @@ import com.squareup.workflow.WorkflowAction.Companion.emitOutput
  *
  * @see StatefulWorkflow
  */
-abstract class StatelessWorkflow<InputT : Any, OutputT : Any, RenderingT> :
+abstract class StatelessWorkflow<InputT, OutputT : Any, RenderingT> :
     Workflow<InputT, OutputT, RenderingT> {
 
   private val statefulWorkflow = object : StatefulWorkflow<InputT, Unit, OutputT, RenderingT>() {

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -34,7 +34,7 @@ import com.squareup.workflow.WorkflowAction.Companion.emitOutput
  *
  * @see StatefulWorkflow
  */
-abstract class StatelessWorkflow<InputT : Any, OutputT : Any, RenderingT : Any> :
+abstract class StatelessWorkflow<InputT : Any, OutputT : Any, RenderingT> :
     Workflow<InputT, OutputT, RenderingT> {
 
   private val statefulWorkflow = object : StatefulWorkflow<InputT, Unit, OutputT, RenderingT>() {

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -74,7 +74,7 @@ package com.squareup.workflow
  * @see StatefulWorkflow
  * @see StatelessWorkflow
  */
-interface Workflow<in InputT : Any, out OutputT : Any, out RenderingT> {
+interface Workflow<in InputT, out OutputT : Any, out RenderingT> {
 
   /**
    * Provides a [StatefulWorkflow] view of this workflow. Necessary because [StatefulWorkflow] is

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -74,7 +74,7 @@ package com.squareup.workflow
  * @see StatefulWorkflow
  * @see StatelessWorkflow
  */
-interface Workflow<in InputT : Any, out OutputT : Any, out RenderingT : Any> {
+interface Workflow<in InputT : Any, out OutputT : Any, out RenderingT> {
 
   /**
    * Provides a [StatefulWorkflow] view of this workflow. Necessary because [StatefulWorkflow] is

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -19,7 +19,7 @@ package com.squareup.workflow
  * A function that can change the current state of a [Workflow] by returning a new one, and
  * also optionally emit an output.
  */
-interface WorkflowAction<StateT : Any, out OutputT : Any> : (StateT) -> Pair<StateT, OutputT?> {
+interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, OutputT?> {
 
   override operator fun invoke(state: StateT): Pair<StateT, OutputT?>
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
@@ -44,12 +44,12 @@ private val DEFAULT_WORKFLOW_COROUTINE_NAME = CoroutineName("WorkflowHost")
  *
  * Create these by injecting a [Factory] and calling [run][Factory.run].
  */
-interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT : Any> {
+interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT> {
 
   /**
    * Output from a [WorkflowHost]. Emitted from [WorkflowHost.updates] after every render pass.
    */
-  data class Update<out OutputT : Any, out RenderingT : Any>(
+  data class Update<out OutputT : Any, out RenderingT>(
     val rendering: RenderingT,
     val snapshot: Snapshot,
     val output: OutputT? = null
@@ -82,7 +82,7 @@ interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT : Any>
      * @param context The [CoroutineContext] used to run the workflow tree. Added to the [Factory]'s
      * context.
      */
-    fun <InputT : Any, OutputT : Any, RenderingT : Any> run(
+    fun <InputT : Any, OutputT : Any, RenderingT> run(
       workflow: Workflow<InputT, OutputT, RenderingT>,
       inputs: ReceiveChannel<InputT>,
       snapshot: Snapshot? = null,
@@ -103,7 +103,7 @@ interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT : Any>
           }
       }
 
-    fun <OutputT : Any, RenderingT : Any> run(
+    fun <OutputT : Any, RenderingT> run(
       workflow: Workflow<Unit, OutputT, RenderingT>,
       snapshot: Snapshot? = null,
       context: CoroutineContext = EmptyCoroutineContext
@@ -118,7 +118,7 @@ interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT : Any>
      * the testing extension method defined there on your workflow itself.
      */
     @TestOnly
-    fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any> runTestFromState(
+    fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT> runTestFromState(
       workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
       inputs: ReceiveChannel<InputT>,
       initialState: StateT
@@ -153,7 +153,7 @@ interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT : Any>
  * favorite Rx library to map a stream of [InputT]s into [Update]s.
  */
 @UseExperimental(InternalCoroutinesApi::class)
-suspend fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any> runWorkflowTree(
+suspend fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT> runWorkflowTree(
   workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
   inputs: ReceiveChannel<InputT>,
   initialSnapshot: Snapshot?,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
@@ -153,7 +153,7 @@ interface WorkflowHost<in InputT, out OutputT : Any, out RenderingT> {
  * favorite Rx library to map a stream of [InputT]s into [Update]s.
  */
 @UseExperimental(InternalCoroutinesApi::class)
-suspend fun <InputT, StateT : Any, OutputT : Any, RenderingT> runWorkflowTree(
+suspend fun <InputT, StateT, OutputT : Any, RenderingT> runWorkflowTree(
   workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
   inputs: ReceiveChannel<InputT>,
   initialSnapshot: Snapshot?,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
@@ -44,7 +44,7 @@ private val DEFAULT_WORKFLOW_COROUTINE_NAME = CoroutineName("WorkflowHost")
  *
  * Create these by injecting a [Factory] and calling [run][Factory.run].
  */
-interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT> {
+interface WorkflowHost<in InputT, out OutputT : Any, out RenderingT> {
 
   /**
    * Output from a [WorkflowHost]. Emitted from [WorkflowHost.updates] after every render pass.
@@ -82,7 +82,7 @@ interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT> {
      * @param context The [CoroutineContext] used to run the workflow tree. Added to the [Factory]'s
      * context.
      */
-    fun <InputT : Any, OutputT : Any, RenderingT> run(
+    fun <InputT, OutputT : Any, RenderingT> run(
       workflow: Workflow<InputT, OutputT, RenderingT>,
       inputs: ReceiveChannel<InputT>,
       snapshot: Snapshot? = null,
@@ -118,7 +118,7 @@ interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT> {
      * the testing extension method defined there on your workflow itself.
      */
     @TestOnly
-    fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT> runTestFromState(
+    fun <InputT, StateT : Any, OutputT : Any, RenderingT> runTestFromState(
       workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
       inputs: ReceiveChannel<InputT>,
       initialState: StateT
@@ -153,7 +153,7 @@ interface WorkflowHost<in InputT : Any, out OutputT : Any, out RenderingT> {
  * favorite Rx library to map a stream of [InputT]s into [Update]s.
  */
 @UseExperimental(InternalCoroutinesApi::class)
-suspend fun <InputT : Any, StateT : Any, OutputT : Any, RenderingT> runWorkflowTree(
+suspend fun <InputT, StateT : Any, OutputT : Any, RenderingT> runWorkflowTree(
   workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
   inputs: ReceiveChannel<InputT>,
   initialSnapshot: Snapshot?,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.Deferred
  *
  * @see RealRenderContext
  */
-internal data class Behavior<StateT : Any, out OutputT : Any>(
+internal data class Behavior<StateT, out OutputT : Any>(
   val childCases: List<WorkflowOutputCase<*, *, StateT, OutputT>>,
   val workerCases: List<WorkerCase<*, StateT, OutputT>>,
   val nextActionFromEvent: Deferred<WorkflowAction<StateT, OutputT>>
@@ -38,7 +38,7 @@ internal data class Behavior<StateT : Any, out OutputT : Any>(
   data class WorkflowOutputCase<
       ChildInputT : Any,
       ChildOutputT : Any,
-      ParentStateT : Any,
+      ParentStateT,
       out ParentOutputT : Any
       >(
         val workflow: Workflow<*, ChildOutputT, *>,
@@ -52,7 +52,7 @@ internal data class Behavior<StateT : Any, out OutputT : Any>(
       }
       // @formatter:on
 
-  data class WorkerCase<T, StateT : Any, out OutputT : Any>(
+  data class WorkerCase<T, StateT, out OutputT : Any>(
     val worker: Worker<T>,
     val key: String,
     val handler: (OutputOrFinished<T>) -> WorkflowAction<StateT, OutputT>

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -28,11 +28,11 @@ import kotlinx.coroutines.CompletableDeferred
 /**
  * An implementation of [RenderContext] that builds a [Behavior] via [buildBehavior].
  */
-internal class RealRenderContext<StateT : Any, OutputT : Any>(
+internal class RealRenderContext<StateT, OutputT : Any>(
   private val renderer: Renderer<StateT, OutputT>
 ) : RenderContext<StateT, OutputT> {
 
-  interface Renderer<StateT : Any, in OutputT : Any> {
+  interface Renderer<StateT, in OutputT : Any> {
     fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any> render(
       case: WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT>,
       child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
@@ -30,7 +30,7 @@ import kotlin.coroutines.CoroutineContext
  * Responsible for tracking child workflows, starting them and tearing them down when necessary. Also
  * manages restoring children from snapshots.
  */
-internal class SubtreeManager<StateT : Any, OutputT : Any>(
+internal class SubtreeManager<StateT, OutputT : Any>(
   private val contextForChildren: CoroutineContext
 ) : RealRenderContext.Renderer<StateT, OutputT> {
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
@@ -30,7 +30,7 @@ internal typealias AnyId = WorkflowId<*, *, *>
  * Value type that can be used to distinguish between different workflows of different types or
  * the same type (in that case using a [name]).
  */
-internal data class WorkflowId<in InputT : Any, out OutputT : Any, out RenderingT : Any>
+internal data class WorkflowId<in InputT : Any, out OutputT : Any, out RenderingT>
 @PublishedApi
 internal constructor(
   internal val type: KClass<out Workflow<InputT, OutputT, RenderingT>>,
@@ -38,7 +38,7 @@ internal constructor(
 )
 
 @Suppress("unused")
-internal fun <W : Workflow<P, O, R>, P : Any, O : Any, R : Any>
+internal fun <W : Workflow<P, O, R>, P : Any, O : Any, R>
     W.id(key: String = ""): WorkflowId<P, O, R> =
   WorkflowId(this::class, key)
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
@@ -30,7 +30,7 @@ internal typealias AnyId = WorkflowId<*, *, *>
  * Value type that can be used to distinguish between different workflows of different types or
  * the same type (in that case using a [name]).
  */
-internal data class WorkflowId<in InputT : Any, out OutputT : Any, out RenderingT>
+internal data class WorkflowId<in InputT, out OutputT : Any, out RenderingT>
 @PublishedApi
 internal constructor(
   internal val type: KClass<out Workflow<InputT, OutputT, RenderingT>>,
@@ -38,8 +38,8 @@ internal constructor(
 )
 
 @Suppress("unused")
-internal fun <W : Workflow<P, O, R>, P : Any, O : Any, R>
-    W.id(key: String = ""): WorkflowId<P, O, R> =
+internal fun <W : Workflow<I, O, R>, I, O : Any, R>
+    W.id(key: String = ""): WorkflowId<I, O, R> =
   WorkflowId(this::class, key)
 
 internal fun WorkflowId<*, *, *>.toByteString(): ByteString = Buffer()

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -39,7 +39,7 @@ import kotlin.coroutines.CoroutineContext
  * @param initialState Allows unit tests to start the node from a given state, instead of calling
  * [StatefulWorkflow.initialState].
  */
-internal class WorkflowNode<InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any>(
+internal class WorkflowNode<InputT : Any, StateT : Any, OutputT : Any, RenderingT>(
   val id: WorkflowId<InputT, OutputT, RenderingT>,
   workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
   initialInput: InputT,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -39,7 +39,7 @@ import kotlin.coroutines.CoroutineContext
  * @param initialState Allows unit tests to start the node from a given state, instead of calling
  * [StatefulWorkflow.initialState].
  */
-internal class WorkflowNode<InputT, StateT : Any, OutputT : Any, RenderingT>(
+internal class WorkflowNode<InputT, StateT, OutputT : Any, RenderingT>(
   val id: WorkflowId<InputT, OutputT, RenderingT>,
   workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
   initialInput: InputT,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -39,7 +39,7 @@ import kotlin.coroutines.CoroutineContext
  * @param initialState Allows unit tests to start the node from a given state, instead of calling
  * [StatefulWorkflow.initialState].
  */
-internal class WorkflowNode<InputT : Any, StateT : Any, OutputT : Any, RenderingT>(
+internal class WorkflowNode<InputT, StateT : Any, OutputT : Any, RenderingT>(
   val id: WorkflowId<InputT, OutputT, RenderingT>,
   workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
   initialInput: InputT,

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
@@ -51,7 +51,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  *  - [sendInput]
  *    - Send a new [InputT] to the root workflow.
  */
-class WorkflowTester<InputT : Any, OutputT : Any, RenderingT> @TestOnly internal constructor(
+class WorkflowTester<InputT, OutputT : Any, RenderingT> @TestOnly internal constructor(
   private val inputs: SendChannel<InputT>,
   private val host: WorkflowHost<InputT, OutputT, RenderingT>,
   context: CoroutineContext
@@ -191,7 +191,7 @@ class WorkflowTester<InputT : Any, OutputT : Any, RenderingT> @TestOnly internal
  */
 // @formatter:off
 @TestOnly
-fun <T, InputT : Any, OutputT : Any, RenderingT>
+fun <T, InputT, OutputT : Any, RenderingT>
     Workflow<InputT, OutputT, RenderingT>.testFromStart(
       input: InputT,
       snapshot: Snapshot? = null,
@@ -224,7 +224,7 @@ fun <T, OutputT : Any, RenderingT> Workflow<Unit, OutputT, RenderingT>.testFromS
  */
 // @formatter:off
 @TestOnly
-fun <T, InputT : Any, StateT : Any, OutputT : Any, RenderingT>
+fun <T, InputT, StateT : Any, OutputT : Any, RenderingT>
     StatefulWorkflow<InputT, StateT, OutputT, RenderingT>.testFromState(
       input: InputT,
       initialState: StateT,
@@ -254,7 +254,7 @@ fun <StateT : Any, OutputT : Any, RenderingT>
 // @formatter:on
 
 @UseExperimental(InternalCoroutinesApi::class)
-private fun <T, I : Any, O : Any, R> test(
+private fun <T, I, O : Any, R> test(
   testBlock: (WorkflowTester<I, O, R>) -> T,
   baseContext: CoroutineContext,
   starter: (WorkflowHost.Factory, inputs: Channel<I>) -> WorkflowHost<I, O, R>

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
@@ -51,7 +51,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  *  - [sendInput]
  *    - Send a new [InputT] to the root workflow.
  */
-class WorkflowTester<InputT : Any, OutputT : Any, RenderingT : Any> @TestOnly internal constructor(
+class WorkflowTester<InputT : Any, OutputT : Any, RenderingT> @TestOnly internal constructor(
   private val inputs: SendChannel<InputT>,
   private val host: WorkflowHost<InputT, OutputT, RenderingT>,
   context: CoroutineContext
@@ -191,7 +191,7 @@ class WorkflowTester<InputT : Any, OutputT : Any, RenderingT : Any> @TestOnly in
  */
 // @formatter:off
 @TestOnly
-fun <T, InputT : Any, OutputT : Any, RenderingT : Any>
+fun <T, InputT : Any, OutputT : Any, RenderingT>
     Workflow<InputT, OutputT, RenderingT>.testFromStart(
       input: InputT,
       snapshot: Snapshot? = null,
@@ -209,7 +209,7 @@ fun <T, InputT : Any, OutputT : Any, RenderingT : Any>
  * All workflow-related coroutines are cancelled when the block exits.
  */
 @TestOnly
-fun <T, OutputT : Any, RenderingT : Any> Workflow<Unit, OutputT, RenderingT>.testFromStart(
+fun <T, OutputT : Any, RenderingT> Workflow<Unit, OutputT, RenderingT>.testFromStart(
   snapshot: Snapshot? = null,
   context: CoroutineContext = EmptyCoroutineContext,
   block: WorkflowTester<Unit, OutputT, RenderingT>.() -> T
@@ -224,7 +224,7 @@ fun <T, OutputT : Any, RenderingT : Any> Workflow<Unit, OutputT, RenderingT>.tes
  */
 // @formatter:off
 @TestOnly
-fun <T, InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any>
+fun <T, InputT : Any, StateT : Any, OutputT : Any, RenderingT>
     StatefulWorkflow<InputT, StateT, OutputT, RenderingT>.testFromState(
       input: InputT,
       initialState: StateT,
@@ -245,7 +245,7 @@ fun <T, InputT : Any, StateT : Any, OutputT : Any, RenderingT : Any>
  */
 // @formatter:off
 @TestOnly
-fun <StateT : Any, OutputT : Any, RenderingT : Any>
+fun <StateT : Any, OutputT : Any, RenderingT>
     StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.testFromState(
       initialState: StateT,
       context: CoroutineContext = EmptyCoroutineContext,
@@ -254,7 +254,7 @@ fun <StateT : Any, OutputT : Any, RenderingT : Any>
 // @formatter:on
 
 @UseExperimental(InternalCoroutinesApi::class)
-private fun <T, I : Any, O : Any, R : Any> test(
+private fun <T, I : Any, O : Any, R> test(
   testBlock: (WorkflowTester<I, O, R>) -> T,
   baseContext: CoroutineContext,
   starter: (WorkflowHost.Factory, inputs: Channel<I>) -> WorkflowHost<I, O, R>


### PR DESCRIPTION
Making these types non-nullable doesn't add any inherent value or safety. There may be workflows
that want to define nullable types, so we should let them. Workflows that define their types to be non-nullable still get all the null safety they expect.