### PR TITLE
Handle `Actions` from a sink synchronously.

### DIFF
--- a/swift/Samples/SampleApp/Sources/DemoScreen.swift
+++ b/swift/Samples/SampleApp/Sources/DemoScreen.swift
@@ -7,6 +7,9 @@ struct DemoScreen: Screen {
     let color: UIColor
     let onTitleTap: () -> Void
 
+    let subscribeTitle: String
+    let onSubscribeTapped: () -> Void
+
     let refreshText: String
     let isRefreshEnabled: Bool
     let onRefreshTap: () -> Void
@@ -25,11 +28,13 @@ extension ViewRegistry {
 fileprivate final class DemoViewController: ScreenViewController<DemoScreen> {
 
     private let titleButton: UIButton
+    private let subscribeButton: UIButton
     private let statusLabel: UILabel
     private let refreshButton: UIButton
 
     required init(screen: DemoScreen, viewRegistry: ViewRegistry) {
         titleButton = UIButton(frame: .zero)
+        subscribeButton = UIButton(frame: .zero)
         statusLabel = UILabel(frame: .zero)
         refreshButton = UIButton(frame: .zero)
         super.init(screen: screen, viewRegistry: viewRegistry)
@@ -42,12 +47,15 @@ fileprivate final class DemoViewController: ScreenViewController<DemoScreen> {
 
         titleButton.addTarget(self, action: #selector(titleButtonPressed(sender:)), for: .touchUpInside)
 
+        subscribeButton.addTarget(self, action: #selector(subscribePressed(sender:)), for: .touchUpInside)
+
         statusLabel.textAlignment = .center
 
         refreshButton.addTarget(self, action: #selector(refreshButtonPressed(sender:)), for: .touchUpInside)
         refreshButton.setTitle("Reverse!", for: .normal)
 
         view.addSubview(titleButton)
+        view.addSubview(subscribeButton)
         view.addSubview(statusLabel)
         view.addSubview(refreshButton)
     }
@@ -55,12 +63,23 @@ fileprivate final class DemoViewController: ScreenViewController<DemoScreen> {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        let (top, bottom) = view.bounds.divided(atDistance: view.bounds.height / 2, from: CGRectEdge.minYEdge)
+        let height: CGFloat = 44.0
+        let inset: CGFloat = 12.0
+
+        var (top, bottom) = view.bounds.divided(atDistance: view.bounds.height / 2, from: CGRectEdge.minYEdge)
+
+        top.size.height -= (height / 2.0)
+        bottom.origin.y += (height)
+        bottom.size.height -= (height / 2.0)
 
         titleButton.frame = top
 
-        let height: CGFloat = 44.0
-        let inset: CGFloat = 12.0
+        subscribeButton.frame = CGRect(
+            x: 0.0,
+            y: top.maxY,
+            width: top.size.width,
+            height: height)
+
         let yOffset = bottom.midY - (height / 2.0)
 
         refreshButton.frame = CGRect(
@@ -85,6 +104,9 @@ fileprivate final class DemoViewController: ScreenViewController<DemoScreen> {
         titleButton.setTitle(screen.title, for: .normal)
         titleButton.backgroundColor = screen.color
 
+        subscribeButton.setTitle(screen.subscribeTitle, for: .normal)
+        subscribeButton.backgroundColor = .black
+
         statusLabel.text = screen.refreshText
 
         refreshButton.isEnabled = screen.isRefreshEnabled
@@ -97,6 +119,10 @@ fileprivate final class DemoViewController: ScreenViewController<DemoScreen> {
 
     @objc private func titleButtonPressed(sender: UIButton) {
         screen.onTitleTap()
+    }
+
+    @objc private func subscribePressed(sender: UIButton) {
+        screen.onSubscribeTapped()
     }
 
     @objc private func refreshButtonPressed(sender: UIButton) {

--- a/swift/Workflow/Sources/WorkflowHost.swift
+++ b/swift/Workflow/Sources/WorkflowHost.swift
@@ -43,6 +43,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
 
         self.mutableRendering = MutableProperty(self.rootNode.render())
         self.rendering = Property(mutableRendering)
+        self.rootNode.enableEvents()
 
         debugger?.didEnterInitialState(snapshot: self.rootNode.makeDebugSnapshot())
 
@@ -62,6 +63,8 @@ public final class WorkflowHost<WorkflowType: Workflow> {
         debugger?.didUpdate(
             snapshot: rootNode.makeDebugSnapshot(),
             updateInfo: output.debugInfo)
+
+        rootNode.enableEvents()
     }
 
     /// A signal containing output events emitted by the root workflow in the hierarchy.

--- a/swift/Workflow/Sources/WorkflowNode.swift
+++ b/swift/Workflow/Sources/WorkflowNode.swift
@@ -64,6 +64,10 @@ final class WorkflowNode<WorkflowType: Workflow> {
         }
     }
 
+    func enableEvents() {
+        subtreeManager.enableEvents()
+    }
+
     /// Updates the workflow.
     func update(workflow: WorkflowType) {
         workflow.workflowDidChange(from: self.workflow, state: &state)

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -1,0 +1,258 @@
+import XCTest
+@testable import Workflow
+
+import ReactiveSwift
+import Result
+
+
+final class ConcurrencyTests: XCTestCase {
+
+    // Applying an action from a sink must synchronously update the rendering.
+    func test_sinkRenderLoopIsSynchronous() {
+        let host = WorkflowHost(workflow: TestWorkflow())
+
+        let expectation = XCTestExpectation()
+        var first = true
+        var observedScreen: TestWorkflow.TestScreen? = nil
+
+        let disposable = host.rendering.signal.observeValues { rendering in
+            if first {
+                expectation.fulfill()
+                first = false
+            }
+            observedScreen = rendering
+        }
+
+        let initialScreen = host.rendering.value
+        XCTAssertEqual(0, initialScreen.count)
+        initialScreen.update()
+
+        // This update happens immediately as a new rendering is generated synchronously.
+        XCTAssertEqual(1, host.rendering.value.count)
+
+        wait(for: [expectation], timeout: 1.0)
+        guard let screen = observedScreen else {
+            XCTFail("Screen was not updated.")
+            disposable?.dispose()
+            return
+        }
+        XCTAssertEqual(1, screen.count)
+
+        disposable?.dispose()
+    }
+
+    // Events emitted between `render` on a workflow and `enableEvents` are queued and will be delivered immediately when `enableEvents` is called.
+    func test_queuedEvents() {
+        let host = WorkflowHost(workflow: TestWorkflow())
+
+        let expectation = XCTestExpectation()
+        var first = true
+
+        let disposable = host.rendering.signal.observeValues { rendering in
+            if first {
+                expectation.fulfill()
+                first = false
+                // Emit an event when the rendering is first received.
+                rendering.update()
+            }
+        }
+
+        let initialScreen = host.rendering.value
+        XCTAssertEqual(0, initialScreen.count)
+
+        // Updating the screen will cause two events - the `update` here, and the update caused by the first time the rendering changes.
+        initialScreen.update()
+
+        XCTAssertEqual(2, host.rendering.value.count)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        disposable?.dispose()
+    }
+
+    // When events are queued, the debug info must be received in the order the events were processed.
+    // This is to validate that `enableEvents` is tail recursive when handled by the WorkflowHost.
+    func test_debugEventsAreOrdered() {
+        final class Debugger: WorkflowDebugger {
+            var snapshots: [WorkflowHierarchyDebugSnapshot] = []
+
+            func didEnterInitialState(snapshot: WorkflowHierarchyDebugSnapshot) {
+                // nop
+            }
+
+            func didUpdate(snapshot: WorkflowHierarchyDebugSnapshot, updateInfo: WorkflowUpdateDebugInfo) {
+                snapshots.append(snapshot)
+            }
+        }
+
+        let debugger = Debugger()
+        let host = WorkflowHost(workflow: TestWorkflow(), debugger: debugger)
+
+        var first = true
+        let disposable = host.rendering.signal.observeValues { rendering in
+            if first {
+                first = false
+                rendering.update()
+            }
+        }
+
+        let initialScreen = host.rendering.value
+        initialScreen.update()
+
+        XCTAssertEqual(2, debugger.snapshots.count)
+        XCTAssertEqual("1", debugger.snapshots[0].stateDescription)
+        XCTAssertEqual("2", debugger.snapshots[1].stateDescription)
+
+        disposable?.dispose()
+    }
+
+    // Signals are subscribed on a different scheduler than the UI scheduler,
+    // which means that if they fire immediately, the action will be received after
+    // `render` has completed.
+    func test_subscriptionsAreAsync() {
+        let signal = TestSignal()
+        let host = WorkflowHost(
+            workflow: TestWorkflow(
+                running: .signal,
+                signal: signal))
+
+        let expectation = XCTestExpectation()
+        let disposable = host.rendering.signal.observeValues { rendering in
+            expectation.fulfill()
+        }
+
+        let screen = host.rendering.value
+
+        XCTAssertEqual(0, screen.count)
+
+        signal.send(value: 1)
+
+        XCTAssertEqual(0, host.rendering.value.count)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(1, host.rendering.value.count)
+
+        disposable?.dispose()
+    }
+
+    // Workers are subscribed on a different scheduler than the UI scheduler,
+    // which means that if they fire immediately, the action will be received after
+    // `render` has completed.
+    func test_workersAreAsync() {
+        let host = WorkflowHost(
+            workflow: TestWorkflow(
+                running: .worker))
+
+        let expectation = XCTestExpectation()
+        let disposable = host.rendering.signal.observeValues { rendering in
+            expectation.fulfill()
+        }
+
+        XCTAssertEqual(0, host.rendering.value.count)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(1, host.rendering.value.count)
+
+        disposable?.dispose()
+    }
+
+    fileprivate class TestSignal {
+        let (signal, observer) = Signal<Int, NoError>.pipe()
+        var sent: Bool = false
+
+        func send(value: Int) {
+            if !sent {
+                observer.send(value: value)
+                sent = true
+            }
+        }
+    }
+
+    fileprivate struct TestWorkflow: Workflow {
+
+        init(running: Running = .idle, signal: TestSignal = TestSignal()) {
+            self.running = running
+            self.signal = signal
+        }
+
+        var running: Running
+        enum Running {
+            case idle
+            case signal
+            case worker
+        }
+        var signal: TestSignal
+
+        struct State: CustomStringConvertible {
+            var count: Int
+            var running: Running
+            var signal: TestSignal
+
+            var description: String {
+                return "\(count)"
+            }
+        }
+
+        func makeInitialState() -> ConcurrencyTests.TestWorkflow.State {
+            return State(count: 0, running: self.running, signal: self.signal)
+        }
+
+        func workflowDidChange(from previousWorkflow: ConcurrencyTests.TestWorkflow, state: inout ConcurrencyTests.TestWorkflow.State) {
+        }
+
+        enum Action: WorkflowAction {
+            typealias WorkflowType = TestWorkflow
+
+            case update
+
+            func apply(toState state: inout ConcurrencyTests.TestWorkflow.State) -> ConcurrencyTests.TestWorkflow.Output? {
+                switch self {
+                case .update:
+                    state.count += 1
+                    return nil
+                }
+            }
+        }
+
+        struct TestScreen {
+            var count: Int
+            var update: () -> Void
+        }
+
+        typealias Rendering = TestScreen
+
+        func render(state: ConcurrencyTests.TestWorkflow.State, context: RenderContext<ConcurrencyTests.TestWorkflow>) -> ConcurrencyTests.TestWorkflow.TestScreen {
+
+            switch state.running {
+            case .idle:
+                break
+            case .signal:
+                context.subscribe(signal: signal.signal.map({ _ -> Action in
+                    return .update
+                }))
+
+            case .worker:
+                context.awaitResult(for: TestWorker())
+            }
+
+            let sink = context.makeSink(of: Action.self)
+
+            return TestScreen(
+                count: state.count,
+                update: { sink.send(.update) })
+        }
+
+        struct TestWorker: Worker {
+            typealias Output = TestWorkflow.Action
+
+            func run() -> SignalProducer<ConcurrencyTests.TestWorkflow.Action, NoError> {
+                return SignalProducer(value: .update)
+            }
+
+            func isEquivalent(to otherWorker: ConcurrencyTests.TestWorkflow.TestWorker) -> Bool {
+                return true
+            }
+        }
+    }
+}

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 @testable import Workflow
+import ReactiveSwift
+import Result
+
 
 final class SubtreeManagerTests: XCTestCase {
 
@@ -68,6 +71,7 @@ final class SubtreeManagerTests: XCTestCase {
                 key: "",
                 outputMap: { _ in AnyWorkflowAction.identity })
         }
+        manager.enableEvents()
 
         viewModel.onTap()
         viewModel.onTap()
@@ -94,6 +98,7 @@ final class SubtreeManagerTests: XCTestCase {
                 key: "",
                 outputMap: { _ in AnyWorkflowAction.identity })
         }
+        manager.enableEvents()
 
         viewModel.onToggle()
         viewModel.onToggle()
@@ -116,10 +121,164 @@ final class SubtreeManagerTests: XCTestCase {
                 key: "",
                 outputMap: { _ in AnyWorkflowAction.identity })
         }
-        
+        manager.enableEvents()
+
         XCTAssertFalse(escapingContext.isValid)
     }
 
+    // A worker declared on a first `render` pass that is not on a subsequent should have the work cancelled.
+    func test_cancelsWorkers() {
+        struct WorkerWorkflow: Workflow {
+            var startExpectation: XCTestExpectation
+            var endExpectation: XCTestExpectation
+
+            enum State {
+                case notWorking
+                case working
+            }
+
+            func makeInitialState() -> WorkerWorkflow.State {
+                return .notWorking
+            }
+
+            func workflowDidChange(from previousWorkflow: WorkerWorkflow, state: inout WorkerWorkflow.State) {
+
+            }
+
+            func render(state: WorkerWorkflow.State, context: RenderContext<WorkerWorkflow>) -> Bool {
+                switch state {
+                case .notWorking:
+                    return false
+                case .working:
+                    context.awaitResult(
+                        for: ExpectingWorker(
+                            startExpectation: startExpectation,
+                            endExpectation: endExpectation),
+                        outputMap: { output -> AnyWorkflowAction<WorkerWorkflow> in
+                            return AnyWorkflowAction.identity
+                        })
+                    return true
+                }
+            }
+
+            struct ExpectingWorker: Worker {
+                var startExpectation: XCTestExpectation
+                var endExpectation: XCTestExpectation
+
+                typealias Output = Void
+
+                func run() -> SignalProducer<Void, NoError> {
+                    return SignalProducer<Void, NoError>({ [weak startExpectation, weak endExpectation] (observer, lifetime) in
+                        lifetime.observeEnded {
+                            endExpectation?.fulfill()
+                        }
+
+                        startExpectation?.fulfill()
+                    })
+                }
+
+                func isEquivalent(to otherWorker: WorkerWorkflow.ExpectingWorker) -> Bool {
+                    return true
+                }
+            }
+        }
+
+        let startExpectation = XCTestExpectation()
+        let endExpectation = XCTestExpectation()
+        let manager = WorkflowNode<WorkerWorkflow>.SubtreeManager()
+
+        let isRunning = manager.render({ context -> Bool in
+            WorkerWorkflow(
+                startExpectation: startExpectation,
+                endExpectation: endExpectation)
+                .render(
+                    state: .working,
+                    context: context)
+        })
+
+        XCTAssertEqual(true, isRunning)
+        wait(for: [startExpectation], timeout: 1.0)
+
+        let isStillRunning = manager.render({ context -> Bool in
+            WorkerWorkflow(
+                startExpectation: startExpectation,
+                endExpectation: endExpectation)
+                .render(
+                    state: .notWorking,
+                    context: context)
+        })
+
+        XCTAssertFalse(isStillRunning)
+        wait(for: [endExpectation], timeout: 1.0)
+    }
+
+    func test_subscriptionsUnsubscribe() {
+        struct SubscribingWorkflow: Workflow {
+            var signal: Signal<Void, NoError>?
+
+            struct State {}
+
+            func makeInitialState() -> SubscribingWorkflow.State {
+                return State()
+            }
+
+            func workflowDidChange(from previousWorkflow: SubscribingWorkflow, state: inout SubscribingWorkflow.State) {
+            }
+
+            func render(state: SubscribingWorkflow.State, context: RenderContext<SubscribingWorkflow>) -> Bool {
+                if let signal = signal {
+                    context.subscribe(signal: signal.map({ _ -> AnyWorkflowAction<SubscribingWorkflow> in
+                        return AnyWorkflowAction.identity
+                    }))
+                    return true
+                } else {
+                    return false
+                }
+            }
+        }
+
+        let emittedExpectation = XCTestExpectation()
+        let notEmittedExpectation = XCTestExpectation()
+        notEmittedExpectation.isInverted = true
+
+        let manager = WorkflowNode<SubscribingWorkflow>.SubtreeManager()
+        manager.onUpdate = { output in
+            emittedExpectation.fulfill()
+        }
+
+        let (signal, observer) = Signal<Void, NoError>.pipe()
+
+        let isSubscribing = manager.render { context -> Bool in
+            SubscribingWorkflow(
+                signal: signal)
+                .render(
+                    state: SubscribingWorkflow.State(),
+                    context: context)
+        }
+        manager.enableEvents()
+
+        XCTAssertTrue(isSubscribing)
+        observer.send(value: ())
+        wait(for: [emittedExpectation], timeout: 1.0)
+
+        manager.onUpdate = { output in
+            notEmittedExpectation.fulfill()
+        }
+
+        let isStillSubscribing = manager.render { context -> Bool in
+            SubscribingWorkflow(
+                signal: nil)
+                .render(
+                    state: SubscribingWorkflow.State(),
+                    context: context)
+        }
+        manager.enableEvents()
+
+        XCTAssertFalse(isStillSubscribing)
+
+        observer.send(value: ())
+        wait(for: [notEmittedExpectation], timeout: 1.0)
+    }
 }
 
 

--- a/swift/Workflow/Tests/WorkflowNodeTests.swift
+++ b/swift/Workflow/Tests/WorkflowNodeTests.swift
@@ -34,6 +34,7 @@ final class WorkflowNodeTests: XCTestCase {
         let node = WorkflowNode(workflow: workflow)
 
         let rendering = node.render()
+        node.enableEvents()
 
         var outputs: [WorkflowType.Output] = []
 
@@ -73,9 +74,17 @@ final class WorkflowNodeTests: XCTestCase {
             }
         }
 
-        node.render().aRendering.toggle()
-        node.render().aRendering.toggle()
-        node.render().aRendering.toggle()
+        var aRendering = node.render().aRendering
+        node.enableEvents()
+        aRendering.toggle()
+
+        aRendering = node.render().aRendering
+        node.enableEvents()
+        aRendering.toggle()
+
+        aRendering = node.render().aRendering
+        node.enableEvents()
+        aRendering.toggle()
 
         wait(for: [expectation], timeout: 1.0)
 
@@ -93,6 +102,7 @@ final class WorkflowNodeTests: XCTestCase {
         let node = WorkflowNode(workflow: workflow)
 
         let rendering = node.render()
+        node.enableEvents()
 
         var emittedDebugInfo: [WorkflowUpdateDebugInfo] = []
 
@@ -228,6 +238,7 @@ final class WorkflowNodeTests: XCTestCase {
         }
 
         node.render()
+        node.enableEvents()
 
         wait(for: [expectation], timeout: 1.0)
 

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -151,6 +151,15 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         return workflow.render(state: testContext.state, context: context)
     }
 
+    func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where Action : WorkflowAction, T == Action.WorkflowType {
+        let (signal, observer) = Signal<AnyWorkflowAction<WorkflowType>, NoError>.pipe()
+        let sink = Sink<Action> { action in
+            observer.send(value: AnyWorkflowAction(action))
+        }
+        subscribe(signal: signal)
+        return sink
+    }
+
     func subscribe<Action>(signal: Signal<Action, NoError>) where Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
         signal
             .take(during: lifetime)


### PR DESCRIPTION
This guarantees that an action being applied from a sink
will immediately cause a render pass, providing a new sink to
the UI side, and prevents lost events.

Additionally, fixes that the SignalProducer from a worker
was not being cancelled on a subsequent render pass if it
was not declared.

Fixes #348