### PR TITLE
Introduce alternative testing infrastructure to test single render passes more directly.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -123,8 +123,17 @@ interface Worker<out T> {
    * [Worker] emitting an output, and finishing (returning from [performWork]).
    */
   sealed class OutputOrFinished<out T> {
+    /**
+     * Indicates that a [Worker] emitted an output value.
+     */
     data class Output<out T>(val value: T) : OutputOrFinished<T>()
-    object Finished : OutputOrFinished<Nothing>()
+
+    /**
+     * Indicates that a [Worker] finished, and will not emit any more output values.
+     */
+    object Finished : OutputOrFinished<Nothing>() {
+      override fun toString(): String = "Finished"
+    }
   }
 
   /**

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.Deferred
  *
  * @see RealRenderContext
  */
-internal data class Behavior<StateT, out OutputT : Any>(
+data class Behavior<StateT, out OutputT : Any> internal constructor(
   val childCases: List<WorkflowOutputCase<*, *, StateT, OutputT>>,
   val workerCases: List<WorkerCase<*, StateT, OutputT>>,
   val nextActionFromEvent: Deferred<WorkflowAction<StateT, OutputT>>
@@ -40,7 +40,7 @@ internal data class Behavior<StateT, out OutputT : Any>(
       ChildOutputT : Any,
       ParentStateT,
       out ParentOutputT : Any
-      >(
+      > internal constructor(
         val workflow: Workflow<*, ChildOutputT, *>,
         val id: WorkflowId<ChildInputT, ChildOutputT, *>,
         val input: ChildInputT,
@@ -52,7 +52,7 @@ internal data class Behavior<StateT, out OutputT : Any>(
       }
       // @formatter:on
 
-  data class WorkerCase<T, StateT, out OutputT : Any>(
+  data class WorkerCase<T, StateT, out OutputT : Any> internal constructor(
     val worker: Worker<T>,
     val key: String,
     val handler: (OutputOrFinished<T>) -> WorkflowAction<StateT, OutputT>

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -27,8 +27,10 @@ import kotlinx.coroutines.CompletableDeferred
 
 /**
  * An implementation of [RenderContext] that builds a [Behavior] via [buildBehavior].
+ *
+ * Not for general application use.
  */
-internal class RealRenderContext<StateT, OutputT : Any>(
+class RealRenderContext<StateT, OutputT : Any>(
   private val renderer: Renderer<StateT, OutputT>
 ) : RenderContext<StateT, OutputT> {
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
@@ -30,17 +30,21 @@ internal typealias AnyId = WorkflowId<*, *, *>
  * Value type that can be used to distinguish between different workflows of different types or
  * the same type (in that case using a [name]).
  */
-internal data class WorkflowId<in InputT, out OutputT : Any, out RenderingT>
+data class WorkflowId<in InputT, out OutputT : Any, out RenderingT>
 @PublishedApi
 internal constructor(
   internal val type: KClass<out Workflow<InputT, OutputT, RenderingT>>,
   internal val name: String = ""
-)
+) {
+  constructor(
+    workflow: Workflow<InputT, OutputT, RenderingT>,
+    name: String = ""
+  ) : this(workflow::class, name)
+}
 
 @Suppress("unused")
 internal fun <W : Workflow<I, O, R>, I, O : Any, R>
-    W.id(key: String = ""): WorkflowId<I, O, R> =
-  WorkflowId(this::class, key)
+    W.id(key: String = ""): WorkflowId<I, O, R> = WorkflowId(this, key)
 
 internal fun WorkflowId<*, *, *>.toByteString(): ByteString = Buffer()
     .also { sink ->

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockChildWorkflow.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockChildWorkflow.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.stateless
+
+/**
+ * A mock implementation of [Workflow] for use in tests with `testRender` and [TestRenderResult].
+ *
+ * Note this workflow can not actually emit any output itself. Use
+ * [TestRenderResult.executeWorkflowActionFromOutput] to evaluate output handlers.
+ *
+ * @param renderer Function that is invoked in each render pass to calculate the rendering.
+ *
+ * @see StatefulWorkflow.testRender
+ * @see com.squareup.workflow.StatelessWorkflow.testRender
+ */
+class MockChildWorkflow<I, R>(private val renderer: (I) -> R) : Workflow<I, Nothing, R> {
+
+  /**
+   * Creates a [MockChildWorkflow] that will always render the same value, [rendering].
+   */
+  constructor(rendering: R) : this({ rendering })
+
+  private object NullSentinal
+
+  private var _lastSeenInput: Any? = null
+
+  /**
+   * Returns the last input value used to render this instance.
+   */
+  val lastSeenInput: I
+    @Suppress("UNCHECKED_CAST")
+    get() =
+      (_lastSeenInput ?: error("Expected MockChildWorkflow to be rendered before reading input."))
+          .takeUnless { it === NullSentinal } as I
+
+  private val workflow = Workflow
+      .stateless<I, Nothing, R> { input, _ ->
+        _lastSeenInput = input ?: NullSentinal
+        return@stateless renderer(input)
+      }
+      .asStatefulWorkflow()
+
+  override fun asStatefulWorkflow(): StatefulWorkflow<I, *, Nothing, R> = workflow
+}

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockChildWorkflow.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockChildWorkflow.kt
@@ -23,7 +23,7 @@ import com.squareup.workflow.stateless
  * A mock implementation of [Workflow] for use in tests with `testRender` and [TestRenderResult].
  *
  * Note this workflow can not actually emit any output itself. Use
- * [TestRenderResult.executeWorkflowActionFromOutput] to evaluate output handlers.
+ * [TestRenderResult.handleOutput] to evaluate output handlers.
  *
  * @param renderer Function that is invoked in each render pass to calculate the rendering.
  *

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockWorker.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockWorker.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import com.squareup.workflow.Worker
+import com.squareup.workflow.Worker.Emitter
+
+/**
+ * A mock implementation of [Worker] for use in tests with `testRender` and [TestRenderResult].
+ *
+ * Note this [Worker] can not actually emit any output itself. Use
+ * [TestRenderResult.executeWorkerActionFromOutput] or
+ * [TestRenderResult.executeWorkerActionFromFinish] to evaluate output handlers.
+ *
+ * @see com.squareup.workflow.StatefulWorkflow.testRender
+ * @see com.squareup.workflow.StatelessWorkflow.testRender
+ */
+class MockWorker<T>(val name: String) : Worker<T> {
+
+  override suspend fun performWork(emitter: Emitter<T>) {
+    throw AssertionError("MockWorker can't do work. Use TestRenderResult.executeWorkerAction*.")
+  }
+
+  override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean =
+    otherWorker is MockWorker && name == otherWorker.name
+}

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockWorker.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockWorker.kt
@@ -22,8 +22,8 @@ import com.squareup.workflow.Worker.Emitter
  * A mock implementation of [Worker] for use in tests with `testRender` and [TestRenderResult].
  *
  * Note this [Worker] can not actually emit any output itself. Use
- * [TestRenderResult.executeWorkerActionFromOutput] or
- * [TestRenderResult.executeWorkerActionFromFinish] to evaluate output handlers.
+ * [TestRenderResult.handleOutput] or
+ * [TestRenderResult.handleFinish] to evaluate output handlers.
  *
  * @see com.squareup.workflow.StatefulWorkflow.testRender
  * @see com.squareup.workflow.StatelessWorkflow.testRender

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import com.squareup.workflow.EventHandler
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.StatelessWorkflow
+import com.squareup.workflow.Worker
+import com.squareup.workflow.Worker.OutputOrFinished
+import com.squareup.workflow.Worker.OutputOrFinished.Finished
+import com.squareup.workflow.Worker.OutputOrFinished.Output
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.internal.Behavior
+import com.squareup.workflow.internal.Behavior.WorkerCase
+import com.squareup.workflow.internal.Behavior.WorkflowOutputCase
+import com.squareup.workflow.internal.RealRenderContext
+import com.squareup.workflow.internal.RealRenderContext.Renderer
+import com.squareup.workflow.internal.WorkflowId
+
+/**
+ * Calls [StatelessWorkflow.render] and returns a [TestRenderResult] that can be used to get at
+ * the actual [rendering][TestRenderResult.rendering], assert on which children and workers were
+ * run, and execute the output handlers for rendered children and workers to assert on their
+ * state transitions and emitted output.
+ *
+ * ## Mocking Child Workflows and Workers
+ *
+ * All child [Workflow]s must be instances of [MockChildWorkflow], as they are not given a working
+ * [RenderContext]. This function only allows you to test a single workflow's render method.
+ *
+ * Child [Worker]s should be instances of [MockWorker].
+ */
+fun <O : Any, R> StatelessWorkflow<Unit, O, R>.testRender(): TestRenderResult<Unit, O, R> =
+  testRender(Unit)
+
+/**
+ * Calls [StatelessWorkflow.render] and returns a [TestRenderResult] that can be used to get at
+ * the actual [rendering][TestRenderResult.rendering], assert on which children and workers were
+ * run, and execute the output handlers for rendered children and workers to assert on their
+ * state transitions and emitted output.
+ *
+ * ## Mocking Child Workflows and Workers
+ *
+ * All child [Workflow]s must be instances of [MockChildWorkflow], as they are not given a working
+ * [RenderContext]. This function only allows you to test a single workflow's render method.
+ *
+ * Child [Worker]s should be instances of [MockWorker].
+ */
+fun <I, O : Any, R> StatelessWorkflow<I, O, R>.testRender(input: I): TestRenderResult<Unit, O, R> =
+  @Suppress("UNCHECKED_CAST")
+  (asStatefulWorkflow() as StatefulWorkflow<I, Unit, O, R>)
+      .testRender(input, Unit)
+
+/**
+ * Calls [StatefulWorkflow.render] and returns a [TestRenderResult] that can be used to get at
+ * the actual [rendering][TestRenderResult.rendering], assert on which children and workers were
+ * run, and execute the output handlers for rendered children and workers to assert on their
+ * state transitions and emitted output.
+ *
+ * ## Mocking Child Workflows and Workers
+ *
+ * All child [Workflow]s must be instances of [MockChildWorkflow], as they are not given a working
+ * [RenderContext]. This function only allows you to test a single workflow's render method.
+ *
+ * Child [Worker]s should be instances of [MockWorker].
+ */
+fun <S, O : Any, R> StatefulWorkflow<Unit, S, O, R>.testRender(
+  state: S
+): TestRenderResult<S, O, R> = testRender(Unit, state)
+
+/**
+ * Calls [StatefulWorkflow.render] and returns a [TestRenderResult] that can be used to get at
+ * the actual [rendering][TestRenderResult.rendering], assert on which children and workers were
+ * run, and execute the output handlers for rendered children and workers to assert on their
+ * state transitions and emitted output.
+ *
+ * ## Mocking Child Workflows and Workers
+ *
+ * All child [Workflow]s must be instances of [MockChildWorkflow], as they are not given a working
+ * [RenderContext]. This function only allows you to test a single workflow's render method.
+ *
+ * Child [Worker]s should be instances of [MockWorker].
+ */
+fun <I, S, O : Any, R> StatefulWorkflow<I, S, O, R>.testRender(
+  input: I,
+  state: S
+): TestRenderResult<S, O, R> {
+  val testRenderContext = RealRenderContext(object : Renderer<S, O> {
+    override fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> render(
+      case: WorkflowOutputCase<ChildInputT, ChildOutputT, S, O>,
+      child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
+      id: WorkflowId<ChildInputT, ChildOutputT, ChildRenderingT>,
+      input: ChildInputT
+    ): ChildRenderingT {
+      require(child is MockChildWorkflow) {
+        "Expected child workflow to be a MockChildWorkflow: $id"
+      }
+
+      @Suppress("UNCHECKED_CAST")
+      val childStatefulWorkflow =
+        child.asStatefulWorkflow() as StatefulWorkflow<ChildInputT, Any?, ChildOutputT, ChildRenderingT>
+      val childInitialState = childStatefulWorkflow.initialState(input, null)
+      // Allow the workflow-under-test to *render* children, but those children must not try to
+      // use the RenderContext themselves.
+      return childStatefulWorkflow.render(input, childInitialState, NoopRenderContext)
+    }
+  })
+
+  val rendering = render(input, state, testRenderContext)
+  return TestRenderResult(rendering, state, testRenderContext.buildBehavior())
+}
+
+/**
+ * Represents the result of running a single render pass on a workflow.
+ *
+ * @param rendering The actual [RenderingT] value returned from the workflow's `render` method.
+ * @param state The [StateT] passed into the `render` method.
+ * @param behavior The [Behavior] generated from the [RenderContext].
+ */
+class TestRenderResult<StateT, OutputT : Any, RenderingT> internal constructor(
+  val rendering: RenderingT,
+  private val state: StateT,
+  private val behavior: Behavior<StateT, OutputT>
+) {
+
+  /**
+   * Throws an [AssertionError] if the render pass did not render [workflow] with [key].
+   */
+  fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> assertWorkflowRendered(
+    workflow: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
+    key: String = ""
+  ) {
+    findWorkflowCase(workflow, key)
+  }
+
+  /**
+   * Asserts that [workflow] was rendered with the given [key] and then executes the output handler
+   * with the given [output] (as an [Output]). Returns the new state and output returned by the
+   * output handler.
+   */
+  fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> executeWorkflowActionFromOutput(
+    workflow: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
+    output: ChildOutputT,
+    key: String = ""
+  ): Pair<StateT, OutputT?> {
+    val case = findWorkflowCase(workflow, key)
+    val action = case.acceptChildOutput(output)
+    return action(state)
+  }
+
+  /**
+   * Throws an [AssertionError] if the render pass did not run [worker] with [key].
+   */
+  fun <T : Any> assertWorkerRan(
+    worker: Worker<T>,
+    key: String = ""
+  ) {
+    findWorkerCase(worker, key)
+  }
+
+  /**
+   * Asserts that [worker] was ran with the given [key] and then executes the output handler
+   * with the given [output] (as an [Output]). Returns the new state and output returned by the
+   * output handler.
+   */
+  fun <T : Any> executeWorkerActionFromOutput(
+    worker: Worker<T>,
+    output: T,
+    key: String = ""
+  ): Pair<StateT, OutputT?> = executeWorkerAction(worker, Output(output), key)
+
+  /**
+   * Asserts that [worker] was ran with the given [key] and then executes the output handler
+   * with [Finished]. Returns the new state and output returned by the output handler.
+   */
+  fun <T : Any> executeWorkerActionFromFinish(
+    worker: Worker<T>,
+    key: String = ""
+  ): Pair<StateT, OutputT?> = executeWorkerAction(worker, Finished, key)
+
+  /**
+   * Throws an [AssertionError] if any [Workflow]s were rendered.
+   */
+  fun assertNoWorkflowsRendered() {
+    behavior.childCases.let {
+      if (it.isNotEmpty()) {
+        throw AssertionError("Expected no workflows to be rendered, but ${it.size} were.")
+      }
+    }
+  }
+
+  /**
+   * Throws an [AssertionError] if any [Worker]s were run.
+   */
+  fun assertNoWorkersRan() {
+    behavior.workerCases.let {
+      if (it.isNotEmpty()) {
+        throw AssertionError("Expected no workflows to be rendered, but ${it.size} were.")
+      }
+    }
+  }
+
+  private fun <T : Any> executeWorkerAction(
+    worker: Worker<T>,
+    outputOrFinished: OutputOrFinished<T>,
+    key: String = ""
+  ): Pair<StateT, OutputT?> {
+    val case = findWorkerCase(worker, key)
+    val action = case.acceptUpdate(outputOrFinished)
+    return action(state)
+  }
+
+  private fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> findWorkflowCase(
+    workflow: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
+    key: String
+  ): WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT> {
+    val id = WorkflowId(workflow, key)
+    @Suppress("UNCHECKED_CAST")
+    return behavior.childCases.singleOrNull { it.id == id }
+        as WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT>?
+        ?: throw AssertionError("Expected workflow to be rendered: $workflow (key=\"$key\")")
+  }
+
+  private fun <T : Any> findWorkerCase(
+    worker: Worker<T>,
+    key: String
+  ): WorkerCase<T, StateT, OutputT> {
+    @Suppress("UNCHECKED_CAST")
+    return behavior.workerCases.singleOrNull { it.worker.doesSameWorkAs(worker) && it.key == key }
+        as WorkerCase<T, StateT, OutputT>?
+        ?: throw AssertionError("Expected worker to be rendered: $worker (key=\"$key\")")
+  }
+}
+
+private object NoopRenderContext : RenderContext<Any?, Any> {
+  override fun <EventT : Any> onEvent(handler: (EventT) -> WorkflowAction<Any?, Any>): EventHandler<EventT> {
+    throw UnsupportedOperationException()
+  }
+
+  override fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> renderChild(
+    child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
+    input: ChildInputT,
+    key: String,
+    handler: (ChildOutputT) -> WorkflowAction<Any?, Any>
+  ): ChildRenderingT {
+    throw UnsupportedOperationException()
+  }
+
+  override fun <T> onWorkerOutputOrFinished(
+    worker: Worker<T>,
+    key: String,
+    handler: (OutputOrFinished<T>) -> WorkflowAction<Any?, Any>
+  ) {
+    throw UnsupportedOperationException()
+  }
+}

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.StatelessWorkflow
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.WorkflowAction.Companion.enterState
+import com.squareup.workflow.renderChild
+import com.squareup.workflow.stateless
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class RenderTesterTest {
+
+  @Test fun `stateless input and rendering`() {
+    val workflow = Workflow.stateless<String, String, String> { input, context ->
+      return@stateless "input: $input"
+    } as StatelessWorkflow
+
+    val result = workflow.testRender("start")
+
+    assertEquals("input: start", result.rendering)
+  }
+
+  @Test fun `stateful workflow gets state`() {
+    val workflow = object : StatefulWorkflow<String, String, Nothing, String>() {
+      override fun initialState(
+        input: String,
+        snapshot: Snapshot?
+      ): String = fail("Expected initialState not to be called.")
+
+      override fun render(
+        input: String,
+        state: String,
+        context: RenderContext<String, Nothing>
+      ): String {
+        return "input=$input, state=$state"
+      }
+
+      override fun snapshotState(state: String): Snapshot =
+        fail("Expected snapshotState not to be called.")
+    }
+
+    val result = workflow.testRender(input = "foo", state = "bar")
+
+    assertEquals("input=foo, state=bar", result.rendering)
+  }
+
+  @Test fun `assert no composition`() {
+    val workflow = Workflow.stateless<Nothing, Unit> { Unit } as StatelessWorkflow
+
+    val result = workflow.testRender()
+
+    result.assertNoWorkflowsRendered()
+    result.assertNoWorkersRan()
+  }
+
+  @Test fun `renders child with input`() {
+    val child = MockChildWorkflow<String, String> { "input: $it" }
+    val workflow = Workflow.stateless<Nothing, String> { context ->
+      "child: " + context.renderChild(child, "foo")
+    } as StatelessWorkflow
+
+    val result = workflow.testRender()
+
+    assertEquals("foo", child.lastSeenInput)
+    assertEquals("child: input: foo", result.rendering)
+  }
+
+  @Test fun `renders worker output`() {
+    val worker = MockWorker<String>("worker")
+    val workflow = object : StatefulWorkflow<Unit, String, String, Unit>() {
+      override fun initialState(
+        input: Unit,
+        snapshot: Snapshot?
+      ): String = fail()
+
+      override fun render(
+        input: Unit,
+        state: String,
+        context: RenderContext<String, String>
+      ) {
+        context.onWorkerOutputOrFinished(worker) {
+          enterState(
+              "state: $it",
+              emittingOutput = "output: $it"
+          )
+        }
+      }
+
+      override fun snapshotState(state: String): Snapshot = fail()
+    }
+
+    val result = workflow.testRender("")
+
+    result.assertNoWorkflowsRendered()
+    result.assertWorkerRan(worker)
+
+    // Output
+    val (outputState, output) = result.executeWorkerActionFromOutput(worker, "work!")
+    assertEquals("state: Output(value=work!)", outputState)
+    assertEquals("output: Output(value=work!)", output)
+
+    // Finish
+    val (finishState, finish) = result.executeWorkerActionFromFinish(worker)
+    assertEquals("state: Finished", finishState)
+    assertEquals("output: Finished", finish)
+  }
+
+  @Test fun `child workflow output`() {
+    val child: Workflow<Unit, String, Unit> = MockChildWorkflow(Unit)
+    val workflow = object : StatefulWorkflow<Unit, String, String, Unit>() {
+      override fun initialState(
+        input: Unit,
+        snapshot: Snapshot?
+      ): String = fail()
+
+      override fun render(
+        input: Unit,
+        state: String,
+        context: RenderContext<String, String>
+      ) {
+        context.renderChild(child) {
+          enterState(
+              "state: $it",
+              emittingOutput = "output: $it"
+          )
+        }
+      }
+
+      override fun snapshotState(state: String): Snapshot = fail()
+    }
+
+    val result = workflow.testRender("")
+
+    result.assertNoWorkersRan()
+    result.assertWorkflowRendered(child)
+    val (state, output) = result.executeWorkflowActionFromOutput(child, "output!")
+    assertEquals("state: output!", state)
+    assertEquals("output: output!", output)
+  }
+}

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkflowTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkflowTesterTest.kt
@@ -15,9 +15,15 @@
  */
 @file:Suppress("EXPERIMENTAL_API_USAGE")
 
-package com.squareup.workflow
+package com.squareup.workflow.testing
 
-import com.squareup.workflow.testing.testFromStart
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.asWorker
+import com.squareup.workflow.onWorkerOutput
+import com.squareup.workflow.stateless
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job


### PR DESCRIPTION
Given a `StatefulWorkflow` or `StatelessWorkflow`, call `.testRender()` on it.
    Pass the `InputT`, and for `StatefulWorkflow`s also pass the `StateT`.
    This returns a `TestRenderResult` which provides access to the actual rendering
    as well as methods to assert that children or workers were rendered and invoke
    their output handlers.