### PR TITLE
Updates to sdk 29, and tidies dependencies.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -15,45 +15,44 @@
  */
 buildscript {
   ext.versions = [
-      'agp': '3.5.0-beta05',
-      'buildTools': '28.0.3',
-      'compileSdk': '28',
-      'lifecycle': '2.0.0',
-      'minSdk': 21,
-      'targetSdk': 28,
-      'sourceCompatibility': JavaVersion.VERSION_1_8,
-      'targetCompatibility': JavaVersion.VERSION_1_8,
-
-      'coordinators': '0.4',
-      'rxandroid2': '2.1.0',
-      'timber': '4.7.1',
-
-      'detektPlugin': '1.0.0-RC16',
+      'targetSdk': 29,
       'dokka': '0.9.18',
-      'hamcrest': '1.3',
-      'intellijAnnotations': '13.0',
-      'junit': '4.12',
       'kotlin': '1.3.41',
       'kotlinCoroutines': '1.3.0-M2',
-      'ktlintPlugin': '5.1.0',
-      'mavenPublishPlugin': '0.8.0',
-      'mockito': '2.7.5',
-      'mockitoKotlin': '1.5.0',
-      'rxjava2Extensions': '0.20.4',
-      'truth': '1.0',
   ]
 
-  ext.deps = [
-      'android_gradle_plugin': "com.android.tools.build:gradle:${versions.agp}",
+  rootProject.ext.defaultAndroidConfig = {
+    compileSdkVersion versions.targetSdk
+    buildToolsVersion '29.0.0'
 
-      'appcompat': "androidx.appcompat:appcompat:1.0.2",
-      'coordinators': "com.squareup.coordinators:coordinators:${versions.coordinators}",
-      'constraint_layout': "androidx.constraintlayout:constraintlayout:1.1.3",
-      'lifecycle': "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}",
-      'rxandroid2': "io.reactivex.rxjava2:rxandroid:${versions.rxandroid2}",
-      'timber': "com.jakewharton.timber:timber:${versions.timber}",
-      'transition': "androidx.transition:transition:1.0.1",
-      'material': "com.google.android.material:material:1.0.0",
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+      minSdkVersion 21
+      targetSdkVersion versions.targetSdk
+      versionCode 1
+      versionName "1.0"
+    }
+  }
+
+  ext.deps = [
+      'android_gradle_plugin': "com.android.tools.build:gradle:3.5.0-beta05",
+
+      'androidx': [
+          'appcompat': "androidx.appcompat:appcompat:1.0.2",
+          'constraint_layout': "androidx.constraintlayout:constraintlayout:1.1.3",
+          'lifecycle': "androidx.lifecycle:lifecycle-extensions:2.0.0",
+          // Note that we're not using the actual androidx material dep yet, it's still alpha.
+          'material': "com.google.android.material:material:1.0.0",
+          'transition': "androidx.transition:transition:1.0.1",
+      ],
+
+      'coordinators': "com.squareup.coordinators:coordinators:0.4",
+      'rxandroid2': "io.reactivex.rxjava2:rxandroid:2.1.0",
+      'timber': "com.jakewharton.timber:timber:4.7.1",
 
       'kotlin': [
           'gradlePlugin': "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
@@ -74,30 +73,31 @@ buildscript {
               'common': "org.jetbrains.kotlin:kotlin-test-common",
               'annotations': "org.jetbrains.kotlin:kotlin-test-annotations-common",
               'jdk': "org.jetbrains.kotlin:kotlin-test-junit",
-              'mockito': "com.nhaarman:mockito-kotlin-kt1.1:${versions.mockitoKotlin}"
+              'mockito': "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
           ]
       ],
       'dokkaAndroid': "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}",
       'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
-      'mavenPublish': "com.vanniktech:gradle-maven-publish-plugin:${versions.mavenPublishPlugin}",
-      'ktlint': "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:${versions.ktlintPlugin}",
+      // Source of "API 'variant.getJavaCompile()' is obsolete" warning, because of course it is.
+      'mavenPublish': "com.vanniktech:gradle-maven-publish-plugin:0.8.0",
+      'ktlint': "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:5.1.0",
       'lanterna': "com.googlecode.lanterna:lanterna:3.0.1",
-      'detekt': "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detektPlugin}",
+      'detekt': "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC16",
       'okio': "com.squareup.okio:okio:2.2.2",
       'rxjava2':[
           'rxjava2': "io.reactivex.rxjava2:rxjava:2.2.3",
           'interop': "com.github.akarnokd:rxjava2-interop:0.11.4",
-          'extensions': "com.github.akarnokd:rxjava2-extensions:${versions.rxjava2Extensions}"
+          'extensions': "com.github.akarnokd:rxjava2-extensions:0.20.4"
       ],
       'annotations': [
-          'intellij': "org.jetbrains:annotations:${versions.intellijAnnotations}",
+          'intellij': "org.jetbrains:annotations:13.0",
           'androidSupport': "com.android.support:support-annotations:26.0.2",
       ],
       'test': [
-          'truth': "com.google.truth:truth:${versions.truth}",
-          'junit': "junit:junit:${versions.junit}",
-          'mockito': "org.mockito:mockito-core:${versions.mockito}",
-          'hamcrestCore': "org.hamcrest:hamcrest-core:${versions.hamcrest}"
+          'truth': "com.google.truth:truth:1.0",
+          'junit': "junit:junit:4.12",
+          'mockito': "org.mockito:mockito-core:2.7.5",
+          'hamcrestCore': "org.hamcrest:hamcrest-core:1.3"
       ]
   ]
 
@@ -121,23 +121,6 @@ buildscript {
 rootProject.ext.defaultDokkaConfig = {
     outputFormat = 'gfm'
     outputDirectory = "$buildDir/docs"
-}
-
-rootProject.ext.defaultAndroidConfig = {
-  compileSdkVersion versions.targetSdk
-  buildToolsVersion versions.buildTools
-
-  compileOptions {
-    sourceCompatibility versions.sourceCompatibility
-    targetCompatibility versions.targetCompatibility
-  }
-
-  defaultConfig {
-    minSdkVersion versions.minSdk
-    targetSdkVersion versions.targetSdk
-    versionCode 1
-    versionName "1.0"
-  }
 }
 
 allprojects {

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -16,6 +16,8 @@
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.parallel=true
 android.useAndroidX=true
+# Uncomment this to diagnose "API $s is obsolete" warnings. Commented out b/c it's pretty noisy.
+#android.debug.obsoleteApi=true
 
 GROUP=com.squareup.workflow
 VERSION_NAME=0.18.0-SNAPSHOT

--- a/kotlin/samples/hello-workflow-fragment/build.gradle
+++ b/kotlin/samples/hello-workflow-fragment/build.gradle
@@ -38,6 +38,6 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.appcompat
+  implementation deps.androidx.appcompat
   implementation deps.rxjava2.rxjava2
 }

--- a/kotlin/samples/hello-workflow/build.gradle
+++ b/kotlin/samples/hello-workflow/build.gradle
@@ -38,6 +38,6 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.appcompat
+  implementation deps.androidx.appcompat
   implementation deps.rxjava2.rxjava2
 }

--- a/kotlin/samples/tictactoe/android/build.gradle
+++ b/kotlin/samples/tictactoe/android/build.gradle
@@ -21,7 +21,7 @@ android rootProject.ext.defaultAndroidConfig
 android {
   defaultConfig {
     applicationId "com.squareup.sample.tictacworkflow"
-    minSdkVersion versions.minSdk
+    minSdkVersion 21
     multiDexEnabled true
     targetSdkVersion versions.targetSdk
     versionCode 1
@@ -40,9 +40,9 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.appcompat
-  implementation deps.constraint_layout
-  implementation deps.lifecycle
+  implementation deps.androidx.appcompat
+  implementation deps.androidx.constraint_layout
+  implementation deps.androidx.lifecycle
   implementation deps.kotlin.coroutines.rx2
   implementation deps.kotlin.reflect
   implementation deps.okio

--- a/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/mainactivity/MainComponent.kt
+++ b/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/mainactivity/MainComponent.kt
@@ -51,7 +51,7 @@ internal class MainComponent {
       val stock = Thread.getDefaultUncaughtExceptionHandler()
       Thread.setDefaultUncaughtExceptionHandler { thread, error ->
         Timber.e(error)
-        stock.uncaughtException(thread, error)
+        stock?.uncaughtException(thread, error)
       }
     }
   }

--- a/kotlin/samples/todo-android/todo-android-app/build.gradle
+++ b/kotlin/samples/todo-android/todo-android-app/build.gradle
@@ -40,10 +40,10 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.appcompat
-  implementation deps.constraint_layout
-  implementation deps.material
-  implementation deps.lifecycle
+  implementation deps.androidx.appcompat
+  implementation deps.androidx.constraint_layout
+  implementation deps.androidx.material
+  implementation deps.androidx.lifecycle
   implementation deps.kotlin.coroutines.rx2
   implementation deps.kotlin.reflect
   implementation deps.okio

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -31,13 +31,13 @@ dependencies {
   api project(':workflow-core')
   api project(':workflow-ui-core')
 
+  api deps.androidx.lifecycle
+  api deps.androidx.transition
   api deps.kotlin.stdLib.jdk6
-  api deps.lifecycle
   api deps.rxjava2.rxjava2
-  api deps.transition
 
   implementation project(':workflow-runtime')
-  implementation deps.appcompat
+  implementation deps.androidx.appcompat
   implementation deps.coordinators
   implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.coroutines.core

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
@@ -114,9 +114,7 @@ class WorkflowLayout(
     }
 
     constructor(source: Parcel) : super(source) {
-      @Suppress("UNCHECKED_CAST")
-      this.childState = source.readSparseArray(SavedState::class.java.classLoader)
-          as SparseArray<Parcelable>
+      this.childState = source.readSparseArray<Parcelable>(SavedState::class.java.classLoader)!!
     }
 
     val childState: SparseArray<Parcelable>

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
@@ -61,11 +61,11 @@ class ViewStateCache private constructor(
    *
    * @param oldViewMaybe the view that is being removed, if any, which is expected to be showing
    * a [Named] rendering. If that rendering is
-   * [compatible with][com.squareup.workflow.ui.Compatible.isCompatibleWith] a member of
+   * [compatible with][com.squareup.workflow.ui.compatible] a member of
    * [retainedRenderings], its state will be [saved][View.saveHierarchyState].
    *
    * @param newView the view that is about to be displayed, which must be showing a
-   * [Named] rendering. If [compatible][com.squareup.workflow.ui.Compatible.isCompatibleWith]
+   * [Named] rendering. If [compatible][com.squareup.workflow.ui.compatible]
    * view state is found in the cache, it is [restored][View.restoreHierarchyState].
    *
    * @return true if [newView] has been restored.
@@ -159,13 +159,13 @@ class ViewStateCache private constructor(
     parcel: Parcel,
     flags: Int
   ) {
-    parcel.writeMap(viewStates)
+    parcel.writeMap(viewStates as Map<*, *>)
   }
 
   companion object CREATOR : Creator<ViewStateCache> {
     override fun createFromParcel(parcel: Parcel): ViewStateCache {
       return mutableMapOf<String, ViewStateFrame>()
-          .apply { parcel.readMap(this, ViewStateCache::class.java.classLoader) }
+          .apply { parcel.readMap(this as Map<*, *>, ViewStateCache::class.java.classLoader) }
           .let { ViewStateCache(it) }
     }
 

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateFrame.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateFrame.kt
@@ -23,7 +23,7 @@ import android.util.SparseArray
 /**
  * Used by [ViewStateCache] to record the [viewState] data for the view identified
  * by [key], which is expected to match the `toString()` of a
- * [com.squareup.workflow.ui.Named.Key].
+ * [com.squareup.workflow.ui.Compatible.compatibilityKey].
  */
 internal data class ViewStateFrame(
   val key: String,
@@ -44,10 +44,7 @@ internal data class ViewStateFrame(
   companion object CREATOR : Creator<ViewStateFrame> {
     override fun createFromParcel(parcel: Parcel): ViewStateFrame {
       val key = parcel.readString()!!
-
-      @Suppress("UNCHECKED_CAST")
-      val viewState = parcel.readSparseArray(ViewStateFrame::class.java.classLoader)
-          as SparseArray<Parcelable>
+      val viewState = parcel.readSparseArray<Parcelable>(ViewStateFrame::class.java.classLoader)!!
 
       return ViewStateFrame(key, viewState)
     }


### PR DESCRIPTION
`androidx` deps are now grouped, and `versions` is now consistent: it only
holds shared values, others are inlined (as an increasing number already
were). Benefit, now the IDE nudges us when SDK gets stale.