### PR TITLE
Added builder functions for creating stateful workflows.

### DIFF
--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
@@ -135,29 +135,16 @@ class SnapshottingIntegrationTest {
 
   // See https://github.com/square/workflow/issues/404
   @Test fun `descendant snapshots are independent over state transitions`() {
-    val workflow = object : StatefulWorkflow<String, String, Nothing, Unit>() {
-      override fun initialState(
-        input: String,
-        snapshot: Snapshot?
-      ): String = input
-
-      override fun onInputChanged(
-        old: String,
-        new: String,
-        state: String
-      ): String = new
-
-      override fun render(
-        input: String,
-        state: String,
-        context: RenderContext<String, Nothing>
-      ) {
-      }
-
-      override fun snapshotState(state: String): Snapshot = Snapshot.write {
-        it.writeUtf8WithLength(state)
-      }
-    }
+    val workflow = Workflow.stateful<String, String, Nothing, Unit>(
+        initialState = { input, _ -> input },
+        onInputChanged = { _, new, _ -> new },
+        render = { _, _ -> Unit },
+        snapshot = { state ->
+          Snapshot.write {
+            it.writeUtf8WithLength(state)
+          }
+        }
+    )
     // This test specifically needs to test snapshots from a non-flat workflow tree.
     val root = Workflow.stateless<String, Nothing, Unit> {
       renderChild(workflow, it)


### PR DESCRIPTION
Also made the `Workflow.stateless` function inline.

This lets you define stateful workflows with a function call:
```kotlin
Workflow.stateful<Input, State, Output, Rendering>(
  initialState = { input, snapshot -> TODO() },
  render = { input, state -> renderChild(TODO()) },
  snapshot = { state -> TODO() }
)
```

This is just an idea – does it really make anything better? These test workflows are a horrible test case for ergonomics because they're all very unusually short and usually only implement a subset of the functionality that a real workflow would implement.