### PR TITLE
Fix WorkflowPool to work with ConflatedBroadcastChannel.

### DIFF
--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowPool.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/WorkflowPool.kt
@@ -172,12 +172,14 @@ class WorkflowPool {
           removeCompletedWorkflowAfter(handle.id) {
             var state = receiveOrNull()
             // Skip all the states that match the handle's state.
-            while (state == handle.state) {
+            while (state == handle.state && workflow.isActive) {
               state = receiveOrNull()
             }
-            return state
-                ?.let { Running(handle.copy(state = it)) }
-                ?: Finished(workflow.await())
+            return if (state != null && workflow.isActive) {
+              Running(handle.copy(state = state))
+            } else {
+              Finished(workflow.await())
+            }
           }
         }
   }


### PR DESCRIPTION
Before, the renderings stream came from a regular `Channel`, and the replay/caching
happened downstream. In the legacy integration code, this meant that when a V2 workflow emitted
an output and got cancelled, the pool would immediately see the renderings channel was closed on the next
`onWorkflowUpdate` and emit `Finished`. Now that it's backed by a `ConflatedBroadcastChannel`, it will
always emit the last-emitted value on subscription before sending the close signal. This means the
pool will always see the last state, and emit `Running`, which means the v2 workflow just gets restarted
on the next iteration. Fixed by explicitly checking the `isActive` flag on the workflow's job before
emitting `Running`.