### PR TITLE
Use single object for noAction instead of creating it on every call

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -46,8 +46,9 @@ interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, O
      *
      * Use this to, for example, ignore the output of a child workflow or worker.
      */
+    @Suppress("UNCHECKED_CAST")
     fun <StateT, OutputT : Any> noAction(): WorkflowAction<StateT, OutputT> =
-      WorkflowAction({ "noop" }) { Pair(it, null) }
+      NO_ACTION as WorkflowAction<StateT, OutputT>
 
     /**
      * Convenience function that returns a [WorkflowAction] that will just set the state to [newState]
@@ -100,5 +101,7 @@ interface WorkflowAction<StateT, out OutputT : Any> : (StateT) -> Pair<StateT, O
       output: OutputT
     ): WorkflowAction<StateT, OutputT> =
       WorkflowAction({ "emitOutput($name, $output)" }) { Pair(it, output) }
+
+    private val NO_ACTION = WorkflowAction<Any, Any>({ "noAction" }) { Pair(it, null) }
   }
 }


### PR DESCRIPTION
`WorkflowAction.noAction()` can be highly utilized across consumers, and it's not depending on any particular input or output types. We can assume having the same object across invocations is safe, and it reduces the memory footprint.