### PR TITLE
Don't throw from runningWorker when the worker finishes.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -191,9 +191,16 @@ fun <StateT, OutputT : Any, T> RenderContext<StateT, OutputT>.onWorkerOutput(
  * Ensures a [Worker] that never emits anything is running. Since [worker] can't emit anything,
  * it can't trigger any [WorkflowAction]s.
  *
+ * A simple way to create workers that don't output anything is using [Worker.createSideEffect].
+ *
  * @param key An optional string key that is used to distinguish between identical [Worker]s.
  */
 fun <StateT, OutputT : Any> RenderContext<StateT, OutputT>.runningWorker(
   worker: Worker<Nothing>,
   key: String = ""
-) = onWorkerOutputOrFinished(worker, key) { throw AssertionError("Worker<Nothing> emitted $it") }
+) {
+  // Need to cast to Any so the compiler doesn't complain about unreachable code.
+  onWorkerOutput(worker as Worker<Any>, key) {
+    throw AssertionError("Worker<Nothing> emitted $it")
+  }
+}

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -164,7 +164,8 @@ interface Worker<out T> {
     ): Worker<T> = flow(block).asWorker(key)
 
     /**
-     * Creates a [Worker] that just performs some side effects and doesn't emit anything.
+     * Creates a [Worker] that just performs some side effects and doesn't emit anything. Run the
+     * worker from your `render` method using [RenderContext.runningWorker].
      *
      * The returned [Worker] will equate to any other workers created with this function that have
      * the same key. The key is required for this builder because there is no type information


### PR DESCRIPTION
`runningWorker` is commonly used to run `Worker<Nothing>`s, as created
by `Worker.createSideEffect`. These workers typically do some work, then finish.
It makes no sense to throw an exception when they finish, that's expected behavior.

Fixes #455.