### PR TITLE
DNM: Java 7 to 8, and converts non-legacy jvm tests to kotlintest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ local.properties
 *.iml
 .idea/
 
+# kotlinetest
+.kotlintest
+
 # cocoapods-generate
 gen/
 

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -17,6 +17,7 @@ buildscript {
   ext.versions = [
       'targetSdk': 29,
       'dokka': '0.9.18',
+      'junit5': '5.5.0',
       'kotlin': '1.3.41',
       'kotlinCoroutines': '1.3.0-M2',
   ]
@@ -75,6 +76,7 @@ buildscript {
               'common': "org.jetbrains.kotlin:kotlin-test-common",
               'annotations': "org.jetbrains.kotlin:kotlin-test-annotations-common",
               'jdk': "org.jetbrains.kotlin:kotlin-test-junit",
+              'kotlintest': "io.kotlintest:kotlintest-runner-junit5:3.3.3",
               'mockito': "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
           ]
       ],
@@ -95,8 +97,14 @@ buildscript {
           'intellij': "org.jetbrains:annotations:13.0",
       ],
       'test': [
+          'androidJunit5': "de.mannodermaus.gradle.plugins:android-junit5:1.5.0.0",
           'truth': "com.google.truth:truth:1.0",
           'junit': "junit:junit:4.12",
+          'junit5': [
+              'api': "org.junit.jupiter:junit-jupiter-api:${versions.junit5}",
+              'engine': "org.junit.jupiter:junit-jupiter-engine:${versions.junit5}",
+              'params': "org.junit.jupiter:junit-jupiter-params:${versions.junit5}",
+          ],
           'mockito': "org.mockito:mockito-core:2.7.5",
           'hamcrestCore': "org.hamcrest:hamcrest-core:1.3"
       ]
