### PR TITLE
Make the RenderContext parameter to Workflow.stateless the receiver instead.

### DIFF
--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
@@ -35,8 +35,8 @@ class MainWorkflowTest {
   }
 
   @Test fun `starts game on auth`() {
-    val authWorkflow: AuthWorkflow = Workflow.stateless { context ->
-      context.onWorkerOutput(Worker.from { Unit }) { emitOutput("auth") }
+    val authWorkflow: AuthWorkflow = Workflow.stateless {
+      onWorkerOutput(Worker.from { Unit }) { emitOutput("auth") }
       authScreen()
     }
 

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -145,7 +145,7 @@ class RealRenderContextTest {
     context.buildBehavior()
 
     assertFailsWith<IllegalStateException> { context.onEvent<Unit> { fail() } }
-    val child = Workflow.stateless<Nothing, Unit> { fail() }
+    val child = Workflow.stateless<Unit, Nothing, Unit> { fail() }
     assertFailsWith<IllegalStateException> { context.renderChild(child) }
     val worker = Worker.from { Unit }
     assertFailsWith<IllegalStateException> { context.onWorkerOutput(worker) { fail() } }

--- a/kotlin/workflow-rx2-runtime/src/test/java/com/squareup/workflow/rx2/FlatMapWorkflowTest.kt
+++ b/kotlin/workflow-rx2-runtime/src/test/java/com/squareup/workflow/rx2/FlatMapWorkflowTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.Test
 
 class FlatMapWorkflowTest {
 
-  private val workflow = Workflow.stateless<String, Nothing, String> { input, _ ->
+  private val workflow = Workflow.stateless<String, Nothing, String> { input ->
     "rendered: $input"
   }
   private val inputs = PublishSubject.create<String>()

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockChildWorkflow.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockChildWorkflow.kt
@@ -51,7 +51,7 @@ class MockChildWorkflow<I, R>(private val renderer: (I) -> R) : Workflow<I, Noth
           .takeUnless { it === NullSentinal } as I
 
   private val workflow = Workflow
-      .stateless<I, Nothing, R> { input, _ ->
+      .stateless<I, Nothing, R> { input ->
         _lastSeenInput = input ?: NullSentinal
         return@stateless renderer(input)
       }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -41,8 +41,8 @@ class WorkerCompositionIntegrationTest {
   @Test fun `worker started`() {
     var started = false
     val worker = Worker.create<Unit> { started = true }
-    val workflow = Workflow.stateless<Boolean, Nothing, Unit> { input, context ->
-      if (input) context.onWorkerOutput(worker) { noop() }
+    val workflow = Workflow.stateless<Boolean, Nothing, Unit> { input ->
+      if (input) onWorkerOutput(worker) { noop() }
     }
 
     workflow.testFromStart(false) {
@@ -59,8 +59,8 @@ class WorkerCompositionIntegrationTest {
         cancelled = true
       }
     }
-    val workflow = Workflow.stateless<Boolean, Nothing, Unit> { input, context ->
-      if (input) context.onWorkerOutput(worker) { noop() }
+    val workflow = Workflow.stateless<Boolean, Nothing, Unit> { input ->
+      if (input) onWorkerOutput(worker) { noop() }
     }
 
     workflow.testFromStart(true) {
@@ -82,8 +82,8 @@ class WorkerCompositionIntegrationTest {
         stops++
       }
     }
-    val workflow = Workflow.stateless<Unit, Nothing, Unit> { _, context ->
-      context.onWorkerOutput(worker) { noop() }
+    val workflow = Workflow.stateless<Unit, Nothing, Unit> { _ ->
+      onWorkerOutput(worker) { noop() }
     }
 
     workflow.testFromStart {
@@ -112,8 +112,8 @@ class WorkerCompositionIntegrationTest {
         stops++
       }
     }
-    val workflow = Workflow.stateless<Boolean, Nothing, Unit> { input, context ->
-      if (input) context.onWorkerOutput(worker) { noop() }
+    val workflow = Workflow.stateless<Boolean, Nothing, Unit> { input ->
+      if (input) onWorkerOutput(worker) { noop() }
     }
 
     workflow.testFromStart(false) {
@@ -136,8 +136,8 @@ class WorkerCompositionIntegrationTest {
 
   @Test fun `onWorkerOutputOrFinished gets output`() {
     val channel = Channel<String>(capacity = 1)
-    val workflow = Workflow.stateless<OutputOrFinished<String>, Unit> { context ->
-      context.onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
+    val workflow = Workflow.stateless<Unit, OutputOrFinished<String>, Unit> {
+      onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
     }
 
     workflow.testFromStart {
@@ -151,8 +151,8 @@ class WorkerCompositionIntegrationTest {
 
   @Test fun `onWorkerOutputOrFinished gets finished`() {
     val channel = Channel<String>()
-    val workflow = Workflow.stateless<OutputOrFinished<String>, Unit> { context ->
-      context.onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
+    val workflow = Workflow.stateless<Unit, OutputOrFinished<String>, Unit> {
+      onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
     }
 
     workflow.testFromStart {
@@ -166,8 +166,8 @@ class WorkerCompositionIntegrationTest {
 
   @Test fun `onWorkerOutputOrFinished gets finished after value`() {
     val channel = Channel<String>()
-    val workflow = Workflow.stateless<OutputOrFinished<String>, Unit> { context ->
-      context.onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
+    val workflow = Workflow.stateless<Unit, OutputOrFinished<String>, Unit> {
+      onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
     }
 
     workflow.testFromStart {
@@ -185,8 +185,8 @@ class WorkerCompositionIntegrationTest {
 
   @Test fun `onWorkerOutputOrFinished gets error`() {
     val channel = Channel<String>()
-    val workflow = Workflow.stateless<OutputOrFinished<String>, Unit> { context ->
-      context.onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
+    val workflow = Workflow.stateless<Unit, OutputOrFinished<String>, Unit> {
+      onWorkerOutputOrFinished(channel.asWorker()) { emitOutput(it) }
     }
 
     workflow.testFromStart {
@@ -210,8 +210,8 @@ class WorkerCompositionIntegrationTest {
 
   @Test fun `onWorkerOutput does nothing when worker finished`() {
     val channel = Channel<Unit>()
-    val workflow = Workflow.stateless<Unit, Unit> { context ->
-      context.onWorkerOutput(channel.asWorker()) { fail("Expected handler to not be invoked.") }
+    val workflow = Workflow.stateless<Unit, Unit, Unit> {
+      onWorkerOutput(channel.asWorker()) { fail("Expected handler to not be invoked.") }
     }
 
     workflow.testFromStart {

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
@@ -105,8 +105,8 @@ class WorkflowCompositionIntegrationTest {
   // See https://github.com/square/workflow/issues/261.
   @Test fun `renderChild closes over latest state`() {
     val triggerChildOutput = Channel<Unit>()
-    val child = Workflow.stateless<Unit, Unit> { context ->
-      context.onWorkerOutput(triggerChildOutput.asWorker()) { emitOutput(Unit) }
+    val child = Workflow.stateless<Unit, Unit, Unit> {
+      onWorkerOutput(triggerChildOutput.asWorker()) { emitOutput(Unit) }
     }
     val workflow = object : StatefulWorkflow<Unit, Int, Int, (Unit) -> Unit>() {
       override fun initialState(

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
@@ -30,7 +30,7 @@ import kotlin.test.fail
 class RenderTesterTest {
 
   @Test fun `stateless input and rendering`() {
-    val workflow = Workflow.stateless<String, String, String> { input, context ->
+    val workflow = Workflow.stateless<String, String, String> { input ->
       return@stateless "input: $input"
     } as StatelessWorkflow
 
@@ -64,7 +64,7 @@ class RenderTesterTest {
   }
 
   @Test fun `assert no composition`() {
-    val workflow = Workflow.stateless<Nothing, Unit> { Unit } as StatelessWorkflow
+    val workflow = Workflow.stateless<Unit, Nothing, Unit> { Unit } as StatelessWorkflow
 
     workflow.testRender {
       assertNoWorkflowsRendered()
@@ -74,8 +74,8 @@ class RenderTesterTest {
 
   @Test fun `renders child with input`() {
     val child = MockChildWorkflow<String, String> { "input: $it" }
-    val workflow = Workflow.stateless<Nothing, String> { context ->
-      "child: " + context.renderChild(child, "foo")
+    val workflow = Workflow.stateless<Unit, Nothing, String> {
+      "child: " + renderChild(child, "foo")
     } as StatelessWorkflow
 
     workflow.testRender {


### PR DESCRIPTION
Looking for feedback on whether this is actually nicer. This feels nice to me:
 - "context" types are often receivers in these sort of helper builder higher-order functions.
 - Don't need a separate override to make the input argument optional, since there's only one argument now.