### PR TITLE
WorkflowRunner now delivers single result instead of output stream.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -45,6 +45,7 @@ buildscript {
           'appcompat': "androidx.appcompat:appcompat:1.0.2",
           'constraint_layout': "androidx.constraintlayout:constraintlayout:1.1.3",
           'lifecycle': "androidx.lifecycle:lifecycle-extensions:2.0.0",
+          'lifecycleReactivestreams': "androidx.lifecycle:lifecycle-reactivestreams-ktx:2.0.0",
           // Note that we're not using the actual androidx material dep yet, it's still alpha.
           'material': "com.google.android.material:material:1.0.0",
           'transition': "androidx.transition:transition:1.0.1",

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
@@ -25,7 +25,7 @@ import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.parse
 
-object HelloWorkflow : StatefulWorkflow<Unit, State, Unit, Rendering>() {
+object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   enum class State {
     Hello,
     Goodbye;
@@ -50,7 +50,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Unit, Rendering>() {
   override fun render(
     input: Unit,
     state: State,
-    context: RenderContext<State, Unit>
+    context: RenderContext<State, Nothing>
   ): Rendering = Rendering(
       message = state.name,
       onClick = context.onEvent { enterState(state.theOtherState()) }

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
@@ -18,10 +18,11 @@ package com.squareup.sample.helloworkflowfragment
 import com.squareup.workflow.ui.ExperimentalWorkflowUi
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowFragment
+import com.squareup.workflow.ui.WorkflowRunner
 
 @UseExperimental(ExperimentalWorkflowUi::class)
 class HelloWorkflowFragment : WorkflowFragment<Unit, Unit>() {
-  override fun onCreateWorkflow(): Config<Unit, Unit> {
-    return Config.with(HelloWorkflow, ViewRegistry(HelloFragmentLayoutRunner))
+  override fun onCreateWorkflow(): WorkflowRunner.Config<Unit, Unit> {
+    return WorkflowRunner.Config(HelloWorkflow, ViewRegistry(HelloFragmentLayoutRunner))
   }
 }

--- a/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
+++ b/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
@@ -25,7 +25,7 @@ import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction.Companion.enterState
 import com.squareup.workflow.parse
 
-object HelloWorkflow : StatefulWorkflow<Unit, State, Unit, Rendering>() {
+object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   enum class State {
     Hello,
     Goodbye;
@@ -50,7 +50,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Unit, Rendering>() {
   override fun render(
     input: Unit,
     state: State,
-    context: RenderContext<State, Unit>
+    context: RenderContext<State, Nothing>
   ): Rendering = Rendering(
       message = state.name,
       onClick = context.onEvent { enterState(state.theOtherState()) }

--- a/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflowActivity.kt
+++ b/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflowActivity.kt
@@ -29,7 +29,9 @@ class HelloWorkflowActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    runner = setContentWorkflow(viewRegistry, HelloWorkflow, savedInstanceState)
+    runner = setContentWorkflow(savedInstanceState) {
+      WorkflowRunner.Config(HelloWorkflow, viewRegistry)
+    }
   }
 
   override fun onSaveInstanceState(outState: Bundle) {

--- a/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/authworkflow/LoginLayoutRunner.kt
+++ b/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/authworkflow/LoginLayoutRunner.kt
@@ -19,25 +19,36 @@ import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
-import com.squareup.sample.authworkflow.LoginScreen.SubmitLogin
+import com.squareup.sample.authworkflow.LoginScreen.Event.Cancel
+import com.squareup.sample.authworkflow.LoginScreen.Event.SubmitLogin
 import com.squareup.sample.tictactoe.R
 import com.squareup.workflow.ui.ExperimentalWorkflowUi
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.setBackHandler
 
 @UseExperimental(ExperimentalWorkflowUi::class)
 internal class LoginLayoutRunner(view: View) : LayoutRunner<LoginScreen> {
   private val error: TextView = view.findViewById(R.id.login_error_message)
   private val email: EditText = view.findViewById(R.id.login_email)
   private val password: EditText = view.findViewById(R.id.login_password)
-  private val button: Button = view.findViewById(R.id.login_button)
+  private val loginButton: Button = view.findViewById(R.id.login_button)
+  private val cancelButton: Button = view.findViewById(R.id.cancel_login_button)
+
+  init {
+    view.setBackHandler { cancelButton.performClick() }
+  }
 
   override fun showRendering(rendering: LoginScreen) {
     error.text = rendering.errorMessage
 
-    button.setOnClickListener {
+    loginButton.setOnClickListener {
       rendering.onEvent(SubmitLogin(email.text.toString(), password.text.toString()))
+    }
+
+    cancelButton.setOnClickListener {
+      rendering.onEvent(Cancel)
     }
   }
 

--- a/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
+++ b/kotlin/samples/tictactoe/android/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
@@ -33,7 +33,7 @@ class MainActivity : AppCompatActivity() {
   private var loggingSub = Disposables.disposed()
 
   private lateinit var component: MainComponent
-  private lateinit var workflowRunner: WorkflowRunner<*>
+  private lateinit var workflowRunner: WorkflowRunner<Unit>
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -41,10 +41,14 @@ class MainActivity : AppCompatActivity() {
     component = lastCustomNonConfigurationInstance as? MainComponent
         ?: MainComponent()
 
-    workflowRunner = setContentWorkflow(viewRegistry, component.mainWorkflow, savedInstanceState)
-        .apply {
-          loggingSub = renderings.subscribe { Timber.d("rendering: %s", it) }
-        }
+    workflowRunner = setContentWorkflow(
+        savedInstanceState,
+        { WorkflowRunner.Config(component.mainWorkflow, viewRegistry) }
+    ) {
+      finish()
+    }
+
+    loggingSub = workflowRunner.renderings.subscribe { Timber.d("rendering: %s", it) }
   }
 
   override fun onBackPressed() {

--- a/kotlin/samples/tictactoe/android/src/main/res/layout/login_layout.xml
+++ b/kotlin/samples/tictactoe/android/src/main/res/layout/login_layout.xml
@@ -60,14 +60,34 @@
       android:inputType="textPassword"
       />
 
-  <Button
-      android:id="@+id/login_button"
-      android:layout_width="wrap_content"
+  <LinearLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_gravity="center"
-      android:text="@string/login_button"
-      style="@style/Base.TextAppearance.AppCompat.Button"
-      />
+      android:orientation="horizontal"
+      android:paddingLeft="40dp"
+      android:paddingRight="40dp"
+      >
+
+    <Button
+        android:id="@+id/cancel_login_button"
+        style="@style/Base.TextAppearance.AppCompat.Button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="@string/cancel"
+        />
+
+    <Button
+        android:id="@+id/login_button"
+        style="@style/Base.TextAppearance.AppCompat.Button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:text="@string/login_button"
+        />
+
+  </LinearLayout>
 
   <Space
       android:layout_width="match_parent"

--- a/kotlin/samples/tictactoe/android/src/main/res/values/strings.xml
+++ b/kotlin/samples/tictactoe/android/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
   -->
 <resources>
   <string name="app_name">Tic Tac Workflow</string>
+  <string name="cancel">Cancel</string>
   <string name="end_game">End Game</string>
   <string name="end_game_title">End the Game?</string>
   <string name="exit">Exit</string>

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthState.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthState.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.sample.authworkflow
 
-import com.squareup.sample.authworkflow.LoginScreen.SubmitLogin
+import com.squareup.sample.authworkflow.LoginScreen.Event.SubmitLogin
 import com.squareup.sample.authworkflow.SecondFactorScreen.Event.SubmitSecondFactor
 
 sealed class AuthState {

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/LoginScreen.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/LoginScreen.kt
@@ -17,11 +17,15 @@ package com.squareup.sample.authworkflow
 
 data class LoginScreen(
   val errorMessage: String = "",
-  val onEvent: (SubmitLogin) -> Unit = {}
+  val onEvent: (Event) -> Unit = {}
 ) {
 
-  data class SubmitLogin(
-    val email: String,
-    val password: String
-  )
+  sealed class Event {
+    data class SubmitLogin(
+      val email: String,
+      val password: String
+    ) : Event()
+
+    object Cancel : Event()
+  }
 }

--- a/kotlin/samples/todo-android/todo-android-app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
+++ b/kotlin/samples/todo-android/todo-android-app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
@@ -36,7 +36,9 @@ class MainActivity : AppCompatActivity() {
     rootWorkflow = lastCustomNonConfigurationInstance as? TodoListsAppWorkflow
         ?: TodoListsAppWorkflow()
 
-    workflowRunner = setContentWorkflow(viewRegistry, rootWorkflow, savedInstanceState)
+    workflowRunner = setContentWorkflow(savedInstanceState) {
+      WorkflowRunner.Config(rootWorkflow, viewRegistry)
+    }
   }
 
   override fun onBackPressed() {

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -31,13 +31,14 @@ dependencies {
   api project(':workflow-core')
   api project(':workflow-ui-core')
 
-  api deps.androidx.lifecycle
   api deps.androidx.transition
   api deps.kotlin.stdLib.jdk6
   api deps.rxjava2.rxjava2
 
   implementation project(':workflow-runtime')
   implementation deps.androidx.appcompat
+  implementation deps.androidx.lifecycle
+  implementation deps.androidx.lifecycleReactivestreams
   implementation deps.coordinators
   implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.coroutines.core

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/HandlesBack.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/HandlesBack.kt
@@ -27,7 +27,11 @@ import com.squareup.workflow.ui.HandlesBack.Helper.setConditionalBackHandler
  * subviews should be invoked first, via [Helper.onBackPressed]
  *
  * To kick things off, override [android.app.Activity.onBackPressed] to call
- * [WorkflowActivityRunner.onBackPressed] or [WorkflowFragment.onBackPressed]
+ * [workflowOnBackPressed] or [WorkflowFragment.onBackPressed]
+ *
+ * **NB** This is all expected to be scrapped as soon as
+ * [OnBackPressedDispatcher](https://developer.android.com/reference/androidx/activity/OnBackPressedDispatcher.html)
+ * stabilizes.
  */
 interface HandlesBack {
   /**

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalViewContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalViewContainer.kt
@@ -47,6 +47,12 @@ internal class ModalViewContainer
 
     return Dialog(context, dialogThemeResId)
         .apply {
+          // TODO fix back button dispatch in modals. This doesn't terminate for some reason.
+          // https://github.com/square/workflow/issues/466
+//          setOnKeyListener { _, keyCode, _ ->
+//            keyCode == KeyEvent.KEYCODE_BACK && HandlesBack.Helper.onBackPressed(view)
+//          }
+
           setCancelable(false)
           setContentView(modalDecorator(view))
           window!!.setLayout(WRAP_CONTENT, WRAP_CONTENT)

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
@@ -30,8 +30,8 @@ import io.reactivex.disposables.Disposable
 
 /**
  * A view that can be driven by a [WorkflowRunner]. In most cases you'll use
- * [Activity.setContentWorkflow][android.support.v4.app.FragmentActivity.setContentWorkflow]
- * or subclass [WorkflowFragment] rather than manage this class directly.
+ * [Activity.setContentWorkflow][setContentWorkflow] or subclass [WorkflowFragment]
+ * rather than manage this class directly.
  */
 @ExperimentalWorkflowUi
 class WorkflowLayout(
@@ -54,14 +54,6 @@ class WorkflowLayout(
     registry: ViewRegistry
   ) {
     takeWhileAttached(renderings) { show(it, registry) }
-  }
-
-  /**
-   * Convenience override to start this layout from [renderings][WorkflowRunner.renderings]
-   * and [viewRegistry][WorkflowRunner.viewRegistry] of [workflowRunner].
-   */
-  fun start(workflowRunner: WorkflowRunner<*>) {
-    start(workflowRunner.renderings, workflowRunner.viewRegistry)
   }
 
   override fun onBackPressed(): Boolean {

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
@@ -21,24 +21,23 @@ import android.os.Bundle
 import android.support.annotation.CheckResult
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.toLiveData
 import com.squareup.workflow.Workflow
-import io.reactivex.BackpressureStrategy.LATEST
-import io.reactivex.Flowable
+import com.squareup.workflow.ui.WorkflowRunner.Config
 import io.reactivex.Observable
+import io.reactivex.Single
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.reactive.flow.asFlow
 
 /**
  * Uses a [Workflow] and a [ViewRegistry] to drive a [WorkflowLayout].
  *
- * It is simplest to use
- * [Activity.setContentWorkflow][android.support.v4.app.FragmentActivity.setContentWorkflow]
+ * It is simplest to use [Activity.setContentWorkflow][setContentWorkflow]
  * or subclass [WorkflowFragment] rather than instantiate a [WorkflowRunner] directly.
  */
 @ExperimentalWorkflowUi
@@ -49,9 +48,14 @@ interface WorkflowRunner<out OutputT> {
   fun onSaveInstanceState(outState: Bundle)
 
   /**
-   * A stream of the [output][OutputT] values emitted by the running [Workflow].
+   * Provides the first (and only) [OutputT] value emitted by the workflow.
+   *
+   * The output of the root workflow is treated as a result code, handy for use
+   * as a sign that the host Activity or Fragment should be finished. Thus, once
+   * a value is emitted the workflow is ended its output value is reported through
+   * this field.
    */
-  val output: Flowable<out OutputT>
+  val result: Single<out OutputT>
 
   /**
    * A stream of the rendering values emitted by the running [Workflow].
@@ -60,190 +64,75 @@ interface WorkflowRunner<out OutputT> {
 
   val viewRegistry: ViewRegistry
 
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  class Config<InputT, OutputT : Any> constructor(
+    val workflow: Workflow<InputT, OutputT, Any>,
+    val viewRegistry: ViewRegistry,
+    val inputs: Flow<InputT>,
+    val dispatcher: CoroutineDispatcher
+  ) {
+    constructor(
+      workflow: Workflow<InputT, OutputT, Any>,
+      viewRegistry: ViewRegistry,
+      input: InputT,
+      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
+    ) : this(workflow, viewRegistry, flowOf(input), dispatcher)
+  }
+
   companion object {
+    @Suppress("FunctionName")
+    fun <OutputT : Any> Config(
+      workflow: Workflow<Unit, OutputT, Any>,
+      viewRegistry: ViewRegistry,
+      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
+    ): Config<Unit, OutputT> {
+      return Config(workflow, viewRegistry, Unit, dispatcher)
+    }
+
     /**
-     * Returns a [ViewModel][android.arch.lifecycle.ViewModel] implementation of
-     * [WorkflowRunner], tied to the given [activity].
+     * Returns an instance of [WorkflowRunner] tied to the
+     * [Lifecycle][androidx.lifecycle.Lifecycle] of the given [activity].
      *
      * It's probably more convenient to use [FragmentActivity.setContentWorkflow]
      * rather than calling this method directly.
      *
-     * @param inputs Function that returns a channel that delivers input values for the root
-     * workflow. The first value emitted is passed to `initialState` to determine the root
-     * workflow's initial state, and subsequent emissions are passed as input updates to the root
-     * workflow. The channel returned by this function will be cancelled by the host when it's
-     * finished.
+     * @param configure function defining the root workflow and its environment. Called only
+     * once per [lifecycle][FragmentActivity.getLifecycle], and always called from the UI thread.
      */
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    fun <InputT, OutputT : Any> of(
+    fun <InputT, OutputT : Any> startWorkflow(
       activity: FragmentActivity,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      inputs: Flow<InputT>,
       savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
+      configure: () -> Config<InputT, OutputT>
     ): WorkflowRunner<OutputT> {
-      val factory = WorkflowRunnerViewModel.Factory(
-          workflow, viewRegistry, inputs, savedInstanceState, dispatcher
-      )
+      val factory = WorkflowRunnerViewModel.Factory(savedInstanceState, configure)
+
       @Suppress("UNCHECKED_CAST")
       return ViewModelProviders.of(activity, factory)[WorkflowRunnerViewModel::class.java]
           as WorkflowRunner<OutputT>
     }
 
     /**
-     * Returns a [ViewModel][android.arch.lifecycle.ViewModel] implementation of
-     * [WorkflowRunner], tied to the given [activity].
-     *
-     * It's probably more convenient to use [FragmentActivity.setContentWorkflow]
-     * rather than calling this method directly.
-     */
-    @UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
-    fun <InputT : Any, OutputT : Any> of(
-      activity: FragmentActivity,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      inputs: Flowable<InputT>,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> = of<InputT, OutputT>(
-        activity, viewRegistry, workflow, inputs.asFlow(), savedInstanceState,
-        dispatcher
-    )
-
-    /**
-     * Convenience overload for workflows unconcerned with back-pressure of their inputs.
-     */
-    fun <InputT : Any, OutputT : Any> of(
-      activity: FragmentActivity,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      inputs: Observable<InputT>,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> = of(
-        activity, viewRegistry, workflow, inputs.toFlowable(LATEST), savedInstanceState, dispatcher
-    )
-
-    /**
-     * Convenience overload for workflows that take one input value rather than a stream.
-     */
-    @UseExperimental(ExperimentalCoroutinesApi::class)
-    fun <InputT, OutputT : Any> of(
-      activity: FragmentActivity,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      input: InputT,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> = of(
-        activity, viewRegistry, workflow, flowOf(input), savedInstanceState, dispatcher
-    )
-
-    /**
-     * Convenience overload for workflows that take no input.
-     */
-    fun <OutputT : Any> of(
-      activity: FragmentActivity,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<Unit, OutputT, Any>,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> {
-      return of(activity, viewRegistry, workflow, Unit, savedInstanceState, dispatcher)
-    }
-
-    /**
-     * Returns a [ViewModel][android.arch.lifecycle.ViewModel] implementation of
-     * [WorkflowRunner], tied to the given [fragment].
+     * Returns an instance of [WorkflowRunner] tied to the
+     * [Lifecycle][androidx.lifecycle.Lifecycle] of the given [fragment].
      *
      * It's probably more convenient to subclass [WorkflowFragment] rather than calling
      * this method directly.
      *
-     * @param inputs Function that returns a channel that delivers input values for the root
-     * workflow. The first value emitted is passed to `initialState` to determine the root
-     * workflow's initial state, and subsequent emissions are passed as input updates to the root
-     * workflow. The channel returned by this function will be cancelled by the host when it's
-     * finished.
+     * @param configure function defining the root workflow and its environment. Called only
+     * once per [lifecycle][Fragment.getLifecycle], and always called from the UI thread.
      */
     @UseExperimental(ExperimentalCoroutinesApi::class)
-    fun <InputT, OutputT : Any> of(
+    fun <InputT, OutputT : Any> startWorkflow(
       fragment: Fragment,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      inputs: Flow<InputT>,
       savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
+      configure: () -> Config<InputT, OutputT>
     ): WorkflowRunner<OutputT> {
-      val factory =
-        WorkflowRunnerViewModel.Factory(
-            workflow, viewRegistry, inputs, savedInstanceState, dispatcher
-        )
+      val factory = WorkflowRunnerViewModel.Factory(savedInstanceState, configure)
+
       @Suppress("UNCHECKED_CAST")
       return ViewModelProviders.of(fragment, factory)[WorkflowRunnerViewModel::class.java]
           as WorkflowRunner<OutputT>
-    }
-
-    /**
-     * Returns a [ViewModel][android.arch.lifecycle.ViewModel] implementation of
-     * [WorkflowRunner], tied to the given [fragment].
-     *
-     * It's probably more convenient to subclass [WorkflowFragment] rather than calling
-     * this method directly.
-     */
-    @UseExperimental(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
-    fun <InputT : Any, OutputT : Any> of(
-      fragment: Fragment,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      inputs: Flowable<InputT>,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> = of<InputT, OutputT>(
-        fragment, viewRegistry, workflow, inputs.asFlow(), savedInstanceState,
-        dispatcher
-    )
-
-    /**
-     * Convenience overload for workflows unconcerned with back-pressure of their inputs.
-     */
-    fun <InputT : Any, OutputT : Any> of(
-      fragment: Fragment,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      inputs: Observable<InputT>,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> = of(
-        fragment, viewRegistry, workflow, inputs.toFlowable(LATEST), savedInstanceState,
-        dispatcher
-    )
-
-    /**
-     * Convenience overload for workflows that take one input value rather than a stream.
-     */
-    @UseExperimental(ExperimentalCoroutinesApi::class)
-    fun <InputT, OutputT : Any> of(
-      fragment: Fragment,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<InputT, OutputT, Any>,
-      input: InputT,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> =
-      of(fragment, viewRegistry, workflow, flowOf(input), savedInstanceState, dispatcher)
-
-    /**
-     * Convenience overload for workflows that take no input.
-     */
-    fun <OutputT : Any> of(
-      fragment: Fragment,
-      viewRegistry: ViewRegistry,
-      workflow: Workflow<Unit, OutputT, Any>,
-      savedInstanceState: Bundle?,
-      dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-    ): WorkflowRunner<OutputT> {
-      return of(fragment, viewRegistry, workflow, Unit, savedInstanceState, dispatcher)
     }
   }
 }
@@ -253,56 +142,42 @@ interface WorkflowRunner<out OutputT> {
  * It creates a [WorkflowRunner] for this activity, if one doesn't already exist, and
  * sets a view driven by that model as the content view.
  *
- * Hold onto the [WorkflowRunner] returned and:
+ * @param configure function defining the root workflow and its environment. Called only
+ * once per [lifecycle][FragmentActivity.getLifecycle], and always called from the UI thread.
  *
- *  - Call [FragmentActivity.workflowOnBackPressed] from [FragmentActivity.onBackPressed] to allow
- *    workflows to handle back button events. (See [HandlesBack] for more details.)
- *
- *  - Call [WorkflowRunner.onSaveInstanceState] from [FragmentActivity.onSaveInstanceState].
- *
- *  e.g.:
- *
- *     class MainActivity : AppCompatActivity() {
- *       private lateinit var runner: WorkflowRunner<*, *>
- *
- *       override fun onCreate(savedInstanceState: Bundle?) {
- *         super.onCreate(savedInstanceState)
- *         runner = setContentWorkflow(MyViewRegistry, MyRootWorkflow(), savedInstanceState)
- *       }
- *
- *       override fun onBackPressed() {
- *         if (!runner.onBackPressed(this)) super.onBackPressed()
- *       }
- *
- *       override fun onSaveInstanceState(outState: Bundle) {
- *         super.onSaveInstanceState(outState)
- *         runner.onSaveInstanceState(outState)
- *       }
- *     }
+ * @param onResult function called with the first (and only) output emitted by the root workflow,
+ * handy for passing to [FragmentActivity.setResult]. The workflow is ended once it emits any
+ * values, so this is also a good place from which to call [FragmentActivity.finish]. Called
+ * only while the activity is active, and always called from the UI thread.
  */
 @ExperimentalWorkflowUi
-@CheckResult
 @UseExperimental(ExperimentalCoroutinesApi::class)
 fun <InputT, OutputT : Any> FragmentActivity.setContentWorkflow(
-  viewRegistry: ViewRegistry,
-  workflow: Workflow<InputT, OutputT, Any>,
-  inputs: Flow<InputT>,
   savedInstanceState: Bundle?,
-  dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
+  configure: () -> Config<InputT, OutputT>,
+  onResult: ((OutputT) -> Unit)
 ): WorkflowRunner<OutputT> {
-  val runner = WorkflowRunner.of(
-      this, viewRegistry, workflow, inputs, savedInstanceState, dispatcher
-  )
-  val layout = WorkflowLayout(this@setContentWorkflow)
-      .apply {
-        id = R.id.workflow_layout
-        start(runner)
-      }
+  val runner = WorkflowRunner.startWorkflow(this, savedInstanceState, configure)
+  val layout = WorkflowLayout(this@setContentWorkflow).apply {
+    id = R.id.workflow_layout
+    start(runner.renderings, runner.viewRegistry)
+  }
+
+  runner.result.toFlowable()
+      .toLiveData()
+      .observe(this, Observer { result -> onResult(result) })
 
   this.setContentView(layout)
 
   return runner
 }
+
+@ExperimentalWorkflowUi
+@UseExperimental(ExperimentalCoroutinesApi::class)
+fun <InputT> FragmentActivity.setContentWorkflow(
+  savedInstanceState: Bundle?,
+  configure: () -> Config<InputT, Nothing>
+): WorkflowRunner<Nothing> = setContentWorkflow(savedInstanceState, configure) {}
 
 /**
  * If your workflow needs to manage the back button, override [FragmentActivity.onBackPressed]
@@ -323,62 +198,3 @@ fun <InputT, OutputT : Any> FragmentActivity.setContentWorkflow(
 fun FragmentActivity.workflowOnBackPressed(): Boolean {
   return HandlesBack.Helper.onBackPressed(this.findViewById(R.id.workflow_layout))
 }
-
-/**
- * Convenience overload for workflows that take a [Flowable] of inputs.
- */
-@ExperimentalWorkflowUi
-@CheckResult
-@UseExperimental(ExperimentalCoroutinesApi::class)
-fun <InputT : Any, OutputT : Any, RenderingT : Any> FragmentActivity.setContentWorkflow(
-  viewRegistry: ViewRegistry,
-  workflow: Workflow<InputT, OutputT, RenderingT>,
-  inputs: Flowable<InputT>,
-  savedInstanceState: Bundle?,
-  dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-): WorkflowRunner<OutputT> = setContentWorkflow(
-    viewRegistry, workflow, inputs.asFlow(), savedInstanceState, dispatcher
-)
-
-/**
- * Convenience overload for workflows unconcerned with back-pressure of their inputs.
- */
-@ExperimentalWorkflowUi
-@CheckResult
-fun <InputT : Any, OutputT : Any, RenderingT : Any> FragmentActivity.setContentWorkflow(
-  viewRegistry: ViewRegistry,
-  workflow: Workflow<InputT, OutputT, RenderingT>,
-  inputs: Observable<InputT>,
-  savedInstanceState: Bundle?,
-  dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-): WorkflowRunner<OutputT> = setContentWorkflow(
-    viewRegistry, workflow, inputs.toFlowable(LATEST), savedInstanceState, dispatcher
-)
-
-/**
- * Convenience overload for workflows that take one input value rather than a stream.
- */
-@ExperimentalWorkflowUi
-@CheckResult
-@UseExperimental(ExperimentalCoroutinesApi::class)
-fun <InputT, OutputT : Any, RenderingT : Any> FragmentActivity.setContentWorkflow(
-  viewRegistry: ViewRegistry,
-  workflow: Workflow<InputT, OutputT, RenderingT>,
-  input: InputT,
-  savedInstanceState: Bundle?,
-  dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-): WorkflowRunner<OutputT> =
-  setContentWorkflow(viewRegistry, workflow, flowOf(input), savedInstanceState, dispatcher)
-
-/**
- * Convenience overload for workflows that take no input.
- */
-@ExperimentalWorkflowUi
-@CheckResult
-fun <OutputT : Any, RenderingT : Any> FragmentActivity.setContentWorkflow(
-  viewRegistry: ViewRegistry,
-  workflow: Workflow<Unit, OutputT, RenderingT>,
-  savedInstanceState: Bundle?,
-  dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
-): WorkflowRunner<OutputT> =
-  setContentWorkflow(viewRegistry, workflow, Unit, savedInstanceState, dispatcher)

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
@@ -20,23 +20,19 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.squareup.workflow.RenderingAndSnapshot
 import com.squareup.workflow.Snapshot
-import com.squareup.workflow.Workflow
 import com.squareup.workflow.launchWorkflowIn
-import io.reactivex.Flowable
 import io.reactivex.Observable
-import kotlinx.coroutines.CoroutineDispatcher
+import io.reactivex.Single
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.rx2.asFlowable
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.rx2.asObservable
+import kotlinx.coroutines.rx2.rxSingle
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.CancellationException
 import kotlin.reflect.jvm.jvmName
@@ -44,46 +40,45 @@ import kotlin.reflect.jvm.jvmName
 @UseExperimental(ExperimentalCoroutinesApi::class)
 @ExperimentalWorkflowUi
 internal class WorkflowRunnerViewModel<OutputT : Any>(
-  override val viewRegistry: ViewRegistry,
-  private val renderingsFlow: Flow<RenderingAndSnapshot<Any>>,
-  outputsFlow: Flow<OutputT>,
-  private val scope: CoroutineScope
+  private val scope: CoroutineScope,
+  renderingsFlow: Flow<RenderingAndSnapshot<Any>>,
+  output: Flow<OutputT>,
+  override val viewRegistry: ViewRegistry
 ) : ViewModel(), WorkflowRunner<OutputT> {
 
-  /**
-   * @param inputs Function that returns a channel that delivers input values for the root
-   * workflow. The first value emitted is passed to `initialState` to determine the root
-   * workflow's initial state, and subsequent emissions are passed as input updates to the root
-   * workflow. The channel returned by this function will be cancelled by the host when it's
-   * finished.
-   */
   @UseExperimental(ExperimentalCoroutinesApi::class)
   internal class Factory<InputT, OutputT : Any>(
-    private val workflow: Workflow<InputT, OutputT, Any>,
-    private val viewRegistry: ViewRegistry,
-    private val inputs: Flow<InputT>,
     savedInstanceState: Bundle?,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate
+    private val configure: () -> WorkflowRunner.Config<InputT, OutputT>
   ) : ViewModelProvider.Factory {
     private val snapshot = savedInstanceState
         ?.getParcelable<PickledWorkflow>(BUNDLE_KEY)
         ?.snapshot
 
-    override fun <T : ViewModel> create(modelClass: Class<T>): T = launchWorkflowIn(
-        CoroutineScope(dispatcher),
-        workflow,
-        inputs,
-        snapshot
-    ) { renderings, outputs ->
-      @Suppress("UNCHECKED_CAST")
-      WorkflowRunnerViewModel(viewRegistry, renderings, outputs, this) as T
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+      return with(configure()) {
+        launchWorkflowIn(
+            CoroutineScope(dispatcher), workflow, inputs, snapshot
+        ) { renderings, output ->
+          @Suppress("UNCHECKED_CAST")
+          WorkflowRunnerViewModel(this, renderings, output, viewRegistry) as T
+        }
+      }
     }
   }
 
-  private val snapshotJob = scope.launch {
+  override val result: Single<out OutputT> = scope
+      .rxSingle { output.first() }
+      .doAfterTerminate {
+        scope.cancel(CancellationException("WorkflowRunnerViewModel delivered result"))
+      }
+      .cache()
+
+  init {
     renderingsFlow
         .map { it.snapshot }
-        .collect { lastSnapshot = it }
+        .onEach { lastSnapshot = it }
+        .launchIn(scope)
   }
 
   private var lastSnapshot: Snapshot = Snapshot.EMPTY
@@ -93,14 +88,8 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
       .map { it.rendering }
       .asObservable()
 
-  @UseExperimental(ExperimentalCoroutinesApi::class)
-  override val output: Flowable<out OutputT> = outputsFlow
-      .asFlowable()
-
   override fun onCleared() {
-    val cancellationException = CancellationException("WorkflowRunnerViewModel cleared.")
-    snapshotJob.cancel(cancellationException)
-    scope.cancel(cancellationException)
+    scope.cancel(CancellationException("WorkflowRunnerViewModel cleared."))
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
@@ -116,13 +105,4 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
   private companion object {
     val BUNDLE_KEY = WorkflowRunner::class.jvmName + "-workflow"
   }
-}
-
-/**
- * Invokes `block` every time a new collector begins collecting this [Flow].
- */
-@UseExperimental(ExperimentalCoroutinesApi::class)
-private fun <T> Flow<T>.onCollect(block: () -> Unit): Flow<T> = flow {
-  block()
-  emitAll(this@onCollect)
 }

--- a/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
+++ b/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
@@ -28,7 +28,7 @@ class WorkflowRunnerViewModelTest {
     val snapshotsChannel = Channel<RenderingAndSnapshot<Unit>>(UNLIMITED)
     val snapshotsFlow = flow { snapshotsChannel.consumeEach { emit(it) } }
 
-    val runner = WorkflowRunnerViewModel(viewRegistry, snapshotsFlow, emptyFlow(), scope)
+    val runner = WorkflowRunnerViewModel(emptyFlow(), viewRegistry, snapshotsFlow, scope)
 
     assertThat(runner.getLastSnapshotForTest()).isEqualTo(Snapshot.EMPTY)
 
@@ -44,10 +44,10 @@ class WorkflowRunnerViewModelTest {
     scope.coroutineContext[Job]!!.invokeOnCompletion { e ->
       if (e is CancellationException) cancelled = true
     }
-    val runner = WorkflowRunnerViewModel(viewRegistry, emptyFlow(), emptyFlow(), scope)
+    val runner = WorkflowRunnerViewModel(emptyFlow(), viewRegistry, emptyFlow(), scope)
 
     assertThat(cancelled).isFalse()
-    runner.output.test()
+    runner.result.test()
     assertThat(cancelled).isFalse()
 
     runner.clearForTest()

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
@@ -15,8 +15,6 @@
  */
 package com.squareup.workflow.ui
 
-typealias GoBackHandler = () -> Unit
-
 /**
  * @param stack: screens that have are / have been displayed, ending in the current screen
  *
@@ -25,16 +23,16 @@ typealias GoBackHandler = () -> Unit
  */
 data class BackStackScreen<StackedT : Any>(
   val stack: List<StackedT>,
-  val onGoBack: GoBackHandler? = null
+  val onGoBack: ((Unit) -> Unit)? = null
 ) {
   constructor(
     only: StackedT,
-    onGoBack: GoBackHandler? = null
+    onGoBack: ((Unit) -> Unit)? = null
   ) : this(listOf(only), onGoBack)
 
   constructor(
     vararg stack: StackedT,
-    onGoBack: GoBackHandler? = null
+    onGoBack: ((Unit) -> Unit)? = null
   ) : this(stack.toList(), onGoBack)
 
   init {


### PR DESCRIPTION
Android's configuration changes make it very difficult to craft an API that
can catch all output values and also avoid double-processing of them, and each
such API we've come up with is very confusing. The cognitive cost  outweighs
the benefit of allowing the Activity or Fragment to consume a stream of
outputs — if that's even a benefit! So far we have no use cases for a stream
v. a single result code that can't be better handled inside the root workflow.

Note that we update the Tic Tac Toe sample to take advantage. We also
(nearly) make it's back button work properly on the initial screen, but
that is blocked by #466.

Closes #430.