### PR TITLE
Added Maven Central and Apache License 2.0 badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # workflow
 
+[![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
 
 An architecture that allows composable state machines to drive UI navigation and content, where the state machines are cleanly separated from UI code.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # workflow
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
+
 An architecture that allows composable state machines to drive UI navigation and content, where the state machines are cleanly separated from UI code.
 
 _**This project is currently experimental and the API subject to breaking changes without notice.**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # workflow
 
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
+[![CocoaPods compatible](https://img.shields.io/cocoapods/v/Workflow.svg)](https://cocoapods.org/pods/Workflow)
 [![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
 
 An architecture that allows composable state machines to drive UI navigation and content, where the state machines are cleanly separated from UI code.


### PR DESCRIPTION
The version number is taken from the published `workflow-core` artifact, but the link points to the page for all packages under the `com.squareup.workflow` group.