### PR TITLE
Moves Named.key up to Compatible.compatibilityKey.

### DIFF
--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
@@ -43,11 +43,10 @@ class ViewStateCache private constructor(
   /**
    * To be called when the set of hidden views changes but the visible view remains
    * the same. Any cached view state held for renderings that are not
-   * [compatible with][com.squareup.workflow.ui.Compatible.isCompatibleWith]
-   * those in [retaining] will be dropped.
+   * [compatible][com.squareup.workflow.ui.compatible] those in [retaining] will be dropped.
    */
   fun prune(retaining: Collection<Named<*>>) {
-    pruneKeys(retaining.map { it.key })
+    pruneKeys(retaining.map { it.compatibilityKey })
   }
 
   private fun pruneKeys(retaining: Collection<String>) {
@@ -78,7 +77,7 @@ class ViewStateCache private constructor(
   ): Boolean {
     val newKey = newView.namedKey
     val hiddenKeys = retainedRenderings.asSequence()
-        .map { it.key }
+        .map { it.compatibilityKey }
         .toSet()
         .apply {
           require(retainedRenderings.size == size) {
@@ -178,6 +177,6 @@ class ViewStateCache private constructor(
 
 @ExperimentalWorkflowUi
 private val View.namedKey: String
-  get() = checkNotNull((showRenderingTag?.showing as? Named<*>)?.key) {
+  get() = checkNotNull((showRenderingTag?.showing as? Named<*>)?.compatibilityKey) {
     "Expected $this to be showing a Named rendering, found ${showRenderingTag?.showing}"
   }

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Compatible.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Compatible.kt
@@ -17,8 +17,8 @@ package com.squareup.workflow.ui
 
 /**
  * Normally returns true if [me] and [you] are instances of the same class.
- * If that common class implements [Compatible],
- * `me.`[isCompatibleWith][Compatible.isCompatibleWith]`(you)` must also be true.
+ * If that common class implements [Compatible], both instances must also
+ * have the same [Compatible.compatibilityKey].
  *
  * A convenient way to take control over the matching behavior of objects that
  * don't implement [Compatible] is to wrap them with [Named].
@@ -29,9 +29,8 @@ fun compatible(
 ): Boolean {
   return when {
     me::class != you::class -> false
-    me !is Compatible<*> -> true
-    // If you see a casting error here, it's a lie. https://youtrack.jetbrains.com/issue/KT-31823
-    else -> me.isCompatibleWith(you as Compatible<*>)
+    me !is Compatible -> true
+    else -> me.compatibilityKey == (you as Compatible).compatibilityKey
   }
 }
 
@@ -40,8 +39,8 @@ fun compatible(
  * to be the top / current value of the stack.
  *
  * Returns a transformation of the receiver by popping back to the first element
- * that is [compatible] with [next]. If no matching frame is found, pushes [next]
- * on [top].
+ * that is [compatible] with [next]. If no matching frame is found, adds [next]
+ * to the end.
  */
 fun <T : Any> List<T>.goTo(next: T): List<T> {
   val splicePoint = indexOfLast { compatible(it, next) }
@@ -55,6 +54,9 @@ fun <T : Any> List<T>.goTo(next: T): List<T> {
  * Renderings that don't implement this interface directly can be distinguished
  * by wrapping them with [Named].
  */
-interface Compatible<out T : Compatible<T>> {
-  fun isCompatibleWith(another: @UnsafeVariance T): Boolean
+interface Compatible {
+  /**
+   * Instances of the same type are [compatible] iff they have the same [compatibilityKey].
+   */
+  val compatibilityKey: String
 }

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Named.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Named.kt
@@ -25,33 +25,26 @@ import kotlin.reflect.jvm.jvmName
 data class Named<W : Any>(
   val wrapped: W,
   val name: String
-) : Compatible<Named<W>> {
+) : Compatible {
   init {
     require(name.isNotBlank()) { "name must not be blank." }
   }
 
-  /**
-   * Used as a comparison key by [isCompatibleWith]. Handy for use as a map key.
-   */
-  val key: String = keyFor(wrapped, name)
-
-  override fun isCompatibleWith(another: Named<W>): Boolean {
-    return this.key == another.key && compatible(this.wrapped, another.wrapped)
-  }
+  override val compatibilityKey: String = keyFor(wrapped, name)
 
   override fun toString(): String {
-    return "${super.toString()}: $key"
+    return "${super.toString()}: $compatibilityKey"
   }
 
   companion object {
     /**
-     * Calculates the [compatibility key][Named.key] for a given [value] and [name].
+     * Calculates the [Named.compatibilityKey] for a given [value] and [name].
      */
     fun keyFor(
       value: Any,
       name: String = ""
     ): String {
-      return ((value as? Named<*>)?.key ?: value::class.jvmName) + "-Named($name)"
+      return ((value as? Compatible)?.compatibilityKey ?: value::class.jvmName) + "-Named($name)"
     }
   }
 }

--- a/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/CompatibleTest.kt
+++ b/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/CompatibleTest.kt
@@ -37,25 +37,17 @@ class CompatibleTest {
   }
 
   @Test fun `isCompatibleWith is honored`() {
-    data class K(
-      val name: String
-    ) : Compatible<K> {
-      override fun isCompatibleWith(another: K) = name == another.name
-    }
+    data class K(override val compatibilityKey: String) : Compatible
 
     assertThat(compatible(K("hey"), K("hey"))).isTrue()
     assertThat(compatible(K("hey"), K("ho"))).isFalse()
   }
 
   @Test fun `Different Compatible types do not match`() {
-    abstract class A : Compatible<A> {
-      abstract val name: String
+    abstract class A : Compatible
 
-      override fun isCompatibleWith(another: A) = name == another.name
-    }
-
-    class Able(override val name: String) : A()
-    class Alpha(override val name: String) : A()
+    class Able(override val compatibilityKey: String) : A()
+    class Alpha(override val compatibilityKey: String) : A()
 
     assertThat(compatible(Able("Hey"), Alpha("Hey"))).isFalse()
   }

--- a/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/NamedTest.kt
+++ b/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/NamedTest.kt
@@ -59,19 +59,38 @@ class NamedTest {
     ).isFalse()
   }
 
-  @Test fun keyRecursion() {
-    assertThat(Named(Named(Hey, "one"), "ho").key)
-        .isEqualTo(Named(Named(Hey, "one"), "ho").key)
+  @Test fun `key recursion`() {
+    assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
+        .isEqualTo(Named(Named(Hey, "one"), "ho").compatibilityKey)
 
-    assertThat(Named(Named(Hey, "one"), "ho").key)
-        .isNotEqualTo(Named(Named(Hey, "two"), "ho").key)
+    assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
+        .isNotEqualTo(Named(Named(Hey, "two"), "ho").compatibilityKey)
 
-    assertThat(Named(Named(Hey, "a"), "ho").key)
-        .isNotEqualTo(Named(Named(Whut, "a"), "ho").key)
+    assertThat(Named(Named(Hey, "a"), "ho").compatibilityKey)
+        .isNotEqualTo(Named(Named(Whut, "a"), "ho").compatibilityKey)
   }
 
-  @Test fun recursiveKeysAreLegible() {
-    assertThat(Named(Named(Hey, "one"), "ho").key)
+  @Test fun `recursive keys are legible`() {
+    assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
         .isEqualTo("com.squareup.workflow.ui.NamedTest\$Hey-Named(one)-Named(ho)")
+  }
+
+  private class Foo(override val compatibilityKey: String) : Compatible
+
+  @Test fun `the test Compatible class actually works`() {
+    assertThat(compatible(Foo("bar"), Foo("bar"))).isTrue()
+    assertThat(compatible(Foo("bar"), Foo("baz"))).isFalse()
+  }
+
+  @Test fun `wrapping custom Compatible compatibility works`() {
+    assertThat(compatible(Named(Foo("bar"), "name"), Named(Foo("bar"), "name"))).isTrue()
+    assertThat(compatible(Named(Foo("bar"), "name"), Named(Foo("baz"), "name"))).isFalse()
+  }
+
+  @Test fun `wrapping custom Compatible keys work`() {
+    assertThat(Named(Foo("bar"), "name").compatibilityKey)
+        .isEqualTo(Named(Foo("bar"), "name").compatibilityKey)
+    assertThat(Named(Foo("bar"), "name").compatibilityKey)
+        .isNotEqualTo(Named(Foo("baz"), "name").compatibilityKey)
   }
 }


### PR DESCRIPTION
`Compatibility.isCompatibleWith` could not easily be kept in sync with
`Named.key`, so now the latter is the only way to play the "same type but not
the same" game.

Closes #428.