### PR TITLE
Replace updates channel with rendering/snapshot and output Flows on WorkflowHost

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -41,6 +41,7 @@ buildscript {
       'mockito': '2.7.5',
       'mockitoKotlin': '1.5.0',
       'rxjava2Extensions': '0.20.4',
+      'truth': '1.0-rc1',
   ]
 
   ext.deps = [
@@ -95,6 +96,7 @@ buildscript {
       ],
       'test': [
           'assertj': "org.assertj:assertj-core:${versions.assertj}",
+          'truth': "com.google.truth:truth:${versions.truth}",
           'junit': "junit:junit:${versions.junit}",
           'mockito': "org.mockito:mockito-core:${versions.mockito}",
           'hamcrestCore': "org.hamcrest:hamcrest-core:${versions.hamcrest}"

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/RealWorkflowHost.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/RealWorkflowHost.kt
@@ -1,0 +1,78 @@
+package com.squareup.workflow
+
+import com.squareup.workflow.WorkflowHost.RenderingAndSnapshot
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart.ATOMIC
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Implements the [WorkflowHost] interface by [launching][CoroutineScope.launch] a new coroutine
+ * on [start].
+ *
+ * @param context The context used to launch the runtime coroutine.
+ * @param run Gets invoked from a new coroutine started with `context`, and passed functions
+ * that will cause [renderingsAndSnapshots] and [outputs] to emit, respectively. If any exception
+ * is thrown, those Flows will both rethrow the exception.
+ */
+@UseExperimental(ExperimentalCoroutinesApi::class)
+internal class RealWorkflowHost<O : Any, R>(
+  context: CoroutineContext,
+  private val run: suspend (
+    onRendering: suspend (RenderingAndSnapshot<R>) -> Unit,
+    onOutput: suspend (O) -> Unit
+  ) -> Unit
+) : WorkflowHost<O, R> {
+
+  /**
+   * This must be a [SupervisorJob] because if any of the workflow coroutines fail, we will handle
+   * the error explicitly by using it to close the [renderingsAndSnapshots] and [outputs] streams.
+   */
+  private val scope = CoroutineScope(context + SupervisorJob(parent = context[Job]))
+
+  private val _renderingsAndSnapshots = ConflatedBroadcastChannel<RenderingAndSnapshot<R>>()
+  private val _outputs = BroadcastChannel<O>(capacity = 1)
+
+  private var job: Job? = null
+
+  @UseExperimental(FlowPreview::class)
+  override val renderingsAndSnapshots: Flow<RenderingAndSnapshot<R>>
+    get() = _renderingsAndSnapshots.asFlow()
+
+  @UseExperimental(FlowPreview::class)
+  override val outputs: Flow<O>
+    get() = _outputs.asFlow()
+
+  override fun start(): Job {
+    return job ?: scope
+        // We need to launch atomically so that, if scope is already cancelled, the coroutine is
+        // still allowed to handle the error by closing the channels.
+        .launch(start = ATOMIC) {
+          val result = runCatching {
+            run(_renderingsAndSnapshots::send, _outputs::send)
+          }
+          // We need to unwrap the cancellation exception so that we *complete* the channels instead
+          // of cancelling them if our coroutine was merely cancelled.
+          val error = result.exceptionOrNull()
+              ?.unwrapCancellationCause()
+          _renderingsAndSnapshots.close(error)
+          _outputs.close(error)
+          result.getOrThrow()
+        }
+        .also { job = it }
+  }
+}
+
+private tailrec fun Throwable.unwrapCancellationCause(): Throwable? {
+  if (this !is CancellationException) return this
+  return cause?.unwrapCancellationCause()
+}

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealWorkflowHostTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealWorkflowHostTest.kt
@@ -1,0 +1,323 @@
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.RealWorkflowHost
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.WorkflowHost.RenderingAndSnapshot
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers.Unconfined
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@UseExperimental(
+    InternalCoroutinesApi::class,
+    ExperimentalCoroutinesApi::class,
+    FlowPreview::class
+)
+class RealWorkflowHostTest {
+
+  private class ExpectedException : RuntimeException()
+
+  @Test fun `exception from run doesn't cancel base context`() {
+    val baseJob = Job()
+    val host = RealWorkflowHost<Nothing, Unit>(Unconfined + baseJob) { _, _ ->
+      throw ExpectedException()
+    }
+    val job = host.start()
+
+    assertFalse(baseJob.isCompleted)
+    assertTrue(job.isCancelled)
+  }
+
+  @Test fun `exception from run is propagated to start job`() {
+    val host = RealWorkflowHost<Nothing, Unit>(Unconfined) { _, _ ->
+      throw ExpectedException()
+    }
+    val job = host.start()
+
+    assertTrue(job.isCancelled)
+    assertTrue(job.getCancellationException().hasCause { it is ExpectedException })
+  }
+
+  @Suppress("ReplaceSingleLineLet")
+  @Test fun `exceptions from run are propagated to flows`() {
+    val host = RealWorkflowHost<Unit, Unit>(Unconfined) { _, _ ->
+      throw ExpectedException()
+    }
+    host.start()
+
+    runBlocking {
+      runCatching { host.renderingsAndSnapshots.first() }.apply {
+        assertTrue(exceptionOrNull().hasCause {
+          it is ExpectedException
+        })
+      }
+
+      runCatching { host.outputs.first() }.apply {
+        assertTrue(exceptionOrNull().hasCause {
+          it is ExpectedException
+        })
+      }
+    }
+  }
+
+  @Test fun `exceptions from renderings collector cancels host`() {
+    val host = RealWorkflowHost<Unit, Unit>(Unconfined) { onRendering, _ ->
+      onRendering(RenderingAndSnapshot(Unit, Snapshot.EMPTY))
+    }
+
+    val job = GlobalScope.launch(Unconfined + Job()) {
+      host.renderingsAndSnapshots.collect {
+        throw ExpectedException()
+      }
+    }
+    host.start()
+
+    assertTrue(job.getCancellationException().hasCause { it is ExpectedException })
+  }
+
+  @Test fun `exceptions from outputs collector cancels host`() {
+    val host = RealWorkflowHost<Unit, Unit>(Unconfined) { _, onOutput ->
+      onOutput(Unit)
+    }
+
+    val job = GlobalScope.launch(Unconfined) {
+      host.outputs.collect {
+        throw ExpectedException()
+      }
+    }
+    host.start()
+
+    assertTrue(job.getCancellationException().hasCause { it is ExpectedException })
+  }
+
+  @Test fun `cancelling start Job doesn't cancel base context`() {
+    val baseJob = Job()
+    val host = RealWorkflowHost<Unit, Unit>(Unconfined + baseJob, ::runForever)
+    val job = host.start()
+
+    job.cancel()
+    assertFalse(baseJob.isCompleted)
+  }
+
+  @Test fun `cancelling base context cancels host`() {
+    val baseJob = Job()
+    val host = RealWorkflowHost<Unit, Unit>(Unconfined + baseJob, ::runForever)
+    val job = host.start()
+
+    baseJob.cancel()
+    assertTrue(job.isCancelled)
+  }
+
+  @Test fun `cancelling start Job completes flows`() {
+    val baseJob = Job()
+    val host = RealWorkflowHost<Unit, Unit>(Unconfined + baseJob, ::runForever)
+    val renderingsJob = GlobalScope.launch(Unconfined) {
+      host.renderingsAndSnapshots.collect()
+    }
+    val outputsJob = GlobalScope.launch(Unconfined) {
+      host.outputs.collect()
+    }
+    val job = host.start()
+
+    job.cancel()
+
+    assertTrue(renderingsJob.isCompleted)
+    assertFalse(renderingsJob.isCancelled)
+    assertTrue(outputsJob.isCompleted)
+    assertFalse(outputsJob.isCancelled)
+  }
+
+  @Test fun `flows complete immediately when base context is already cancelled on start`() {
+    val baseJob = Job().apply { cancel() }
+    val host = RealWorkflowHost<Unit, Unit>(Unconfined + baseJob, ::runForever)
+    val renderingsJob = GlobalScope.launch(Unconfined) {
+      host.renderingsAndSnapshots.collect()
+    }
+    val outputsJob = GlobalScope.launch(Unconfined) {
+      host.outputs.collect()
+    }
+    host.start()
+
+    assertTrue(renderingsJob.isCompleted)
+    assertFalse(renderingsJob.isCancelled)
+    assertTrue(outputsJob.isCompleted)
+    assertFalse(outputsJob.isCancelled)
+  }
+
+  @Test fun `renderings flow replays to new collectors`() {
+    val host = RealWorkflowHost<Nothing, String>(Unconfined) { onRendering, _ ->
+      onRendering(RenderingAndSnapshot("foo", Snapshot.EMPTY))
+      suspendCancellableCoroutine<Nothing> { }
+    }
+    host.start()
+
+    val firstRendering = runBlocking { host.renderingsAndSnapshots.first() }
+    assertEquals("foo", firstRendering.rendering)
+  }
+
+  @Test fun `outputs flow does not replay to new collectors`() {
+    val trigger = CompletableDeferred<Unit>()
+    val host = RealWorkflowHost<String, Unit>(Unconfined) { _, onOutput ->
+      onOutput("one")
+      trigger.await()
+      onOutput("two")
+    }
+    host.start()
+
+    val outputs = GlobalScope.async(Unconfined) { host.outputs.toList() }
+    trigger.complete(Unit)
+    assertEquals(listOf("two"), runBlocking { outputs.await() })
+  }
+
+  @Test fun `renderings flow is multicasted`() {
+    val host = RealWorkflowHost<Nothing, String>(Unconfined) { onRendering, _ ->
+      onRendering(RenderingAndSnapshot("one", Snapshot.EMPTY))
+      onRendering(RenderingAndSnapshot("two", Snapshot.EMPTY))
+    }
+    val renderings1 = GlobalScope.async(Unconfined) {
+      host.renderingsAndSnapshots.map { it.rendering }
+          .toList()
+    }
+    val renderings2 = GlobalScope.async(Unconfined) {
+      host.renderingsAndSnapshots.map { it.rendering }
+          .toList()
+    }
+    host.start()
+
+    assertEquals(listOf("one", "two"), runBlocking { renderings1.await() })
+    assertEquals(listOf("one", "two"), runBlocking { renderings2.await() })
+  }
+
+  @Test fun `outputs flow is multicasted`() {
+    val host = RealWorkflowHost<String, Unit>(Unconfined) { _, onOutput ->
+      onOutput("one")
+      onOutput("two")
+    }
+    val outputs1 = GlobalScope.async(Unconfined) {
+      host.outputs.toList()
+    }
+    val outputs2 = GlobalScope.async(Unconfined) {
+      host.outputs.toList()
+    }
+    host.start()
+
+    assertEquals(listOf("one", "two"), runBlocking { outputs1.await() })
+    assertEquals(listOf("one", "two"), runBlocking { outputs2.await() })
+  }
+
+  @Test fun `start is idempotent`() {
+    var starts = 0
+    val host = RealWorkflowHost<Nothing, Unit>(Unconfined) { _, _ ->
+      starts++
+      suspendCancellableCoroutine<Nothing> { }
+    }
+
+    assertEquals(0, starts)
+    val job1 = host.start()
+    val job2 = host.start()
+    assertEquals(1, starts)
+    assertSame(job1, job2)
+
+    job2.cancel()
+
+    val job3 = host.start()
+    assertEquals(1, starts)
+    assertEquals(job2, job3)
+  }
+
+  @Test fun `renderings flow has no backpressure`() {
+    val host = RealWorkflowHost<Nothing, String>(Unconfined) { onRendering, _ ->
+      onRendering(RenderingAndSnapshot("one", Snapshot.EMPTY))
+      onRendering(RenderingAndSnapshot("two", Snapshot.EMPTY))
+      suspendCancellableCoroutine<Nothing> { }
+    }
+    host.start()
+
+    val firstRendering = runBlocking { host.renderingsAndSnapshots.first() }
+    assertEquals("two", firstRendering.rendering)
+  }
+
+  @Test fun `outputs flow has no backpressure when not subscribed`() {
+    val emittedOutputs = Channel<String>(UNLIMITED)
+    val host = RealWorkflowHost<String, Unit>(Unconfined) { _, onOutput ->
+      onOutput("one")
+      emittedOutputs.send("one")
+      onOutput("two")
+      emittedOutputs.send("two")
+      emittedOutputs.close()
+    }
+    host.start()
+
+    assertEquals("one", emittedOutputs.poll())
+    assertEquals("two", emittedOutputs.poll())
+  }
+
+  @Test fun `outputs flow honors backpressure`() {
+    val emittedOutputs = Channel<Int>(UNLIMITED)
+    val host = RealWorkflowHost<Int, Unit>(Unconfined) { _, onOutput ->
+      for (i in 0 until 10) {
+        onOutput(i)
+        emittedOutputs.send(i)
+      }
+      emittedOutputs.close()
+    }
+    val outputs = GlobalScope.produce(Unconfined, capacity = 0) {
+      host.outputs.collect {
+        send(it)
+      }
+    }
+    host.start()
+
+    // There is effectively a two-element buffer: the BroadcastChannel has a buffer of one, and
+    // the produce coroutine above acts as another buffer.
+    assertEquals(0, emittedOutputs.poll())
+    assertEquals(1, emittedOutputs.poll())
+    assertNull(emittedOutputs.poll())
+
+    // Reading one item out of the actual outputs Flow should allow another one to get buffered.
+    assertEquals(0, outputs.poll())
+    assertEquals(2, emittedOutputs.poll())
+    assertNull(emittedOutputs.poll())
+
+    assertEquals(1, outputs.poll())
+    assertEquals(3, emittedOutputs.poll())
+    assertNull(emittedOutputs.poll())
+    assertEquals(2, outputs.poll())
+  }
+
+  @Suppress("UNUSED_PARAMETER")
+  private suspend fun <O, R> runForever(
+    onRendering: suspend (RenderingAndSnapshot<R>) -> Unit,
+    onOutput: suspend (O) -> Unit
+  ) {
+    suspendCancellableCoroutine<Nothing> { }
+  }
+
+  private inline fun Throwable?.hasCause(predicate: (Throwable) -> Boolean): Boolean =
+    causeChain.any(predicate)
+
+  private val Throwable?.causeChain
+    get() = this?.let { e ->
+      generateSequence(e) { it.cause }
+    } ?: emptySequence()
+}

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -194,16 +194,8 @@ class WorkerCompositionIntegrationTest {
 
       channel.cancel(CancellationException(null, ExpectedException()))
 
-      assertFailsWith<CancellationException> {
+      assertFailsWith<ExpectedException> {
         awaitNextOutput()
-      }.also { error ->
-        // Search up the cause chain for the expected exception, since multiple CancellationExceptions
-        // may be chained together first.
-        val causeChain = generateSequence<Throwable>(error) { it.cause }
-        assertEquals(
-            1, causeChain.count { it is ExpectedException },
-            "Expected cancellation exception cause chain to include original cause."
-        )
       }
     }
   }

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -43,4 +43,7 @@ dependencies {
   implementation deps.kotlin.coroutines.core
   implementation deps.kotlin.coroutines.rx2
   implementation deps.kotlin.reflect
+
+  testImplementation deps.test.junit
+  testImplementation deps.test.truth
 }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
@@ -17,11 +17,11 @@
 
 package com.squareup.workflow.ui
 
-import androidx.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.annotation.CheckResult
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModelProviders
 import com.squareup.workflow.Workflow
 import io.reactivex.BackpressureStrategy.LATEST
 import io.reactivex.Flowable
@@ -47,11 +47,13 @@ interface WorkflowRunner<out OutputT> {
   fun onSaveInstanceState(outState: Bundle)
 
   /**
-   * A stream of the [output][OutputT] values emitted by the running
-   * [Workflow][com.squareup.workflow.Workflow].
+   * A stream of the [output][OutputT] values emitted by the running [Workflow].
    */
   val output: Flowable<out OutputT>
 
+  /**
+   * A stream of the rendering values emitted by the running [Workflow].
+   */
   val renderings: Observable<out Any>
 
   val viewRegistry: ViewRegistry

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
@@ -15,26 +15,39 @@
  */
 package com.squareup.workflow.ui
 
+import android.os.Bundle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import android.os.Bundle
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowHost
-import io.reactivex.BackpressureStrategy.BUFFER
 import io.reactivex.Flowable
 import io.reactivex.Observable
-import io.reactivex.disposables.CompositeDisposable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.asFlowable
 import kotlinx.coroutines.rx2.asObservable
+import org.jetbrains.annotations.TestOnly
+import java.util.concurrent.CancellationException
+import kotlin.coroutines.CoroutineContext
 import kotlin.reflect.jvm.jvmName
 
+@UseExperimental(ExperimentalCoroutinesApi::class)
 @ExperimentalWorkflowUi
 internal class WorkflowRunnerViewModel<OutputT : Any>(
   override val viewRegistry: ViewRegistry,
-  workflowUpdates: WorkflowHost<OutputT, Any>
+  private val workflowHost: WorkflowHost<OutputT, Any>,
+  private val context: CoroutineContext
 ) : ViewModel(), WorkflowRunner<OutputT> {
 
   /**
@@ -59,46 +72,69 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
       val hostFactory = WorkflowHost.Factory(dispatcher)
       val workflowHost = hostFactory.run(workflow, inputs, snapshot)
       @Suppress("UNCHECKED_CAST")
-      return WorkflowRunnerViewModel(viewRegistry, workflowHost) as T
+      return WorkflowRunnerViewModel(viewRegistry, workflowHost, dispatcher) as T
     }
   }
 
-  private val subs = CompositeDisposable()
+  private val snapshotJob = GlobalScope.launch(context) {
+    workflowHost.renderingsAndSnapshots
+        .map { it.snapshot }
+        .collect { lastSnapshot = it }
+  }
 
-  @Suppress("EXPERIMENTAL_API_USAGE")
-  private val updates =
-    workflowUpdates.updates.asObservable(Dispatchers.Unconfined)
-        .doOnNext { lastSnapshot = it.snapshot }
-        .replay(1)
-        .autoConnect(1) { subs.add(it) }
+  private var workflowJob: Job? = null
 
   private var lastSnapshot: Snapshot = Snapshot.EMPTY
 
-  override val renderings: Observable<out Any> = updates.map { it.rendering }
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  override val renderings: Observable<out Any> = workflowHost.renderingsAndSnapshots
+      .onCollect { startWorkflowHost() }
+      .map { it.rendering }
+      .asObservable()
 
-  override val output: Flowable<out OutputT> =
-    // Buffer on backpressure so outputs don't get lost.
-    updates.toFlowable(BUFFER)
-        .filter { it.output != null }
-        .map { it.output!! }
-        // DON'T replay, outputs are events.
-        .publish()
-        // Subscribe upstream immediately so we immediately start getting notified about outputs.
-        // If [renderings] triggers the upstream subscription before we do, if the workflow emits
-        // an output immediately we might not see it.
-        .autoConnect(0) { subs.add(it) }
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  override val output: Flowable<out OutputT> = workflowHost.outputs
+      .onCollect { startWorkflowHost() }
+      .asFlowable()
 
   override fun onCleared() {
-    // Has the side effect of closing the updates channel, which in turn
-    // will fire any tear downs registered by the root workflow.
-    subs.clear()
+    val cancellationException = CancellationException("WorkflowRunnerViewModel cleared.")
+    snapshotJob.cancel(cancellationException)
+    workflowJob?.cancel(cancellationException)
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
     outState.putParcelable(BUNDLE_KEY, PickledWorkflow(lastSnapshot))
   }
 
+  @TestOnly
+  internal fun clearForTest() = onCleared()
+
+  @TestOnly
+  internal fun getLastSnapshotForTest() = lastSnapshot
+
+  /**
+   * Starts the [workflowHost] and saves its job to [workflowJob].
+   *
+   * This call is idempotent and will always return the same Job, so we can just call it
+   * every time. And so by making this call inside of `onCollect()`, we basically get the
+   * nice effects of Rx's `autoConnect(1)` start up a shared stream the the first time
+   * someone "subscribes" / collects.
+   */
+  private fun startWorkflowHost() {
+    workflowJob = workflowHost.start()
+  }
+
   private companion object {
     val BUNDLE_KEY = WorkflowRunner::class.jvmName + "-workflow"
   }
+}
+
+/**
+ * Invokes `block` every time a new collector begins collecting this [Flow].
+ */
+@UseExperimental(ExperimentalCoroutinesApi::class)
+private fun <T> Flow<T>.onCollect(block: () -> Unit): Flow<T> = flow {
+  block()
+  emitAll(this@onCollect)
 }

--- a/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
+++ b/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
@@ -1,0 +1,107 @@
+package com.squareup.workflow.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.WorkflowHost
+import com.squareup.workflow.WorkflowHost.RenderingAndSnapshot
+import kotlinx.coroutines.Dispatchers.Unconfined
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+import org.junit.Test
+
+@UseExperimental(ExperimentalWorkflowUi::class, ExperimentalCoroutinesApi::class)
+class WorkflowRunnerViewModelTest {
+
+  @Suppress("RemoveRedundantSpreadOperator")
+  private val viewRegistry = ViewRegistry(*emptyArray<ViewBinding<*>>())
+
+  @Test fun hostStartedLazilyOnRenderingsSubscription() {
+    var started = false
+    val host = object : WorkflowHost<Nothing, Unit> {
+      override val renderingsAndSnapshots: Flow<RenderingAndSnapshot<Unit>> = emptyFlow()
+      override val outputs: Flow<Nothing> = emptyFlow()
+
+      override fun start(): Job {
+        started = true
+        return Job()
+      }
+    }
+    val runner = WorkflowRunnerViewModel(viewRegistry, host, Unconfined)
+
+    assertThat(started).isFalse()
+
+    runner.renderings.test()
+    assertThat(started).isTrue()
+  }
+
+  @Test fun hostStartedLazilyOnOutputsSubscription() {
+    var started = false
+    val host = object : WorkflowHost<Unit, Unit> {
+      override val renderingsAndSnapshots: Flow<RenderingAndSnapshot<Unit>> = emptyFlow()
+      override val outputs: Flow<Nothing> = emptyFlow()
+
+      override fun start(): Job {
+        started = true
+        return Job()
+      }
+    }
+    val runner = WorkflowRunnerViewModel(viewRegistry, host, Unconfined)
+
+    assertThat(started).isFalse()
+
+    runner.output.test()
+    assertThat(started).isTrue()
+  }
+
+  @Test fun snapshotUpdatedOnHostEmission() {
+    val snapshot1 = Snapshot.of("one")
+    val snapshot2 = Snapshot.of("two")
+    val snapshotsChannel = Channel<RenderingAndSnapshot<Unit>>(UNLIMITED)
+
+    val host = object : WorkflowHost<Unit, Unit> {
+      override val renderingsAndSnapshots: Flow<RenderingAndSnapshot<Unit>> = flow {
+        snapshotsChannel.consumeEach {
+          emit(it)
+        }
+      }
+      override val outputs: Flow<Nothing> = emptyFlow()
+
+      override fun start() = Job()
+    }
+    val runner = WorkflowRunnerViewModel(viewRegistry, host, Unconfined)
+
+    assertThat(runner.getLastSnapshotForTest()).isEqualTo(Snapshot.EMPTY)
+
+    snapshotsChannel.offer(RenderingAndSnapshot(Unit, snapshot1))
+    assertThat(runner.getLastSnapshotForTest()).isEqualTo(snapshot1)
+
+    snapshotsChannel.offer(RenderingAndSnapshot(Unit, snapshot2))
+    assertThat(runner.getLastSnapshotForTest()).isEqualTo(snapshot2)
+  }
+
+  @Test fun hostCancelledOnCleared() {
+    var cancelled = false
+    val host = object : WorkflowHost<Unit, Unit> {
+      override val renderingsAndSnapshots: Flow<RenderingAndSnapshot<Unit>> = emptyFlow()
+      override val outputs: Flow<Nothing> = emptyFlow()
+
+      private val job = Job().apply { invokeOnCompletion { cancelled = true } }
+
+      override fun start(): Job = job
+    }
+    val runner = WorkflowRunnerViewModel(viewRegistry, host, Unconfined)
+
+    assertThat(cancelled).isFalse()
+    runner.output.test()
+    assertThat(cancelled).isFalse()
+
+    runner.clearForTest()
+    assertThat(cancelled).isTrue()
+  }
+}


### PR DESCRIPTION
_There are two commits, the first just cleans up the existing `WorkflowHost` implementation to make the main change easier to implement and review._

The new Flows are backed by `BroadcastChannels`. The `renderingsAndSnapshots` Flow
is backed by a `ConflatedBroadcastChannel`, so it doesn't get backpressure and will
always emit the latest rendering + snapshot on collection. The `outputs` Flow is
a regular `BroadcastChannel` with a capacity of 1 (one more than the old channel,
which was unbuffered). `BroadcastChannel`s aren't allowed to be unbuffered, so while
this channel experiences backpressure, it's no longer perfect lock-step.

This change also updates all the internal consumers of `WorkflowHost`s to use the Flows.
Namely, `WorkflowTester` and `WorkflowRunnerViewModel`, the latter of which now simply
converts the `Flow`s to `Observable`s/`Flowable`s with `asObservable()`/`asFlowable()`.
