### PR TITLE
Convert InputT streams from channels to Flows.

### DIFF
--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
@@ -24,6 +24,10 @@ import com.squareup.workflow.Workflow
 import io.reactivex.BackpressureStrategy.LATEST
 import io.reactivex.Flowable
 import io.reactivex.Observable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.reactive.flow.asFlow
 
 /**
  * A [Fragment] that can run a workflow. Subclasses implement [onCreateWorkflow]
@@ -61,19 +65,26 @@ import io.reactivex.Observable
 @ExperimentalWorkflowUi
 abstract class WorkflowFragment<InputT, OutputT : Any> : Fragment() {
 
+  @UseExperimental(ExperimentalCoroutinesApi::class)
   data class Config<InputT, OutputT : Any> internal constructor(
     val workflow: Workflow<InputT, OutputT, Any>,
     val viewRegistry: ViewRegistry,
-    val inputs: Flowable<InputT>
+    val inputs: Flow<InputT>
   ) {
     companion object {
       fun <InputT, OutputT : Any> with(
         workflow: Workflow<InputT, OutputT, Any>,
         viewRegistry: ViewRegistry,
-        inputs: Flowable<InputT>
+        inputs: Flow<InputT>
       ): Config<InputT, OutputT> = Config(workflow, viewRegistry, inputs)
 
-      fun <InputT, OutputT : Any> with(
+      fun <InputT : Any, OutputT : Any> with(
+        workflow: Workflow<InputT, OutputT, Any>,
+        viewRegistry: ViewRegistry,
+        inputs: Flowable<InputT>
+      ): Config<InputT, OutputT> = with(workflow, viewRegistry, inputs.asFlow())
+
+      fun <InputT : Any, OutputT : Any> with(
         workflow: Workflow<InputT, OutputT, Any>,
         viewRegistry: ViewRegistry,
         inputs: Observable<InputT>
@@ -83,7 +94,7 @@ abstract class WorkflowFragment<InputT, OutputT : Any> : Fragment() {
         workflow: Workflow<InputT, OutputT, Any>,
         viewRegistry: ViewRegistry,
         input: InputT
-      ): Config<InputT, OutputT> = with(workflow, viewRegistry, Flowable.just(input))
+      ): Config<InputT, OutputT> = with(workflow, viewRegistry, flowOf(input))
 
       fun <OutputT : Any> with(
         workflow: Workflow<Unit, OutputT, Any>,

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
@@ -57,10 +56,11 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
    * workflow. The channel returned by this function will be cancelled by the host when it's
    * finished.
    */
-  internal class Factory<InputT, OutputT : Any> constructor(
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  internal class Factory<InputT, OutputT : Any>(
     private val workflow: Workflow<InputT, OutputT, Any>,
     private val viewRegistry: ViewRegistry,
-    private val inputs: () -> ReceiveChannel<InputT>,
+    private val inputs: Flow<InputT>,
     savedInstanceState: Bundle?,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
   ) : ViewModelProvider.Factory {


### PR DESCRIPTION
Workflows accept _streams_ of inputs, which were previously passed around
as "channel producers" of the type `() -> ReceiveChannel<InputT>`.

Channels are not a good abstraction for this – they don't compose as well
as Flows, and they are inherently more expensive since they are meant to
be thread-safe, lock-free synchronization and queuing devices. Flows are
perfect for this API, since they are cold, easily composable, and map
directly to various reactive streams libraries (RxJava, Reactive Streams, etc.)