### PR TITLE
Cleans up persistence of ModalContainer.

### DIFF
--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Named.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Named.kt
@@ -33,7 +33,7 @@ data class Named<W : Any>(
   /**
    * Used as a comparison key by [isCompatibleWith]. Handy for use as a map key.
    */
-  val key: String = ((wrapped as? Named<*>)?.key ?: wrapped::class.jvmName) + "-Named($name)"
+  val key: String = keyFor(wrapped, name)
 
   override fun isCompatibleWith(another: Named<W>): Boolean {
     return this.key == another.key && compatible(this.wrapped, another.wrapped)
@@ -41,5 +41,17 @@ data class Named<W : Any>(
 
   override fun toString(): String {
     return "${super.toString()}: $key"
+  }
+
+  companion object {
+    /**
+     * Calculates the [compatibility key][Named.key] for a given [value] and [name].
+     */
+    fun keyFor(
+      value: Any,
+      name: String = ""
+    ): String {
+      return ((value as? Named<*>)?.key ?: value::class.jvmName) + "-Named($name)"
+    }
   }
 }


### PR DESCRIPTION
No longer necessary to save body state now that views are not created until
they have something to render. Use the recursive compatibility check from
`Named` when deciding whether or not to restore saved dialog state.