### PR TITLE
Fixes BackStackContainer config change.

### DIFF
--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
@@ -32,11 +32,10 @@ import com.squareup.workflow.ui.BackStackScreen
 import com.squareup.workflow.ui.BuilderBinding
 import com.squareup.workflow.ui.ExperimentalWorkflowUi
 import com.squareup.workflow.ui.HandlesBack
-import com.squareup.workflow.ui.R
 import com.squareup.workflow.ui.Named
+import com.squareup.workflow.ui.R
 import com.squareup.workflow.ui.ViewBinding
 import com.squareup.workflow.ui.ViewRegistry
-import com.squareup.workflow.ui.backstack.ViewStateCache.SavedState
 import com.squareup.workflow.ui.bindShowRendering
 import com.squareup.workflow.ui.canShowRendering
 import com.squareup.workflow.ui.showRendering
@@ -54,8 +53,7 @@ open class BackStackContainer(
 ) : FrameLayout(context, attributeSet), HandlesBack {
   constructor(context: Context) : this(context, null)
 
-  private var restored: ViewStateCache? = null
-  private val viewStateCache by lazy { restored ?: ViewStateCache() }
+  private val viewStateCache = ViewStateCache()
 
   private val showing: View? get() = if (childCount > 0) getChildAt(0) else null
 
@@ -134,14 +132,13 @@ open class BackStackContainer(
   }
 
   override fun onSaveInstanceState(): Parcelable {
-    showing?.let { viewStateCache.save(it) }
-    return SavedState(super.onSaveInstanceState(), viewStateCache)
+    return ViewStateCache.SavedState(super.onSaveInstanceState(), viewStateCache)
   }
 
   override fun onRestoreInstanceState(state: Parcelable) {
-    (state as? SavedState)
+    (state as? ViewStateCache.SavedState)
         ?.let {
-          restored = it.viewStateCache
+          viewStateCache.restore(it.viewStateCache)
           super.onRestoreInstanceState(state.superState)
         }
         ?: super.onRestoreInstanceState(state)

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
@@ -31,9 +31,8 @@ import com.squareup.workflow.ui.showRenderingTag
  * showing a view for one at a time -- think back stacks or tab sets.
  *
  * This class implements [Parcelable] so that it can be preserved from
- * a container view's own [View.saveHierarchyState] method -- call [save] first.
- * A simple container can return [SavedState] from that method rather than
- * creating its own persistence class.
+ * a container view's own [View.saveHierarchyState] method. A simple container can
+ * return [SavedState] from that method rather than creating its own persistence class.
  */
 @ExperimentalWorkflowUi
 class ViewStateCache private constructor(
@@ -108,13 +107,12 @@ class ViewStateCache private constructor(
   }
 
   /**
-   * To be called from [View.saveHierarchyState] before serializing this instance,
-   * to ensure that the state of the currently visible view is saved.
+   * Replaces the state of the receiver with that of [from]. Typical usage is to call this from
+   * a container view's [View.onRestoreInstanceState].
    */
-  fun save(currentView: View) {
-    val saved = SparseArray<Parcelable>().apply { currentView.saveHierarchyState(this) }
-    val newFrame = ViewStateFrame(currentView.namedKey, saved)
-    viewStates += newFrame.key to newFrame
+  fun restore(from: ViewStateCache) {
+    viewStates.clear()
+    viewStates += from.viewStates
   }
 
   /**


### PR DESCRIPTION
Closes #400.

Our view persistence story got a lot simpler with the move to  `LayoutRunner`,
since we no longer try to render views before they have a complete rendering
to display. `BackStackContainer` didn't get the memo, and its assumption
that `onRestoreInstanceState` would come too late was breaking things.

Fix is simple, don't go like that.