### PR TITLE
Fix the maven version badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![CocoaPods compatible](https://img.shields.io/cocoapods/v/Workflow.svg)](https://cocoapods.org/pods/Workflow)
-[![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
+[![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core-jvm.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
 
 An architecture that allows composable state machines to drive UI navigation and content, where the state machines are cleanly separated from UI code.
 
@@ -30,7 +30,7 @@ pod 'WorkflowUI'
 
 ### Kotlin
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
+[![Maven Central](https://img.shields.io/maven-central/v/com.squareup.workflow/workflow-core-jvm.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.squareup.workflow%22)
 
 Artifacts are hosted on Maven Central. If you're using Gradle, ensure `mavenCentral()` appears in your `repositories` block, and then add dependencies on the following artifacts:
 


### PR DESCRIPTION
Forgot to update the name of the artifact used to retrieve our version badges, so they're still showing the old version.