### PR TITLE
Upgrade coroutines dependency to latest version.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -36,7 +36,7 @@ buildscript {
       'intellijAnnotations': '13.0',
       'junit': '4.12',
       'kotlin': '1.3.21',
-      'kotlinCoroutines': '1.1.1',
+      'kotlinCoroutines': '1.2.1',
       'ktlintPlugin': '5.1.0',
       'mavenPublishPlugin': '0.6.0',
       'mockito': '2.7.5',

--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/CoroutineWorkflowTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/CoroutineWorkflowTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Unconfined
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.consume
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -173,7 +174,7 @@ class CoroutineWorkflowTest : CoroutineScope {
     workflow.sendEvent(Unit)
   }
 
-  @Test fun `block gets original cancellation reason`() {
+  @Test fun `block gets original cancellation reason - null cause`() {
     lateinit var cancelReason: Throwable
     val workflow = workflow<Nothing, Nothing, Nothing> { _, _ ->
       suspendCancellableCoroutine<Nothing> { continuation ->
@@ -190,7 +191,7 @@ class CoroutineWorkflowTest : CoroutineScope {
   }
 
   @Suppress("DEPRECATION")
-  @Test fun `block gets original cancellation reason - deprecated cancel`() {
+  @Test fun `block gets original cancellation reason - non-null cause`() {
     lateinit var cancelReason: Throwable
     val workflow = workflow<Nothing, Nothing, Nothing> { _, _ ->
       suspendCancellableCoroutine<Nothing> { continuation ->
@@ -203,10 +204,16 @@ class CoroutineWorkflowTest : CoroutineScope {
     workflow.cancel(ExpectedException)
 
     assertTrue(cancelReason is CancellationException)
-    assertEquals(ExpectedException, cancelReason.cause)
+    // Search up the cause chain for the expected exception, since multiple CancellationExceptions
+    // may be chained together first.
+    val causeChain = generateSequence<Throwable>(cancelReason) { it.cause }
+    assertEquals(
+        1, causeChain.count { it === ExpectedException },
+        "Expected cancellation exception cause chain to include ExpectedException."
+    )
   }
 
   private companion object {
-    object ExpectedException : RuntimeException()
+    object ExpectedException : CancellationException()
   }
 }

--- a/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/WorkflowOperatorsTest.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/WorkflowOperatorsTest.kt
@@ -78,8 +78,6 @@ class WorkflowOperatorsTest {
     states.cancel()
 
     assertThat(subscribeCount).isEqualTo(1)
-    // For some reason the observable is actually disposed twice. Seems like a coroutines bug, but
-    // Disposable.dispose() is an idempotent operation so it should be fine.
-    assertThat(disposeCount).isEqualTo(2)
+    assertThat(disposeCount).isEqualTo(1)
   }
 }

--- a/kotlin/samples/tictactoe/android/build.gradle
+++ b/kotlin/samples/tictactoe/android/build.gradle
@@ -27,6 +27,11 @@ android {
     versionCode 1
     versionName "1.0.0"
   }
+
+  // See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940
+  packagingOptions {
+    exclude 'META-INF/atomicfu.kotlin_module'
+  }
 }
 
 dependencies {

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkersTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkersTest.kt
@@ -20,6 +20,7 @@ package com.squareup.workflow.internal
 import com.squareup.workflow.Worker.OutputOrFinished
 import com.squareup.workflow.Worker.OutputOrFinished.Finished
 import com.squareup.workflow.Worker.OutputOrFinished.Output
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
@@ -82,16 +83,22 @@ class WorkersTest {
 
   @Test fun `handles error`() {
     val channel = Channel<Output<String>>()
-    // TODO https://github.com/square/workflow/issues/188 Stop using parameterized cancel.
-    @Suppress("DEPRECATION")
-    channel.cancel(ExpectedException())
+    channel.cancel(CancellationException(null, ExpectedException()))
 
-    assertFailsWith<ExpectedException> {
+    assertFailsWith<CancellationException> {
       runBlocking {
         select<OutputOrFinished<String>> {
           onReceiveOutputOrFinished(channel) { it }
         }
       }
+    }.also { error ->
+      // Search up the cause chain for the expected exception, since multiple CancellationExceptions
+      // may be chained together first.
+      val causeChain = generateSequence<Throwable>(error) { it.cause }
+      assertEquals(
+          1, causeChain.count { it is ExpectedException },
+          "Expected cancellation exception cause chain to include original cause."
+      )
     }
   }
 

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkersTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkersTest.kt
@@ -105,9 +105,7 @@ class RxWorkersTest {
     worker.test {
       assertEquals(0, disposals)
       cancelWorker()
-      // There's a bug in the coroutine library: the observable is actually disposed twice.
-      // This is fixed in 1.2.0.
-      assertEquals(2, disposals)
+      assertEquals(1, disposals)
     }
   }
 

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
@@ -21,6 +21,7 @@ import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowHost
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
@@ -274,15 +275,13 @@ private fun <T, I, O : Any, R> test(
     throw e
   } finally {
     if (error != null) {
-      // TODO https://github.com/square/workflow/issues/188 Stop using parameterized cancel.
-      @Suppress("DEPRECATION")
-      val cancelled = context.cancel(error)
-      if (!cancelled) {
-        val cancellationCause = context[Job]!!.getCancellationException()
-            .cause
-        if (cancellationCause != error && cancellationCause != null) {
-          error.addSuppressed(cancellationCause)
-        }
+      context.cancel(
+          if (error is CancellationException) error else CancellationException(null, error)
+      )
+      val cancellationCause = context[Job]!!.getCancellationException()
+          .cause
+      if (cancellationCause != error && cancellationCause != null) {
+        error.addSuppressed(cancellationCause)
       }
     } else {
       // Cancel the Job to ensure everything gets cleaned up.

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowTesterTest.kt
@@ -61,8 +61,7 @@ class WorkflowTesterTest {
     val workflow = Workflow.stateless<Unit, Unit> { }
 
     workflow.testFromStart(context = job) {
-      @Suppress("DEPRECATION")
-      job.cancel(ExpectedException())
+      job.cancel(CancellationException(null, ExpectedException()))
       awaitFailure()
           .let { error ->
             val causeChain = generateSequence(error) { it.cause }

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -22,6 +22,11 @@ targetCompatibility = JavaVersion.VERSION_1_7
 
 android rootProject.ext.defaultAndroidConfig
 
+// See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940
+android.packagingOptions {
+  exclude 'META-INF/atomicfu.kotlin_module'
+}
+
 dependencies {
   api project(':workflow-core')
   api project(':workflow-ui-core')


### PR DESCRIPTION
Closes #188 because the deprecated `cancel` method that took `Throwable` has been removed.

The only real thing this "broke" was how legacy workflow's `switchMapState` handles channel cancellation,
now we have to be a bit more explicit. This is why channels shouldn't be used as streams…