### PR TITLE
Change RenderContext.onEvent return type to be a raw function type.

### DIFF
--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -42,7 +42,6 @@ import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
-import com.squareup.workflow.invoke
 import com.squareup.workflow.onWorkerOutput
 import com.squareup.workflow.rx2.asWorker
 import com.squareup.workflow.ui.AlertContainerScreen
@@ -222,8 +221,8 @@ class RealRunGameWorkflow(
     message: String = "Do you really want to concede the game?",
     positive: String = "I Quit",
     negative: String = "No",
-    confirmQuit: EventHandler<Unit> = EventHandler { },
-    continuePlaying: EventHandler<Unit> = EventHandler { }
+    confirmQuit: (Unit) -> Unit = EventHandler { },
+    continuePlaying: (Unit) -> Unit = EventHandler { }
   ): AlertScreen {
     return AlertScreen(
         buttons = mapOf(
@@ -234,11 +233,11 @@ class RealRunGameWorkflow(
         onEvent = { alertEvent ->
           when (alertEvent) {
             is ButtonClicked -> when (alertEvent.button) {
-              POSITIVE -> confirmQuit()
-              NEGATIVE -> continuePlaying()
+              POSITIVE -> confirmQuit(Unit)
+              NEGATIVE -> continuePlaying(Unit)
               NEUTRAL -> throw IllegalArgumentException()
             }
-            Canceled -> continuePlaying()
+            Canceled -> continuePlaying(Unit)
           }
         }
     )

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -62,12 +62,28 @@ interface RenderContext<StateT, in OutputT : Any> {
    *      }
    *    )
    *
+   * ## Equivalence & Testing
+   *
+   * It is common in unit tests to get a rendering from a workflow, then (since renderings should be
+   * value types) create the expected rendering instance and compare them. However, when comparing
+   * renderings there is no meaningful way to compare event handlers (other than a null check if
+   * they're nullable), and so two renderings that are identical but have different event handler
+   * functions should still be considered equal. In order to support this pattern, the functions
+   * returned by this method are all considered equal: `foo == bar` whenever `foo` and `bar` are
+   * values returned by this method. More precisely, this function returns instances of
+   * [EventHandler], and all [EventHandler] instances are considered equal.
+   *
+   * However, since event handling functions are always valid only for the rendering for which they
+   * were created, this means that you can't dedup event handlers in production (e.g. with something
+   * like RxJava's `distinctUntilChanged`). Event handlers must _always_ be updated, and if you
+   * need to de-dup other view data, you must do it at a more granular level.
+   *
    * @param handler A function that returns the [WorkflowAction] to perform when the event handler
    * is invoked.
    */
   fun <EventT : Any> onEvent(
     handler: (EventT) -> WorkflowAction<StateT, OutputT>
-  ): EventHandler<EventT>
+  ): (EventT) -> Unit
 
   /**
    * Ensures [child] is running as a child of this workflow, and returns the result of its

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
@@ -17,7 +17,6 @@
 
 package com.squareup.workflow.internal
 
-import com.squareup.workflow.EventHandler
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
@@ -27,7 +26,6 @@ import com.squareup.workflow.Worker.OutputOrFinished.Output
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.asWorker
-import com.squareup.workflow.invoke
 import com.squareup.workflow.parse
 import com.squareup.workflow.readUtf8WithLength
 import com.squareup.workflow.renderChild
@@ -301,7 +299,7 @@ class WorkflowNodeTest {
 
   @Test fun `worker is cancelled`() {
     val channel = Channel<String>(capacity = 0)
-    lateinit var doClose: EventHandler<Unit>
+    lateinit var doClose: (Unit) -> Unit
     val workflow = object : StringWorkflow() {
       override fun initialState(
         input: String,
@@ -334,7 +332,7 @@ class WorkflowNodeTest {
     runBlocking {
       node.render(workflow, "listen")
       assertFalse(channel.isClosedForSend)
-      doClose()
+      doClose(Unit)
 
       // This tick will process the event handler, it won't close the channel yet.
       withTimeout(1) {

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.workflow.testing
 
-import com.squareup.workflow.EventHandler
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
@@ -180,7 +179,7 @@ class RenderTesterTest {
   }
 
   @Test fun `getEventResult works`() {
-    val workflow = object : StatefulWorkflow<Unit, String, String, EventHandler<String>>() {
+    val workflow = object : StatefulWorkflow<Unit, String, String, (String) -> Unit>() {
       override fun initialState(
         input: Unit,
         snapshot: Snapshot?
@@ -190,7 +189,7 @@ class RenderTesterTest {
         input: Unit,
         state: String,
         context: RenderContext<String, String>
-      ): EventHandler<String> = context.onEvent { event ->
+      ): (String) -> Unit = context.onEvent { event ->
         enterState(
             newState = "from $state on $event",
             emittingOutput = "event: $event"


### PR DESCRIPTION
Also added some additional kdoc on this method.

Prepares for #385, in which `onEvent` will return either a unique function or an always-equivalent function
depending on whether it's being used from a test or not.