### PR TITLE
Make RenderTester not require specific Mock* workflows/workers.

### DIFF
--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -216,7 +216,7 @@ class TestRenderResult<StateT, OutputT : Any, RenderingT> internal constructor(
         ?: throw AssertionError("Expected workflow to be rendered: $workflow (key=\"$key\")")
   }
 
-  internal fun <T> findWorkerCase(
+  private fun <T> findWorkerCase(
     worker: Worker<T>,
     key: String
   ): WorkerCase<T, StateT, OutputT> {
@@ -243,21 +243,13 @@ private class TestOnlyRenderContext<S, O : Any> : RenderContext<S, O>, Renderer<
     input: ChildInputT,
     key: String,
     handler: (ChildOutputT) -> WorkflowAction<S, O>
-  ): ChildRenderingT {
-    require(child is MockChildWorkflow) {
-      "Expected child workflow to be a MockChildWorkflow: $child (key=\"$key\")"
-    }
-    return realContext.renderChild(child, input, key, handler)
-  }
+  ): ChildRenderingT = realContext.renderChild(child, input, key, handler)
 
   override fun <T> onWorkerOutputOrFinished(
     worker: Worker<T>,
     key: String,
     handler: (OutputOrFinished<T>) -> WorkflowAction<S, O>
-  ) {
-    require(worker is MockWorker) { "Expected worker to be a MockWorker: $worker (key=\"$key\")" }
-    return realContext.onWorkerOutputOrFinished(worker, key, handler)
-  }
+  ) = realContext.onWorkerOutputOrFinished(worker, key, handler)
 
   override fun <ChildInputT, ChildOutputT : Any, ChildRenderingT> render(
     case: WorkflowOutputCase<ChildInputT, ChildOutputT, S, O>,


### PR DESCRIPTION
`RenderTester` currently requires all child workflows and workers that the workflow-under-test delegates to to be instances of `MockChildWorkflow` or `MockWorker`, respectively. This makes tests super verbose because if the actual type of a child workflow is a subinterface of `Workflow`, you need to actually implement that interface and can only use the mocks to do implementation-by-delegation, forcing you to repeat all the generics. It's extremely verbose. By removing this restriction, we can use mocking libraries to generate basic implementations of interfaces that should still work with the tester because all the assertion methods actually talk to the test context.

@rjrjr I want to land this in 0.16.1 as well, because I want to be able to use `RenderTester`.