### PR TITLE
Fix Worker backpressure (too much buffering).

### DIFF
--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
@@ -22,7 +22,9 @@ import com.squareup.workflow.Worker.OutputOrFinished.Output
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.produceIn
 import kotlinx.coroutines.selects.SelectBuilder
@@ -38,6 +40,7 @@ internal fun <T> CoroutineScope.launchWorker(worker: Worker<T>): ReceiveChannel<
       // TODO(https://github.com/square/workflow/issues/434) Remove this map to allow operator
       // fusion to occur.
       .map { Output(it) }
+      .buffer(RENDEZVOUS)
       .produceIn(this)
 
 /**


### PR DESCRIPTION
When Workers were converted to flow in 045e5be2ebc2b65f83bc08e4a8e7959c7527f92e (#435), buffering
was introduced. `produceIn` will, by default, use the `BUFFERED` value to configure its channel's
capacity, which resolves to the "default" buffer size. This value is more than zero, which means
buffering was accidentally introduced into workers where it shouldn't be.