@@ -110,6 +118,7 @@ buildscript {
     classpath deps.kotlin.gradlePlugin
     classpath deps.ktlint
     classpath deps.mavenPublish
+    classpath deps.test.androidJunit5
   }
 
   repositories {

--- a/kotlin/legacy/legacy-workflow-core/build.gradle
+++ b/kotlin/legacy/legacy-workflow-core/build.gradle
@@ -17,8 +17,8 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'com.vanniktech.maven.publish'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   compileOnly deps.annotations.intellij

--- a/kotlin/legacy/legacy-workflow-rx2/build.gradle
+++ b/kotlin/legacy/legacy-workflow-rx2/build.gradle
@@ -17,8 +17,8 @@ apply plugin: 'java-library'
 apply plugin: 'kotlin'
 apply plugin: 'com.vanniktech.maven.publish'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
   compileOnly deps.androidx.annotations

--- a/kotlin/samples/tictactoe/android/build.gradle
+++ b/kotlin/samples/tictactoe/android/build.gradle
@@ -32,6 +32,12 @@ android {
   packagingOptions {
     exclude 'META-INF/atomicfu.kotlin_module'
   }
+
+  testOptions {
+    unitTests.all {
+      useJUnitPlatform()
+    }
+  }
 }
 
 dependencies {
@@ -50,6 +56,5 @@ dependencies {
   implementation deps.rxjava2.rxjava2
   implementation deps.timber
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation deps.kotlin.test.kotlintest
 }

--- a/kotlin/samples/tictactoe/common/build.gradle
+++ b/kotlin/samples/tictactoe/common/build.gradle
@@ -25,9 +25,11 @@ dependencies {
   implementation deps.kotlin.reflect
   implementation deps.rxjava2.rxjava2
 
-  testImplementation deps.test.hamcrestCore
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation deps.kotlin.test.kotlintest
   testImplementation deps.rxjava2.extensions
   testImplementation project(':workflow-testing')
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/PlayerInfoTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/PlayerInfoTest.kt
@@ -15,14 +15,15 @@
  */
 package com.squareup.sample.gameworkflow
 
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
 
-class PlayerInfoTest {
-  @Test fun readWriteTurn() {
+class PlayerInfoTest : StringSpec({
+  "read write turn" {
     val before = PlayerInfo("able", "baker")
     val out = before.toSnapshot()
     val after = PlayerInfo.fromSnapshot(out.bytes)
-    assertThat(after).isEqualTo(before)
+
+    after shouldBe before
   }
-}
+})

--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflowTest.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.sample.gameworkflow
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.sample.gameworkflow.Ending.Draw
 import com.squareup.sample.gameworkflow.Ending.Quitted
 import com.squareup.sample.gameworkflow.Ending.Victory
@@ -25,31 +24,31 @@ import com.squareup.sample.gameworkflow.Player.O
 import com.squareup.sample.gameworkflow.Player.X
 import com.squareup.workflow.testing.WorkflowTester
 import com.squareup.workflow.testing.testFromStart
-import org.junit.Test
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
 
-class TakeTurnsWorkflowTest {
-  @Test fun readWriteCompletedGame() {
+class TakeTurnsWorkflowTest : StringSpec({
+  "read write completed game" {
     val turn = Turn()
     val before = CompletedGame(Quitted, turn)
     val out = before.toSnapshot()
     val after = CompletedGame.fromSnapshot(out.bytes)
-    assertThat(after).isEqualTo(before)
+    after shouldBe before
   }
 
-  @Test fun startsGameWithGivenNames() {
+  "starts game with given names" {
     RealTakeTurnsWorkflow().testFromStart(
         TakeTurnsInput.newGame(PlayerInfo("higgledy", "piggledy"))
     ) {
       val (x, o) = awaitNextRendering().playerInfo
 
-      assertThat(x)
-          .isEqualTo("higgledy")
-      assertThat(o)
-          .isEqualTo("piggledy")
+      x shouldBe "higgledy"
+      o shouldBe "piggledy"
     }
   }
 
-  @Test fun xWins() {
+  "x wins" {
     RealTakeTurnsWorkflow().testFromStart(
         TakeTurnsInput.newGame(PlayerInfo("higgledy", "piggledy"))
     ) {
@@ -68,11 +67,11 @@ class TakeTurnsWorkflowTest {
       )
 
       val result = awaitNextOutput()
-      assertThat(result).isEqualTo(CompletedGame(Victory, expectedLastTurn))
+      result shouldBe CompletedGame(Victory, expectedLastTurn)
     }
   }
 
-  @Test fun draw() {
+  "draw" {
     RealTakeTurnsWorkflow().testFromStart(
         TakeTurnsInput.newGame(PlayerInfo("higgledy", "piggledy"))
     ) {
@@ -97,11 +96,11 @@ class TakeTurnsWorkflowTest {
       )
 
       val result = awaitNextOutput()
-      assertThat(result).isEqualTo(CompletedGame(Draw, expectedLastTurn))
+      result shouldBe CompletedGame(Draw, expectedLastTurn)
     }
   }
 
-  @Test fun quiteAndResume() {
+  "quite and resume" {
     var output: CompletedGame? = null
 
     RealTakeTurnsWorkflow().testFromStart(
@@ -111,7 +110,7 @@ class TakeTurnsWorkflowTest {
       output = awaitNextOutput()
     }
 
-    assertThat(output!!.ending).isSameInstanceAs(Quitted)
+    output!!.ending shouldBeSameInstanceAs Quitted
 
     RealTakeTurnsWorkflow().testFromStart(
         TakeTurnsInput.resumeGame(
@@ -119,10 +118,10 @@ class TakeTurnsWorkflowTest {
             output!!.lastTurn
         )
     ) {
-      assertThat(awaitNextRendering().gameState).isEqualTo(output!!.lastTurn)
+      awaitNextRendering().gameState shouldBe output!!.lastTurn
     }
   }
-}
+})
 
 private fun WorkflowTester<*, *, GamePlayScreen>.takeSquare(event: TakeSquare) {
   awaitNextRendering().onEvent(event)

--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
@@ -1,6 +1,5 @@
 package com.squareup.sample.mainworkflow
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.sample.authworkflow.AuthWorkflow
 import com.squareup.sample.authworkflow.Result.Authorized
 import com.squareup.sample.gameworkflow.GamePlayScreen
@@ -15,38 +14,42 @@ import com.squareup.workflow.rendering
 import com.squareup.workflow.stateless
 import com.squareup.workflow.testing.testFromStart
 import com.squareup.workflow.ui.BackStackScreen
-import org.junit.Test
+import io.kotlintest.matchers.collections.shouldHaveSize
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
 
 /**
  * Demonstrates unit testing of a composite workflow. Note how we
  * pass in fakes for the nested workflows.
  */
-class MainWorkflowTest {
-  @Test fun `starts in auth over empty game`() {
-    MainWorkflow(authWorkflow(), runGameWorkflow()).testFromStart {
-      awaitNextRendering()
-          .let { screen ->
-            assertThat(screen.panels).hasSize(1)
-            assertThat(screen.panels[0]).isEqualTo(DEFAULT_AUTH)
+class MainWorkflowTest : StringSpec() {
+  init {
+    "starts in auth over empty game" {
+      MainWorkflow(authWorkflow(), runGameWorkflow()).testFromStart {
+        awaitNextRendering()
+            .let { screen ->
+              screen.panels shouldHaveSize 1
+              screen.panels[0] shouldBe DEFAULT_AUTH
 
-            // This GamePlayScreen() is emitted by MainWorkflow itself.
-            assertThat(screen.body).isEqualTo(GamePlayScreen())
-          }
-    }
-  }
-
-  @Test fun `starts game on auth`() {
-    val authWorkflow: AuthWorkflow = Workflow.stateless {
-      onWorkerOutput(Worker.from { Unit }) { emitOutput(Authorized("auth")) }
-      authScreen()
+              // This GamePlayScreen() is emitted by MainWorkflow itself.
+              screen.body shouldBe GamePlayScreen()
+            }
+      }
     }
 
-    MainWorkflow(authWorkflow, runGameWorkflow()).testFromStart {
-      awaitNextRendering()
-          .let { screen ->
-            assertThat(screen.panels).isEmpty()
-            assertThat(screen.body).isEqualTo(DEFAULT_RUN_GAME)
-          }
+    "starts game on auth" {
+      val authWorkflow: AuthWorkflow = Workflow.stateless {
+        onWorkerOutput(Worker.from { Unit }) { emitOutput(Authorized("auth")) }
+        authScreen()
+      }
+
+      MainWorkflow(authWorkflow, runGameWorkflow()).testFromStart {
+        awaitNextRendering()
+            .let { screen ->
+              screen.panels shouldHaveSize 0
+              screen.body shouldBe DEFAULT_RUN_GAME
+            }
+      }
     }
   }
 

--- a/kotlin/samples/todo-android/todo-android-app/build.gradle
+++ b/kotlin/samples/todo-android/todo-android-app/build.gradle
@@ -32,6 +32,12 @@ android {
   packagingOptions {
     exclude 'META-INF/atomicfu.kotlin_module'
   }
+
+  testOptions {
+    unitTests.all {
+      useJUnitPlatform()
+    }
+  }
 }
 
 dependencies {
@@ -51,6 +57,5 @@ dependencies {
   implementation deps.rxjava2.rxjava2
   implementation deps.timber
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation deps.kotlin.test.kotlintest
 }

--- a/kotlin/samples/todo-android/todo-android-common/build.gradle
+++ b/kotlin/samples/todo-android/todo-android-common/build.gradle
@@ -25,9 +25,11 @@ dependencies {
   implementation deps.kotlin.reflect
   implementation deps.rxjava2.rxjava2
 
-  testImplementation deps.test.hamcrestCore
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation deps.kotlin.test.kotlintest
   testImplementation deps.rxjava2.extensions
   testImplementation project(':workflow-testing')
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/kotlin/workflow-core/build.gradle
+++ b/kotlin/workflow-core/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'kotlin'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 apply from: rootProject.file('.buildscript/configure-dokka.gradle')
 

--- a/kotlin/workflow-runtime/build.gradle
+++ b/kotlin/workflow-runtime/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'kotlin'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 apply from: rootProject.file('.buildscript/configure-dokka.gradle')
 

--- a/kotlin/workflow-rx2/build.gradle
+++ b/kotlin/workflow-rx2/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'kotlin'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 apply from: rootProject.file('.buildscript/configure-dokka.gradle')
 
@@ -35,5 +35,9 @@ dependencies {
   implementation deps.kotlin.reflect
 
   testImplementation project(':workflow-testing')
-  testImplementation deps.kotlin.test.jdk
+  testImplementation deps.kotlin.test.kotlintest
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/kotlin/workflow-rx2/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/kotlin/workflow-rx2/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.squareup.workflow.rx2.DefaultExceptionHandlerExtension

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkersTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkersTest.kt
@@ -16,6 +16,10 @@
 package com.squareup.workflow.rx2
 
 import com.squareup.workflow.testing.test
+import io.kotlintest.matchers.beInstanceOf
+import io.kotlintest.should
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.AnnotationSpec
 import io.reactivex.BackpressureStrategy.MISSING
 import io.reactivex.Flowable
 import io.reactivex.Maybe
@@ -25,11 +29,8 @@ import io.reactivex.subjects.CompletableSubject
 import io.reactivex.subjects.MaybeSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.SingleSubject
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
-class RxWorkersTest {
+class RxWorkersTest : AnnotationSpec() {
 
   private class ExpectedException : RuntimeException()
 
@@ -42,10 +43,10 @@ class RxWorkersTest {
 
     worker.test {
       subject.onNext("foo")
-      assertEquals("foo", nextOutput())
+      nextOutput() shouldBe "foo"
 
       subject.onNext("bar")
-      assertEquals("bar", nextOutput())
+      nextOutput() shouldBe "bar"
     }
   }
 
@@ -65,7 +66,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onNext("foo")
-      assertEquals("foo", nextOutput())
+      nextOutput() shouldBe "foo"
 
       subject.onComplete()
       assertFinished()
@@ -78,7 +79,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onError(ExpectedException())
-      assertTrue(getException() is ExpectedException)
+      getException() should beInstanceOf<ExpectedException>()
     }
   }
 
@@ -88,10 +89,10 @@ class RxWorkersTest {
     val worker = subject.doOnSubscribe { subscriptions++ }
         .asWorker()
 
-    assertEquals(0, subscriptions)
+    subscriptions shouldBe 0
 
     worker.test {
-      assertEquals(1, subscriptions)
+      subscriptions shouldBe 1
     }
   }
 
@@ -101,12 +102,12 @@ class RxWorkersTest {
     val worker = subject.doOnDispose { disposals++ }
         .asWorker()
 
-    assertEquals(0, disposals)
+    disposals shouldBe 0
 
     worker.test {
-      assertEquals(0, disposals)
+      disposals shouldBe 0
       cancelWorker()
-      assertEquals(1, disposals)
+      disposals shouldBe 1
     }
   }
 
@@ -121,10 +122,10 @@ class RxWorkersTest {
 
     worker.test {
       subject.onNext("foo")
-      assertEquals("foo", nextOutput())
+      nextOutput() shouldBe "foo"
 
       subject.onNext("bar")
-      assertEquals("bar", nextOutput())
+      nextOutput() shouldBe "bar"
     }
   }
 
@@ -146,7 +147,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onNext("foo")
-      assertEquals("foo", nextOutput())
+      nextOutput() shouldBe "foo"
 
       subject.onComplete()
       assertFinished()
@@ -160,7 +161,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onError(ExpectedException())
-      assertTrue(getException() is ExpectedException)
+      getException() should beInstanceOf<ExpectedException>()
     }
   }
 
@@ -171,10 +172,10 @@ class RxWorkersTest {
         .doOnSubscribe { subscriptions++ }
         .asWorker()
 
-    assertEquals(0, subscriptions)
+    subscriptions shouldBe 0
 
     worker.test {
-      assertEquals(1, subscriptions)
+      subscriptions shouldBe 1
     }
   }
 
@@ -185,12 +186,12 @@ class RxWorkersTest {
         .doOnCancel { cancels++ }
         .asWorker()
 
-    assertEquals(0, cancels)
+    cancels shouldBe 0
 
     worker.test {
-      assertEquals(0, cancels)
+      cancels shouldBe 0
       cancelWorker()
-      assertEquals(1, cancels)
+      cancels shouldBe 1
     }
   }
 
@@ -204,7 +205,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onSuccess("foo")
-      assertEquals("foo", nextOutput())
+      nextOutput() shouldBe "foo"
       assertFinished()
     }
   }
@@ -225,7 +226,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onError(ExpectedException())
-      assertTrue(getException() is ExpectedException)
+      getException() should beInstanceOf<ExpectedException>()
     }
   }
 
@@ -235,10 +236,10 @@ class RxWorkersTest {
     val worker = subject.doOnSubscribe { subscriptions++ }
         .asWorker()
 
-    assertEquals(0, subscriptions)
+    subscriptions shouldBe 0
 
     worker.test {
-      assertEquals(1, subscriptions)
+      subscriptions shouldBe 1
     }
   }
 
@@ -248,12 +249,12 @@ class RxWorkersTest {
     val worker = subject.doOnDispose { cancels++ }
         .asWorker()
 
-    assertEquals(0, cancels)
+    cancels shouldBe 0
 
     worker.test {
-      assertEquals(0, cancels)
+      cancels shouldBe 0
       cancelWorker()
-      assertEquals(1, cancels)
+      cancels shouldBe 1
     }
   }
 
@@ -267,7 +268,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onSuccess("foo")
-      assertEquals("foo", nextOutput())
+      nextOutput() shouldBe "foo"
       assertFinished()
     }
   }
@@ -278,7 +279,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onError(ExpectedException())
-      assertTrue(getException() is ExpectedException)
+      getException() should beInstanceOf<ExpectedException>()
     }
   }
 
@@ -288,10 +289,10 @@ class RxWorkersTest {
     val worker = subject.doOnSubscribe { subscriptions++ }
         .asWorker()
 
-    assertEquals(0, subscriptions)
+    subscriptions shouldBe 0
 
     worker.test {
-      assertEquals(1, subscriptions)
+      subscriptions shouldBe 1
     }
   }
 
@@ -301,12 +302,12 @@ class RxWorkersTest {
     val worker = subject.doOnDispose { cancels++ }
         .asWorker()
 
-    assertEquals(0, cancels)
+    cancels shouldBe 0
 
     worker.test {
-      assertEquals(0, cancels)
+      cancels shouldBe 0
       cancelWorker()
-      assertEquals(1, cancels)
+      cancels shouldBe 1
     }
   }
 
@@ -330,7 +331,7 @@ class RxWorkersTest {
 
     worker.test {
       subject.onError(ExpectedException())
-      assertTrue(getException() is ExpectedException)
+      getException() should beInstanceOf<ExpectedException>()
     }
   }
 
@@ -340,10 +341,10 @@ class RxWorkersTest {
     val worker = subject.doOnSubscribe { subscriptions++ }
         .asWorker("")
 
-    assertEquals(0, subscriptions)
+    subscriptions shouldBe 0
 
     worker.test {
-      assertEquals(1, subscriptions)
+      subscriptions shouldBe 1
     }
   }
 
@@ -353,12 +354,12 @@ class RxWorkersTest {
     val worker = subject.doOnDispose { cancels++ }
         .asWorker("")
 
-    assertEquals(0, cancels)
+    cancels shouldBe 0
 
     worker.test {
-      assertEquals(0, cancels)
+      cancels shouldBe 0
       cancelWorker()
-      assertEquals(1, cancels)
+      cancels shouldBe 1
     }
   }
 

--- a/kotlin/workflow-testing/build.gradle
+++ b/kotlin/workflow-testing/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'kotlin'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 apply from: rootProject.file('.buildscript/configure-dokka.gradle')
 

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka-android'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 apply from: rootProject.file('.buildscript/configure-dokka.gradle')
 
@@ -28,6 +28,14 @@ android rootProject.ext.defaultAndroidConfig
 // See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940
 android.packagingOptions {
   exclude 'META-INF/atomicfu.kotlin_module'
+}
+
+android {
+  testOptions {
+    unitTests.all {
+      useJUnitPlatform()
+    }
+  }
 }
 
 dependencies {
@@ -48,7 +56,6 @@ dependencies {
   implementation deps.kotlin.coroutines.rx2
   implementation deps.kotlin.reflect
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
   testImplementation deps.kotlin.coroutines.test
+  testImplementation deps.kotlin.test.kotlintest
 }

--- a/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
+++ b/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.squareup.workflow.ui
 
-import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow.RenderingAndSnapshot
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.Workflow
@@ -9,6 +8,8 @@ import com.squareup.workflow.asWorker
 import com.squareup.workflow.onWorkerOutput
 import com.squareup.workflow.stateless
 import com.squareup.workflow.ui.WorkflowRunner.Config
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.AnnotationSpec
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.Unconfined
@@ -24,10 +25,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
-import org.junit.Test
 
 @UseExperimental(ExperimentalWorkflowUi::class, ExperimentalCoroutinesApi::class)
-class WorkflowRunnerViewModelTest {
+class WorkflowRunnerViewModelTest : AnnotationSpec() {
 
   private val scope = CoroutineScope(Unconfined)
   @Suppress("RemoveRedundantSpreadOperator")
@@ -41,13 +41,13 @@ class WorkflowRunnerViewModelTest {
 
     val runner = WorkflowRunnerViewModel(scope, snapshotsFlow, emptyFlow(), viewRegistry)
 
-    assertThat(runner.getLastSnapshotForTest()).isEqualTo(Snapshot.EMPTY)
+    runner.getLastSnapshotForTest() shouldBe Snapshot.EMPTY
 
     snapshotsChannel.offer(RenderingAndSnapshot(Unit, snapshot1))
-    assertThat(runner.getLastSnapshotForTest()).isEqualTo(snapshot1)
+    runner.getLastSnapshotForTest() shouldBe snapshot1
 
     snapshotsChannel.offer(RenderingAndSnapshot(Unit, snapshot2))
-    assertThat(runner.getLastSnapshotForTest()).isEqualTo(snapshot2)
+    runner.getLastSnapshotForTest() shouldBe snapshot2
   }
 
   @Test fun hostCancelledOnResultAndNoSooner() {
@@ -61,11 +61,11 @@ class WorkflowRunnerViewModelTest {
     }
     val runner = WorkflowRunnerViewModel(scope, emptyFlow(), flowOf("fnord"), viewRegistry)
 
-    assertThat(cancelled).isFalse()
+    cancelled shouldBe false
     val tester = runner.result.test()
-    assertThat(cancelled).isTrue()
+    cancelled shouldBe true
     tester.assertComplete()
-    assertThat(tester.values()).isEqualTo(listOf("fnord"))
+    tester.values() shouldBe listOf("fnord")
   }
 
   @Test fun hostCancelledOnCleared() {
@@ -79,10 +79,10 @@ class WorkflowRunnerViewModelTest {
     }
     val runner = WorkflowRunnerViewModel(scope, emptyFlow(), emptyFlow(), viewRegistry)
 
-    assertThat(cancelled).isFalse()
+    cancelled shouldBe false
     val tester = runner.result.test()
     runner.clearForTest()
-    assertThat(cancelled).isTrue()
+    cancelled shouldBe true
     tester.assertComplete()
     tester.assertNoValues()
   }
@@ -101,7 +101,7 @@ class WorkflowRunnerViewModelTest {
     tester.assertNotComplete()
     runBlocking { outputs.send("fnord") }
     tester.assertComplete()
-    assertThat(tester.values()).isEqualTo(listOf("fnord"))
+    tester.values() shouldBe listOf("fnord")
   }
 
   @Test fun resultEmptyOnCleared() {

--- a/kotlin/workflow-ui-core/build.gradle
+++ b/kotlin/workflow-ui-core/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'kotlin'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 apply from: rootProject.file('.buildscript/configure-dokka.gradle')
 
@@ -30,5 +30,9 @@ dependencies {
   implementation deps.kotlin.reflect
 
   testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.truth
+  testImplementation deps.kotlin.test.kotlintest
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/CompatibleTest.kt
+++ b/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/CompatibleTest.kt
@@ -15,12 +15,12 @@
  */
 package com.squareup.workflow.ui
 
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import io.kotlintest.matchers.collections.shouldHaveSize
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.AnnotationSpec
 
-// If you try to replace isTrue() with isTrue compilation fails.
-@Suppress("UsePropertyAccessSyntax")
-class CompatibleTest {
+class CompatibleTest : AnnotationSpec() {
   private object Able
   private object Baker
   private object Charlie
@@ -29,18 +29,18 @@ class CompatibleTest {
     val able = object : Any() {}
     val baker = object : Any() {}
 
-    assertThat(compatible(able, baker)).isFalse()
+    compatible(able, baker) shouldBe false
   }
 
   @Test fun `Same type matches`() {
-    assertThat(compatible("Able", "Baker")).isTrue()
+    compatible("Able", "Baker") shouldBe true
   }
 
   @Test fun `isCompatibleWith is honored`() {
     data class K(override val compatibilityKey: String) : Compatible
 
-    assertThat(compatible(K("hey"), K("hey"))).isTrue()
-    assertThat(compatible(K("hey"), K("ho"))).isFalse()
+    compatible(K("hey"), K("hey")) shouldBe true
+    compatible(K("hey"), K("ho")) shouldBe false
   }
 
   @Test fun `Different Compatible types do not match`() {
@@ -49,14 +49,14 @@ class CompatibleTest {
     class Able(override val compatibilityKey: String) : A()
     class Alpha(override val compatibilityKey: String) : A()
 
-    assertThat(compatible(Able("Hey"), Alpha("Hey"))).isFalse()
+    compatible(Able("Hey"), Alpha("Hey")) shouldBe false
   }
 
   @Test fun `goTo pushes`() {
     val stack = listOf<Any>(Able).goTo(Baker)
         .goTo(Charlie)
 
-    assertThat(stack).isEqualTo(listOf(Able, Baker, Charlie))
+    stack shouldBe listOf(Able, Baker, Charlie)
   }
 
   @Test fun `goTo pops to bottom`() {
@@ -64,7 +64,7 @@ class CompatibleTest {
         .goTo(Charlie)
         .goTo(Able)
 
-    assertThat(stack).isEqualTo(listOf(Able))
+    stack shouldBe listOf(Able)
   }
 
   @Test fun `goTo pops to middle`() {
@@ -72,7 +72,7 @@ class CompatibleTest {
         .goTo(Charlie)
         .goTo(Baker)
 
-    assertThat(stack).isEqualTo(listOf(Able, Baker))
+    stack shouldBe listOf(Able, Baker)
   }
 
   @Test fun `goTo Named works`() {
@@ -83,7 +83,7 @@ class CompatibleTest {
         Named(Able, "three")
     ).goTo(Named(Able, "one"))
 
-    assertThat(stack).hasSize(1)
-    assertThat(stack[0]).isSameInstanceAs(originalAble)
+    stack shouldHaveSize 1
+    stack[0] shouldBeSameInstanceAs originalAble
   }
 }

--- a/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/NamedTest.kt
+++ b/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/NamedTest.kt
@@ -15,82 +15,66 @@
  */
 package com.squareup.workflow.ui
 
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
+import io.kotlintest.specs.AnnotationSpec
 
-// If you try to replace isTrue() with isTrue compilation fails.
-@Suppress("UsePropertyAccessSyntax")
-class NamedTest {
+class NamedTest : AnnotationSpec() {
   object Whut
   object Hey
 
   @Test fun `same type same name matches`() {
-    assertThat(compatible(Named(Hey, "eh"), Named(Hey, "eh"))).isTrue()
+    compatible(Named(Hey, "eh"), Named(Hey, "eh")) shouldBe true
   }
 
   @Test fun `same type diff name matches`() {
-    assertThat(compatible(Named(Hey, "blam"), Named(Hey, "bloom"))).isFalse()
+    compatible(Named(Hey, "blam"), Named(Hey, "bloom")) shouldBe false
   }
 
   @Test fun `diff type same name no match`() {
-    assertThat(compatible(Named(Hey, "a"), Named(Whut, "a"))).isFalse()
+    compatible(Named(Hey, "a"), Named(Whut, "a")) shouldBe false
   }
 
   @Test fun recursion() {
-    assertThat(
-        compatible(
-            Named(Named(Hey, "one"), "ho"),
-            Named(Named(Hey, "one"), "ho")
-        )
-    ).isTrue()
 
-    assertThat(
-        compatible(
-            Named(Named(Hey, "one"), "ho"),
-            Named(Named(Hey, "two"), "ho")
-        )
-    ).isFalse()
+    compatible(Named(Named(Hey, "one"), "ho"), Named(Named(Hey, "one"), "ho")) shouldBe true
 
-    assertThat(
-        compatible(
-            Named(Named(Hey, "a"), "ho"),
-            Named(Named(Whut, "a"), "ho")
-        )
-    ).isFalse()
+    compatible(Named(Named(Hey, "one"), "ho"), Named(Named(Hey, "two"), "ho")) shouldBe false
+
+    compatible(Named(Named(Hey, "a"), "ho"), Named(Named(Whut, "a"), "ho")) shouldBe false
   }
 
   @Test fun `key recursion`() {
-    assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
-        .isEqualTo(Named(Named(Hey, "one"), "ho").compatibilityKey)
+    Named(Named(Hey, "one"), "ho").compatibilityKey shouldBe
+        Named(Named(Hey, "one"), "ho").compatibilityKey
 
-    assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
-        .isNotEqualTo(Named(Named(Hey, "two"), "ho").compatibilityKey)
+    Named(Named(Hey, "one"), "ho").compatibilityKey shouldNotBe
+        Named(Named(Hey, "two"), "ho").compatibilityKey
 
-    assertThat(Named(Named(Hey, "a"), "ho").compatibilityKey)
-        .isNotEqualTo(Named(Named(Whut, "a"), "ho").compatibilityKey)
+    Named(Named(Hey, "a"), "ho").compatibilityKey shouldNotBe
+        Named(Named(Whut, "a"), "ho").compatibilityKey
   }
 
   @Test fun `recursive keys are legible`() {
-    assertThat(Named(Named(Hey, "one"), "ho").compatibilityKey)
-        .isEqualTo("com.squareup.workflow.ui.NamedTest\$Hey-Named(one)-Named(ho)")
+    Named(Named(Hey, "one"), "ho").compatibilityKey shouldBe
+        "com.squareup.workflow.ui.NamedTest\$Hey-Named(one)-Named(ho)"
   }
 
   private class Foo(override val compatibilityKey: String) : Compatible
 
   @Test fun `the test Compatible class actually works`() {
-    assertThat(compatible(Foo("bar"), Foo("bar"))).isTrue()
-    assertThat(compatible(Foo("bar"), Foo("baz"))).isFalse()
+    compatible(Foo("bar"), Foo("bar")) shouldBe true
+    compatible(Foo("bar"), Foo("baz")) shouldBe false
   }
 
   @Test fun `wrapping custom Compatible compatibility works`() {
-    assertThat(compatible(Named(Foo("bar"), "name"), Named(Foo("bar"), "name"))).isTrue()
-    assertThat(compatible(Named(Foo("bar"), "name"), Named(Foo("baz"), "name"))).isFalse()
+    compatible(Named(Foo("bar"), "name"), Named(Foo("bar"), "name")) shouldBe true
+    compatible(Named(Foo("bar"), "name"), Named(Foo("baz"), "name")) shouldBe false
   }
 
   @Test fun `wrapping custom Compatible keys work`() {
-    assertThat(Named(Foo("bar"), "name").compatibilityKey)
-        .isEqualTo(Named(Foo("bar"), "name").compatibilityKey)
-    assertThat(Named(Foo("bar"), "name").compatibilityKey)
-        .isNotEqualTo(Named(Foo("baz"), "name").compatibilityKey)
+    Named(Foo("bar"), "name").compatibilityKey shouldBe Named(Foo("bar"), "name").compatibilityKey
+    Named(Foo("bar"), "name").compatibilityKey shouldNotBe
+        Named(Foo("baz"), "name").compatibilityKey
   }
 }


### PR DESCRIPTION
So this is what kotlintest looks like. I'm a bit freaked out for a couple of reasons:

 * `MainWorkflowTest` and a couple of others pass in the command lie but fail in the IDE with `NoSuchMethodError CompletableJob`
 * A couple of tests in `WorkflowRunnerViewModelTest` flat out fail now that really shouldn't have changed.

I'll look a little harder on Monday, but I'm wary.