### PR TITLE
Use new builder inference for Worker.create so types can be inferred from emitOutput calls.

### DIFF
--- a/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -34,7 +34,7 @@ class BlinkingCursorWorkflow(
 
   private val cursorString = cursor.toString()
 
-  private val intervalWorker = Worker.create<Boolean> {
+  private val intervalWorker = Worker.create {
     var on = true
     while (true) {
       emitOutput(on)

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
+import kotlin.experimental.ExperimentalTypeInference
 import kotlin.reflect.KClass
 
 /**
@@ -183,9 +184,10 @@ interface Worker<out T> {
      * Note: If your worker just needs to perform side effects and doesn't need to emit anything,
      * use [createSideEffect] instead (since `Nothing` can't be used as a reified type parameter).
      */
+    @UseExperimental(ExperimentalTypeInference::class)
     inline fun <reified T> create(
       key: String = "",
-      noinline block: suspend Emitter<T>.() -> Unit
+      @BuilderInference noinline block: suspend Emitter<T>.() -> Unit
     ): Worker<T> = TypedWorker(T::class, key, block)
 
     /**

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
@@ -65,7 +65,7 @@ class WorkerTest {
   }
 
   @Test fun `create emits and finishes`() {
-    val worker = Worker.create<String> {
+    val worker = Worker.create {
       emitOutput("hello")
       emitOutput("world")
     }


### PR DESCRIPTION
While the `@BuilderInference` annotation is still experimental, I am not worried about the
risk of using here because the worst thing that can happen is the wrong type is inferred
and the call site needs to specify an explicit generic type, which is already required
right now.