### PR TITLE
Warnings are now errors.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -156,4 +156,14 @@ subprojects {
   afterEvaluate {
     project.tasks.findByName('check')?.dependsOn 'detekt'
   }
+
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+      kotlinOptions.allWarningsAsErrors = true
+
+      // Don't panic, all this does is allow us to use the @Experimental meta-annotation.
+      // to define our own experiments.
+      freeCompilerArgs += "-Xuse-experimental=kotlin.Experimental"
+    }
+  }
 }

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/CoroutineWorkflow.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/CoroutineWorkflow.kt
@@ -43,6 +43,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  * receiving fast enough, they will miss intermediate states.
  * The event channel has [unlimited capacity][UNLIMITED].
  */
+@Suppress("DEPRECATION")
 @Deprecated("Use com.squareup.workflow.Workflow")
 fun <S : Any, E : Any, O : Any> CoroutineScope.workflow(
   context: CoroutineContext = EmptyCoroutineContext,

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Reaction.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Reaction.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy
 
 /**

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Reactor.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Reactor.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/ReactorException.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/ReactorException.kt
@@ -21,6 +21,7 @@ package com.squareup.workflow.legacy
  * The message includes the name of the [Reactor] class and the result of calling [toString] on the
  * state of the `Reactor` at the time the exception was thrown.
  */
+@Suppress("DEPRECATION")
 @Deprecated("Use com.squareup.workflow.Workflow")
 class ReactorException(
   cause: Throwable,

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Renderer.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Renderer.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy
 
 /**

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Worker.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Worker.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy
 
 import com.squareup.workflow.legacy.WorkflowPool.Type

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Workflow.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Workflow.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy
 
 import kotlinx.coroutines.CancellationException

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowInput.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowInput.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy
 
 /**

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowOperators.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowOperators.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowPool.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowPool.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowUpdate.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowUpdate.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy
 
 /**

--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/CoroutineWorkflowTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/CoroutineWorkflowTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/ReactorAsWorkflowIntegrationTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/ReactorAsWorkflowIntegrationTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/ReactorIntegrationTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/ReactorIntegrationTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy
 
 import com.squareup.workflow.legacy.ReactorIntegrationTest.OuterEvent.Background

--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/WorkerTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/WorkerTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/WorkflowOperatorsTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/WorkflowOperatorsTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/WorkflowPoolTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/WorkflowPoolTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy
 

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/EventChannel.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/EventChannel.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy.rx2
 

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/EventSelectBuilder.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/EventSelectBuilder.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("DeprecatedCallableAddReplaceWith", "EXPERIMENTAL_API_USAGE")
+@file:Suppress("DeprecatedCallableAddReplaceWith", "EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy.rx2
 

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Reactor.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Reactor.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy.rx2
 
 import com.squareup.workflow.legacy.Reaction

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Workers.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Workers.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy.rx2
 
 import com.squareup.workflow.legacy.Worker

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/WorkflowOperators.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/WorkflowOperators.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy.rx2
 

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Workflows.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Workflows.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("EXPERIMENTAL_API_USAGE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
 
 package com.squareup.workflow.legacy.rx2
 

--- a/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/Rx2ReactorIntegrationTest.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/Rx2ReactorIntegrationTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy.rx2
 
 import com.squareup.workflow.legacy.EnterState

--- a/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/Rx2WorkflowPoolIntegrationTest.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/Rx2WorkflowPoolIntegrationTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy.rx2
 
 import com.squareup.workflow.legacy.EnterState

--- a/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/WorkerIntegrationTest.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/WorkerIntegrationTest.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy.rx2
 
 import com.squareup.workflow.legacy.Worker

--- a/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/WorkflowOperatorsTest.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/WorkflowOperatorsTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.squareup.workflow.legacy.rx2
 
 import com.squareup.workflow.legacy.Workflow

--- a/kotlin/legacy/legacy-workflow-test/src/main/java/com/squareup/workflow/legacy/test/Assertions.kt
+++ b/kotlin/legacy/legacy-workflow-test/src/main/java/com/squareup/workflow/legacy/test/Assertions.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:JvmName("Assertions")
+@file:Suppress("DEPRECATION")
 
 package com.squareup.workflow.legacy.test
 

--- a/kotlin/legacy/legacy-workflow-test/src/main/java/com/squareup/workflow/legacy/test/rx2/EventChannels.kt
+++ b/kotlin/legacy/legacy-workflow-test/src/main/java/com/squareup/workflow/legacy/test/rx2/EventChannels.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @file:JvmName("EventChannels")
+@file:Suppress("DEPRECATION")
 
 package com.squareup.workflow.legacy.test.rx2
 

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragmentActivity.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragmentActivity.kt
@@ -18,7 +18,6 @@ package com.squareup.sample.helloworkflowfragment
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 
-@Suppress("EXPERIMENTAL_API_USAGE")
 class HelloWorkflowFragmentActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/kotlin/workflow-core/build.gradle
+++ b/kotlin/workflow-core/build.gradle
@@ -23,12 +23,6 @@ targetCompatibility = JavaVersion.VERSION_1_7
 
 dokka rootProject.ext.defaultDokkaConfig
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-  kotlinOptions {
-    freeCompilerArgs += "-Xuse-experimental=kotlin.Experimental"
-  }
-}
-
 dependencies {
   compileOnly deps.annotations.intellij
 

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -27,12 +27,6 @@ android.packagingOptions {
   exclude 'META-INF/atomicfu.kotlin_module'
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-  kotlinOptions {
-    freeCompilerArgs += "-Xuse-experimental=kotlin.Experimental"
-  }
-}
-
 dependencies {
   api project(':workflow-core')
   api project(':workflow-ui-core')


### PR DESCRIPTION
Suppresses delegation warnings like crazy, but only in legacy code. Good job
us!