### PR TITLE
Bump version number to 0.19.0.

### DIFF
--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Workflow'
-  s.version      = '0.18.0'
+  s.version      = '0.19.0'
   s.summary      = 'Reactive application architecture'
   s.homepage     = 'https://www.github.com/square/workflow'
   s.license      = 'Apache License, Version 2.0'

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'WorkflowTesting'
-  s.version      = '0.18.0'
+  s.version      = '0.19.0'
   s.summary      = 'Reactive application architecture'
   s.homepage     = 'https://www.github.com/square/workflow'
   s.license      = 'Apache License, Version 2.0'

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'WorkflowUI'
-  s.version      = '0.18.0'
+  s.version      = '0.19.0'
   s.summary      = 'Infrastructure for Workflow-powered UI'
   s.homepage     = 'https://www.github.com/square/workflow'
   s.license      = 'Apache License, Version 2.0'

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -21,7 +21,7 @@ android.useAndroidX=true
 #android.debug.obsoleteApi=true
 
 GROUP=com.squareup.workflow
-VERSION_NAME=0.18.0-SNAPSHOT
+VERSION_NAME=0.19.0-SNAPSHOT
 
 POM_DESCRIPTION=Reactive workflows
 


### PR DESCRIPTION
Trying a slightly different approach to releasing this time - cutting a dedicated branch (`release-v0.18.0`) so we can continue to work on master.