### PR TITLE
Convert the Worker API to use Flow instead of using its own Emitter type.

### DIFF
--- a/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -21,6 +21,7 @@ import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Worker
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.onWorkerOutput
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 
 /**
@@ -34,10 +35,11 @@ class BlinkingCursorWorkflow(
 
   private val cursorString = cursor.toString()
 
+  @UseExperimental(ExperimentalCoroutinesApi::class)
   private val intervalWorker = Worker.create {
     var on = true
     while (true) {
-      emitOutput(on)
+      emit(on)
       delay(delayMs)
       on = !on
     }

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/LifecycleWorker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/LifecycleWorker.kt
@@ -15,7 +15,9 @@
  */
 package com.squareup.workflow
 
-import com.squareup.workflow.Worker.Emitter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
@@ -47,7 +49,8 @@ abstract class LifecycleWorker : Worker<Nothing> {
    */
   open fun onCancelled() {}
 
-  final override suspend fun performWork(emitter: Emitter<Nothing>) {
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  final override fun run(): Flow<Nothing> = flow {
     onStarted()
 
     try {

--- a/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorkers.kt
+++ b/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorkers.kt
@@ -16,45 +16,16 @@
 package com.squareup.workflow.rx2
 
 import com.squareup.workflow.Worker
-import com.squareup.workflow.Worker.Emitter
-import com.squareup.workflow.emitAll
+import com.squareup.workflow.asWorker
+import io.reactivex.BackpressureStrategy.BUFFER
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
-import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.reactive.openSubscription
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.reactive.flow.asFlow
 import kotlinx.coroutines.rx2.await
-import kotlinx.coroutines.rx2.openSubscription
-
-/**
- * Emits whatever is emitted by [observable] on this [Emitter].
- *
- * RxJava doesn't allow nulls, but it can't express that in its types. The receiver type parameter
- * is nullable to allow passing in an [Observable] with platform nullability.
- */
-suspend fun <T : Any> Emitter<T>.emitAll(observable: Observable<out T?>) {
-  // This cast works because RxJava types don't actually allow nulls, it's just that they can't
-  // express that in their types because Java.
-  @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
-  val channel = observable.openSubscription() as ReceiveChannel<T>
-  emitAll(channel, closeOnCancel = true)
-}
-
-/**
- * Emits whatever is emitted by [flowable] on this [Emitter].
- *
- * RxJava doesn't allow nulls, but it can't express that in its types. The receiver type parameter
- * is nullable to allow passing in a [Flowable] with platform nullability.
- */
-suspend fun <T : Any> Emitter<T>.emitAll(flowable: Flowable<out T?>) {
-  // This cast works because RxJava types don't actually allow nulls, it's just that they can't
-  // express that in their types because Java.
-  @Suppress("EXPERIMENTAL_API_USAGE", "UNCHECKED_CAST")
-  val channel = flowable.openSubscription() as ReceiveChannel<T>
-  emitAll(channel, closeOnCancel = true)
-}
 
 /**
  * Creates a [Worker] from this [Observable].
@@ -67,7 +38,7 @@ suspend fun <T : Any> Emitter<T>.emitAll(flowable: Flowable<out T?>) {
  * platform nullability.
  */
 inline fun <reified T : Any> Observable<out T?>.asWorker(key: String = ""): Worker<T> =
-  Worker.create(key) { emitAll(this@asWorker) }
+  this.toFlowable(BUFFER).asWorker(key)
 
 /**
  * Creates a [Worker] from this [Flowable].
@@ -79,8 +50,12 @@ inline fun <reified T : Any> Observable<out T?>.asWorker(key: String = ""): Work
  * is nullable so that the resulting [Worker] is non-nullable instead of having
  * platform nullability.
  */
+@UseExperimental(ExperimentalCoroutinesApi::class)
 inline fun <reified T : Any> Flowable<out T?>.asWorker(key: String = ""): Worker<T> =
-  Worker.create(key) { emitAll(this@asWorker) }
+// This cast works because RxJava types don't actually allow nulls, it's just that they can't
+  // express that in their types because Java.
+  @Suppress("UNCHECKED_CAST")
+  (this as Flowable<T>).asFlow().asWorker(key)
 
 /**
  * Creates a [Worker] from this [Maybe].

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockWorker.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/MockWorker.kt
@@ -16,7 +16,8 @@
 package com.squareup.workflow.testing
 
 import com.squareup.workflow.Worker
-import com.squareup.workflow.Worker.Emitter
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 
 /**
  * A mock implementation of [Worker] for use in tests with `testRender` and [TestRenderResult].
@@ -30,7 +31,8 @@ import com.squareup.workflow.Worker.Emitter
  */
 class MockWorker<T>(val name: String) : Worker<T> {
 
-  override suspend fun performWork(emitter: Emitter<T>) {
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  override fun run(): Flow<T> {
     throw AssertionError("MockWorker can't do work. Use TestRenderResult.executeWorkerAction*.")
   }
 

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
@@ -17,20 +17,16 @@
 
 package com.squareup.workflow
 
-import com.squareup.workflow.Worker.Emitter
 import com.squareup.workflow.testing.test
-import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.Unconfined
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class LifecycleWorkerTest {
-
-  private object NoopEmitter : Emitter<Nothing> {
-    override suspend fun emitOutput(output: Nothing) {}
-  }
 
   @Test fun `onStart called immediately`() {
     var onStartCalled = false
@@ -42,9 +38,8 @@ class LifecycleWorkerTest {
 
     assertFalse(onStartCalled)
     runBlocking {
-      val job = launch(start = UNDISPATCHED) {
-        worker.performWork(NoopEmitter)
-      }
+      val job = worker.run()
+          .launchIn(CoroutineScope(Unconfined))
       assertTrue(onStartCalled)
 
       // Don't hang the runBlocking block forever.


### PR DESCRIPTION
The old `Worker` API was just an over-simplified copy of the `Flow` API.
Now that most core Flow APIs have graduated to "experimental" status, it
doesn't make sense to copy them. Using Flow directly has a few benefits:

 - One less reactive streams contract to keep in your head (while the Worker
   API was _similar_ to Flow, it was less strict and likely to diverge more
   over time).
 - We get access to all the built-in Flow operators.
 - Out-of-the-box integration with various reactive streams libraries.
 - Since Workers are always consumed as channels, we get lots of optimizations
   when the source is also a channel, or knows how to make one. Flow
   also does operator fusion for buffering and context-switching operators.
 - The Kotlin Worker API now matches the Swift one almost exactly - the
   only difference is that the streams used by the Swift library don't
   have backpressure.