### PR TITLE
Remove the non-nullable Any upper bound on Input, State, and Rendering types in the rest of the code.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -90,7 +90,7 @@ interface RenderContext<StateT, in OutputT : Any> {
    * @param key An optional string key that is used to distinguish between workflows of the same
    * type.
    */
-  fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any> renderChild(
+  fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> renderChild(
     child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
     input: ChildInputT,
     key: String = "",
@@ -113,7 +113,7 @@ interface RenderContext<StateT, in OutputT : Any> {
 /**
  * Convenience alias of [RenderContext.renderChild] for workflows that don't take input.
  */
-fun <StateT : Any, OutputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
+fun <StateT, OutputT : Any, ChildOutputT : Any, ChildRenderingT>
     RenderContext<StateT, OutputT>.renderChild(
 // Intellij refuses to format this parameter list correctly because of the weird line break,
 // and detekt will complain about it.
@@ -128,7 +128,7 @@ fun <StateT : Any, OutputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
  * Convenience alias of [RenderContext.renderChild] for workflows that don't take input or emit
  * output.
  */
-fun <InputT : Any, StateT : Any, OutputT : Any, ChildRenderingT : Any>
+fun <InputT, StateT, OutputT : Any, ChildRenderingT>
     RenderContext<StateT, OutputT>.renderChild(
 // Intellij refuses to format this parameter list correctly because of the weird line break,
 // and detekt will complain about it.
@@ -143,7 +143,7 @@ fun <InputT : Any, StateT : Any, OutputT : Any, ChildRenderingT : Any>
  * Convenience alias of [RenderContext.renderChild] for workflows that don't take input or emit
  * output.
  */
-fun <StateT : Any, OutputT : Any, ChildRenderingT : Any>
+fun <StateT, OutputT : Any, ChildRenderingT>
     RenderContext<StateT, OutputT>.renderChild(
 // Intellij refuses to format this parameter list correctly because of the weird line break,
 // and detekt will complain about it.
@@ -160,7 +160,7 @@ fun <StateT : Any, OutputT : Any, ChildRenderingT : Any>
  *
  * @param key An optional string key that is used to distinguish between identical [Worker]s.
  */
-fun <StateT : Any, OutputT : Any, T> RenderContext<StateT, OutputT>.onWorkerOutput(
+fun <StateT, OutputT : Any, T> RenderContext<StateT, OutputT>.onWorkerOutput(
   worker: Worker<T>,
   key: String = "",
   handler: (T) -> WorkflowAction<StateT, OutputT>
@@ -177,7 +177,7 @@ fun <StateT : Any, OutputT : Any, T> RenderContext<StateT, OutputT>.onWorkerOutp
  *
  * @param key An optional string key that is used to distinguish between identical [Worker]s.
  */
-fun <StateT : Any, OutputT : Any> RenderContext<StateT, OutputT>.runningWorker(
+fun <StateT, OutputT : Any> RenderContext<StateT, OutputT>.runningWorker(
   worker: Worker<Nothing>,
   key: String = ""
 ) = onWorkerOutputOrFinished(worker, key) { throw AssertionError("Worker<Nothing> emitted $it") }

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -90,7 +90,7 @@ abstract class StatelessWorkflow<InputT, OutputT : Any, RenderingT> :
  * [input][InputT] received from its parent, and it may render child workflows that do have
  * their own internal state.
  */
-fun <InputT : Any, OutputT : Any, RenderingT : Any> Workflow.Companion.stateless(
+fun <InputT, OutputT : Any, RenderingT> Workflow.Companion.stateless(
   render: (
     input: InputT,
     context: RenderContext<Nothing, OutputT>
@@ -109,7 +109,7 @@ fun <InputT : Any, OutputT : Any, RenderingT : Any> Workflow.Companion.stateless
  * Note that while the returned workflow doesn't have any _internal_ state of its own, it may
  * render child workflows that do have their own internal state.
  */
-fun <OutputT : Any, RenderingT : Any> Workflow.Companion.stateless(
+fun <OutputT : Any, RenderingT> Workflow.Companion.stateless(
   render: (context: RenderContext<Nothing, OutputT>) -> RenderingT
 ): Workflow<Unit, OutputT, RenderingT> =
   Workflow.stateless { _: Unit, context: RenderContext<Nothing, OutputT> ->
@@ -120,7 +120,7 @@ fun <OutputT : Any, RenderingT : Any> Workflow.Companion.stateless(
  * Returns a workflow that does nothing but echo the given [rendering].
  * Handy for testing.
  */
-fun <OutputT : Any, RenderingT : Any> Workflow.Companion.rendering(
+fun <OutputT : Any, RenderingT> Workflow.Companion.rendering(
   rendering: RenderingT
 ): Workflow<Unit, OutputT, RenderingT> =
   stateless { _: Unit, _: RenderContext<Nothing, OutputT> -> rendering }
@@ -132,7 +132,7 @@ fun <OutputT : Any, RenderingT : Any> Workflow.Companion.rendering(
 // Intellij refuses to format this parameter list correctly because of the weird line break,
 // and detekt will complain about it.
 // @formatter:off
-fun <InputT : Any, OutputT : Any, FromRenderingT : Any, ToRenderingT : Any>
+fun <InputT, OutputT : Any, FromRenderingT, ToRenderingT>
     Workflow<InputT, OutputT, FromRenderingT>.mapRendering(
       transform: (FromRenderingT) -> ToRenderingT
     ): Workflow<InputT, OutputT, ToRenderingT> = Workflow.stateless { input, context ->

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -32,7 +32,7 @@ interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, O
      * @param name Function that returns a string describing the update for debugging.
      * @param update Function that defines the workflow update.
      */
-    inline operator fun <StateT : Any, OutputT : Any> invoke(
+    inline operator fun <StateT, OutputT : Any> invoke(
       crossinline name: () -> String,
       crossinline update: (StateT) -> Pair<StateT, OutputT?>
     ): WorkflowAction<StateT, OutputT> = object : WorkflowAction<StateT, OutputT> {
@@ -43,14 +43,14 @@ interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, O
     /**
      * Returns a [WorkflowAction] that does nothing.
      */
-    fun <StateT : Any, OutputT : Any> noop(): WorkflowAction<StateT, OutputT> =
+    fun <StateT, OutputT : Any> noop(): WorkflowAction<StateT, OutputT> =
       WorkflowAction({ "noop" }) { Pair(it, null) }
 
     /**
      * Convenience function that returns a [WorkflowAction] that will just set the state to [newState]
      * (without considering the current state) and optionally emit an output.
      */
-    fun <StateT : Any, OutputT : Any> enterState(
+    fun <StateT, OutputT : Any> enterState(
       newState: StateT,
       emittingOutput: OutputT? = null
     ): WorkflowAction<StateT, OutputT> =
@@ -62,7 +62,7 @@ interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, O
      * Convenience function that returns a [WorkflowAction] that will just set the state to [newState]
      * (without considering the current state) and optionally emit an output.
      */
-    fun <StateT : Any, OutputT : Any> enterState(
+    fun <StateT, OutputT : Any> enterState(
       name: String,
       newState: StateT,
       emittingOutput: OutputT? = null
@@ -74,7 +74,7 @@ interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, O
     /**
      * Convenience function to implement [WorkflowAction] without returning the output.
      */
-    fun <StateT : Any, OutputT : Any> modifyState(
+    fun <StateT, OutputT : Any> modifyState(
       name: () -> String,
       emittingOutput: OutputT? = null,
       modify: (StateT) -> StateT
@@ -86,13 +86,13 @@ interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, O
     /**
      * Convenience function to implement [WorkflowAction] without changing the state.
      */
-    fun <StateT : Any, OutputT : Any> emitOutput(output: OutputT): WorkflowAction<StateT, OutputT> =
+    fun <StateT, OutputT : Any> emitOutput(output: OutputT): WorkflowAction<StateT, OutputT> =
       WorkflowAction({ "emitOutput($output)" }) { Pair(it, output) }
 
     /**
      * Convenience function to implement [WorkflowAction] without changing the state.
      */
-    fun <StateT : Any, OutputT : Any> emitOutput(
+    fun <StateT, OutputT : Any> emitOutput(
       name: String,
       output: OutputT
     ): WorkflowAction<StateT, OutputT> =

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/WorkflowHost.kt
@@ -117,7 +117,7 @@ interface WorkflowHost<in InputT, out OutputT : Any, out RenderingT> {
      * the testing extension method defined there on your workflow itself.
      */
     @TestOnly
-    fun <InputT, StateT : Any, OutputT : Any, RenderingT> runTestFromState(
+    fun <InputT, StateT, OutputT : Any, RenderingT> runTestFromState(
       workflow: StatefulWorkflow<InputT, StateT, OutputT, RenderingT>,
       inputs: ReceiveChannel<InputT>,
       initialState: StateT

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -36,7 +36,7 @@ internal data class Behavior<StateT, out OutputT : Any>(
 
   // @formatter:off
   data class WorkflowOutputCase<
-      ChildInputT : Any,
+      ChildInputT,
       ChildOutputT : Any,
       ParentStateT,
       out ParentOutputT : Any

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -33,7 +33,7 @@ internal class RealRenderContext<StateT, OutputT : Any>(
 ) : RenderContext<StateT, OutputT> {
 
   interface Renderer<StateT, in OutputT : Any> {
-    fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any> render(
+    fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> render(
       case: WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT>,
       child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
       id: WorkflowId<ChildInputT, ChildOutputT, ChildRenderingT>,
@@ -66,7 +66,7 @@ internal class RealRenderContext<StateT, OutputT : Any>(
   }
 
   // @formatter:off
-  override fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
+  override fun <ChildInputT, ChildOutputT : Any, ChildRenderingT>
       renderChild(
         child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
         input: ChildInputT,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
@@ -52,7 +52,7 @@ internal class SubtreeManager<StateT, OutputT : Any>(
     )
 
   // @formatter:off
-  override fun <ChildInputT : Any, ChildOutputT : Any, ChildRenderingT : Any>
+  override fun <ChildInputT, ChildOutputT : Any, ChildRenderingT>
       render(
         case: WorkflowOutputCase<ChildInputT, ChildOutputT, StateT, OutputT>,
         child: Workflow<ChildInputT, ChildOutputT, ChildRenderingT>,
@@ -126,7 +126,7 @@ internal class SubtreeManager<StateT, OutputT : Any>(
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun <IC : Any, OC : Any> WorkflowOutputCase<IC, OC, StateT, OutputT>.createNode():
+  private fun <IC, OC : Any> WorkflowOutputCase<IC, OC, StateT, OutputT>.createNode():
       WorkflowNode<IC, *, OC, *> =
     WorkflowNode(
         id,

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -46,11 +46,11 @@ class RealRenderContextTest {
       val case: WorkflowOutputCase<*, *, *, *>,
       val child: Workflow<*, *, *>,
       val id: WorkflowId<*, *, *>,
-      val input: Any
+      val input: Any?
     )
 
     @Suppress("UNCHECKED_CAST")
-    override fun <IC : Any, OC : Any, RC : Any> render(
+    override fun <IC, OC : Any, RC> render(
       case: WorkflowOutputCase<IC, OC, String, String>,
       child: Workflow<IC, OC, RC>,
       id: WorkflowId<IC, OC, RC>,
@@ -77,8 +77,8 @@ class RealRenderContextTest {
     override fun snapshotState(state: String): Snapshot = fail()
   }
 
-  private class PoisonRenderer<S : Any, O : Any> : Renderer<S, O> {
-    override fun <IC : Any, OC : Any, RC : Any> render(
+  private class PoisonRenderer<S, O : Any> : Renderer<S, O> {
+    override fun <IC, OC : Any, RC> render(
       case: WorkflowOutputCase<IC, OC, S, O>,
       child: Workflow<IC, OC, RC>,
       id: WorkflowId<IC, OC, RC>,

--- a/kotlin/workflow-rx2-runtime/src/main/java/com/squareup/workflow/rx2/FlatMapWorkflow.kt
+++ b/kotlin/workflow-rx2-runtime/src/main/java/com/squareup/workflow/rx2/FlatMapWorkflow.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.rx2.rxFlowable
  * how to use backpressure. By operating on [Flowable], this operator leaves it up to the caller to
  * specify strategies for handling backpressure, instead of assuming any particular behavior.
  */
-fun <InputT : Any, OutputT : Any, RenderingT : Any> Flowable<InputT>.flatMapWorkflow(
+fun <InputT, OutputT : Any, RenderingT> Flowable<InputT>.flatMapWorkflow(
   workflow: Workflow<InputT, OutputT, RenderingT>,
   initialSnapshot: Snapshot? = null,
   dispatcher: CoroutineDispatcher = Dispatchers.Unconfined

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
@@ -225,7 +225,7 @@ fun <T, OutputT : Any, RenderingT> Workflow<Unit, OutputT, RenderingT>.testFromS
  */
 // @formatter:off
 @TestOnly
-fun <T, InputT, StateT : Any, OutputT : Any, RenderingT>
+fun <T, InputT, StateT, OutputT : Any, RenderingT>
     StatefulWorkflow<InputT, StateT, OutputT, RenderingT>.testFromState(
       input: InputT,
       initialState: StateT,
@@ -246,7 +246,7 @@ fun <T, InputT, StateT : Any, OutputT : Any, RenderingT>
  */
 // @formatter:off
 @TestOnly
-fun <StateT : Any, OutputT : Any, RenderingT>
+fun <StateT, OutputT : Any, RenderingT>
     StatefulWorkflow<Unit, StateT, OutputT, RenderingT>.testFromState(
       initialState: StateT,
       context: CoroutineContext = EmptyCoroutineContext,

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowActivityRunner.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowActivityRunner.kt
@@ -31,7 +31,7 @@ import io.reactivex.Observable
  * [FragmentActivity.setContentWorkflow]. See that method for more details.
  */
 @ExperimentalWorkflowUi
-class WorkflowActivityRunner<OutputT : Any, RenderingT : Any>
+class WorkflowActivityRunner<out OutputT : Any, out RenderingT : Any>
 internal constructor(private val model: WorkflowViewModel<OutputT, RenderingT>) {
 
   internal val renderings: Observable<out RenderingT> = model.updates.map { it.rendering }
@@ -106,7 +106,7 @@ internal constructor(private val model: WorkflowViewModel<OutputT, RenderingT>) 
  */
 @ExperimentalWorkflowUi
 @CheckResult
-fun <InputT : Any, OutputT : Any, RenderingT : Any> FragmentActivity.setContentWorkflow(
+fun <InputT, OutputT : Any, RenderingT : Any> FragmentActivity.setContentWorkflow(
   viewRegistry: ViewRegistry,
   workflow: Workflow<InputT, OutputT, RenderingT>,
   inputs: Flowable<InputT>,

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewModel.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewModel.kt
@@ -30,12 +30,12 @@ import io.reactivex.disposables.Disposable
  * would be nasty.
  */
 @ExperimentalWorkflowUi
-internal class WorkflowViewModel<OutputT : Any, RenderingT : Any>(
+internal class WorkflowViewModel<OutputT : Any, RenderingT>(
   val viewRegistry: ViewRegistry,
   workflowUpdates: Flowable<Update<OutputT, RenderingT>>
 ) : ViewModel() {
 
-  internal class Factory<InputT : Any, OutputT : Any, RenderingT : Any>(
+  internal class Factory<InputT, OutputT : Any, RenderingT>(
     private val viewRegistry: ViewRegistry,
     private val workflow: Workflow<InputT, OutputT, RenderingT>,
     private val inputs: Flowable<InputT>,


### PR DESCRIPTION
Commit b5ed7b1517e7d234615b8b4a875ba6ab8e3fb3f0 removed the non-nullable upper bound on these types
in Workflow, but missed all the other places that had to duplicate that bound.