### PR TITLE
[Swift] Allow reuse of sinks across render passes

### DIFF
--- a/swift/Workflow/Sources/WorkflowHost.swift
+++ b/swift/Workflow/Sources/WorkflowHost.swift
@@ -53,6 +53,19 @@ public final class WorkflowHost<WorkflowType: Workflow> {
 
     }
 
+    /// Update the input for the workflow. Will cause a render pass.
+    public func update(workflow: WorkflowType) {
+        rootNode.update(workflow: workflow)
+
+        // Treat the update as an "output" from the workflow as an external event to force a render pass.
+        let output = WorkflowNode<WorkflowType>.Output(
+            outputEvent: nil,
+            debugInfo: WorkflowUpdateDebugInfo(
+                workflowType: "\(WorkflowType.self)",
+                kind: .didUpdate(source: .external)))
+        handle(output: output)
+    }
+
     private func handle(output: WorkflowNode<WorkflowType>.Output) {
         mutableRendering.value = rootNode.render()
 

--- a/swift/Workflow/Sources/WorkflowHost.swift
+++ b/swift/Workflow/Sources/WorkflowHost.swift
@@ -57,7 +57,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
     public func update(workflow: WorkflowType) {
         rootNode.update(workflow: workflow)
 
-        // Treat the update as an "output" from the workflow as an external event to force a render pass.
+        // Treat the update as an "output" from the workflow originating from an external event to force a render pass.
         let output = WorkflowNode<WorkflowType>.Output(
             outputEvent: nil,
             debugInfo: WorkflowUpdateDebugInfo(

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -13,7 +13,7 @@ final class ConcurrencyTests: XCTestCase {
 
         let expectation = XCTestExpectation()
         var first = true
-        var observedScreen: TestWorkflow.TestScreen? = nil
+        var observedScreen: TestScreen? = nil
 
         let disposable = host.rendering.signal.observeValues { rendering in
             if first {
@@ -70,6 +70,98 @@ final class ConcurrencyTests: XCTestCase {
         disposable?.dispose()
     }
 
+    // A `sink` is invalidated after a single action has been received. However, if the next `render` pass uses a sink
+    // of the same type, actions sent to an old sink should be proxied through the new sink.
+    // This allows for a UI that does not synchronously update to use the new sink.
+    func test_old_sink_proxies_to_new_sink() {
+        let host = WorkflowHost(workflow: TestWorkflow())
+
+        // Capture the initial screen and corresponding closure that uses the original sink.
+        let initialScreen = host.rendering.value
+        XCTAssertEqual(0, initialScreen.count)
+
+        // Send an action to the workflow. This invalidates this sink, but the next render pass declares a
+        // sink of the same type.
+        initialScreen.update()
+
+        let secondScreen = host.rendering.value
+        XCTAssertEqual(1, secondScreen.count)
+
+        // Send an action from the original screen and sink. It should be proxied through the most recent sink.
+        initialScreen.update()
+
+        let thirdScreen = host.rendering.value
+        XCTAssertEqual(2, thirdScreen.count)
+    }
+
+    // If a previous `sink` has been invalidated due to receiving an action, and a new sink of the same type
+    // is not redeclared on the subsequent render pass, it should be considered invalid and not allowed to send actions.
+    func test_invalidate_old_sink_if_not_redeclared() {
+        let host = WorkflowHost(workflow: OneShotWorkflow())
+
+        // Capture the initial screen and corresponding closure that uses the original sink.
+        let initialScreen = host.rendering.value
+        XCTAssertEqual(0, initialScreen.count)
+
+        // Send an action to the workflow. This invalidates this sink, but the next render pass declares a
+        // sink of the same type.
+        initialScreen.update()
+
+        let secondScreen = host.rendering.value
+        XCTAssertEqual(1, secondScreen.count)
+
+        // MANUAL TEST CASE: Uncomment to validate this fatal errors.
+        // Calling `update` uses the original sink. This will fail with a fatalError as the sink was not redeclared.
+        //initialScreen.update()
+
+        // If the sink *was* still valid, this would be correct. However, it should just fail and be `1` still.
+        //XCTAssertEqual(2, secondScreen.count)
+        // Actual expected result, if we had not fatal errored.
+        XCTAssertEqual(1, host.rendering.value.count)
+
+        struct OneShotWorkflow: Workflow {
+            typealias Output = Never
+            struct State {
+                var count: Int
+            }
+
+            func makeInitialState() -> State {
+                return State(count: 0)
+            }
+
+            func workflowDidChange(from previousWorkflow: OneShotWorkflow, state: inout State) {
+            }
+
+            enum Action: WorkflowAction {
+                typealias WorkflowType = OneShotWorkflow
+
+                case updated
+
+                func apply(toState state: inout State) -> Never? {
+                    switch self {
+                    case .updated:
+                        state.count += 1
+                        return nil
+                    }
+                }
+            }
+
+            typealias Rendering = TestScreen
+            func render(state: State, context: RenderContext<OneShotWorkflow>) -> Rendering {
+                let update: () -> Void
+                if state.count == 0 {
+                    let sink = context.makeSink(of: Action.self)
+                    update = {
+                        sink.send(.updated)
+                    }
+                } else {
+                    update = {}
+                }
+                return TestScreen(count: state.count, update: update)
+            }
+        }
+    }
+
     // When events are queued, the debug info must be received in the order the events were processed.
     // This is to validate that `enableEvents` is tail recursive when handled by the WorkflowHost.
     func test_debugEventsAreOrdered() {
@@ -104,6 +196,64 @@ final class ConcurrencyTests: XCTestCase {
         XCTAssertEqual("2", debugger.snapshots[1].stateDescription)
 
         disposable?.dispose()
+    }
+
+    func test_childWorkflowsAreSynchronous() {
+
+        let host = WorkflowHost(workflow: ParentWorkflow())
+
+        let initialScreen = host.rendering.value
+        XCTAssertEqual(0, initialScreen.count)
+        initialScreen.update()
+
+        // This update happens immediately as a new rendering is generated synchronously.
+        // Both the child updates from the action (incrementing state by 1) as well as the
+        // parent from the output (incrementing its state by 10)
+        XCTAssertEqual(11, host.rendering.value.count)
+
+        struct ParentWorkflow: Workflow {
+            struct State {
+                var count: Int
+            }
+
+            func makeInitialState() -> State {
+                return State(count: 0)
+            }
+
+            func workflowDidChange(from previousWorkflow: ParentWorkflow, state: inout State) {
+            }
+
+            enum Action: WorkflowAction {
+                typealias WorkflowType = ParentWorkflow
+
+                case update
+
+                func apply(toState state: inout State) -> Output? {
+                    switch self {
+                    case .update:
+                        state.count += 10
+                        return nil
+                    }
+                }
+            }
+
+            typealias Rendering = TestScreen
+
+            func render(state: State, context: RenderContext<ParentWorkflow>) -> Rendering {
+                var childScreen = TestWorkflow(running: .idle, signal: TestSignal())
+                    .mapOutput({ output -> Action in
+                        switch output {
+                        case .emit:
+                            return .update
+                        }
+                    })
+                    .rendered(with: context)
+
+                childScreen.count += state.count
+                return childScreen
+            }
+        }
+
     }
 
     // Signals are subscribed on a different scheduler than the UI scheduler,
@@ -157,6 +307,199 @@ final class ConcurrencyTests: XCTestCase {
         disposable?.dispose()
     }
 
+    // Since event pipes are reused for the same type, validate that the `AnyWorkflowAction`
+    // defined event pipes still sends through the correct action.
+    // Because they are just backed by type, not the actual action, they send the actions appropriately.
+    // (Thus, there is a single backing `TypedSink` for `AnyWorkflowAction`, but the correct action is applied.
+    func test_multipleAnyWorkflowAction_sinksDontOverrideEachOther() {
+
+        let host = WorkflowHost(workflow: AnyActionWorkflow())
+
+        let initialScreen = host.rendering.value
+        XCTAssertEqual(0, initialScreen.count)
+
+        // Update using the first action.
+        initialScreen.updateFirst()
+
+        let secondScreen = host.rendering.value
+        XCTAssertEqual(1, secondScreen.count)
+
+        // Update using the second action.
+        secondScreen.updateSecond()
+        XCTAssertEqual(11, host.rendering.value.count)
+
+        struct AnyActionWorkflow: Workflow {
+            enum Output {
+                case emit
+            }
+
+            struct State {
+                var count: Int
+            }
+
+            func makeInitialState() -> State {
+                return State(count: 0)
+            }
+
+            func workflowDidChange(from previousWorkflow: AnyActionWorkflow, state: inout State) {
+
+            }
+
+            enum FirstAction: WorkflowAction {
+
+                typealias WorkflowType = AnyActionWorkflow
+                case update
+
+                func apply(toState state: inout State) -> Output? {
+                    switch self {
+                    case .update:
+                        state.count += 1
+                    }
+                    return nil
+                }
+            }
+
+            enum SecondAction: WorkflowAction {
+
+                typealias WorkflowType = AnyActionWorkflow
+                case update
+
+                func apply(toState state: inout State) -> Output? {
+                    switch self {
+                    case .update:
+                        state.count += 10
+                    }
+                    return nil
+                }
+            }
+
+            struct TestScreen {
+                var count: Int
+                var updateFirst: () -> Void
+                var updateSecond: () -> Void
+            }
+            typealias Rendering = TestScreen
+
+            func render(state: State, context: RenderContext<AnyActionWorkflow>) -> Rendering {
+
+                let firstSink = context
+                    .makeSink(
+                        of: AnyWorkflowAction.self)
+                    .contraMap { (action: FirstAction) -> AnyWorkflowAction<AnyActionWorkflow> in
+                        AnyWorkflowAction(action)
+                    }
+
+                let secondSink = context
+                    .makeSink(
+                        of: AnyWorkflowAction.self)
+                    .contraMap { (action: SecondAction) -> AnyWorkflowAction<AnyActionWorkflow> in
+                        AnyWorkflowAction(action)
+                    }
+
+                return TestScreen(
+                    count: state.count,
+                    updateFirst: {
+                        firstSink.send(.update)
+                    },
+                    updateSecond: {
+                        secondSink.send(.update)
+                    })
+            }
+        }
+
+    }
+
+    /// Since event pipes are allowed to be reused, and shared for the same backing action type
+    /// validate that they are also only reused for the same source type - ie: a sink for an
+    /// action should not use the same event pipe as a worker that maps to the same action type.
+    /// This will likely need to be a test that will be "correct" when it fatal errors
+    /// since the behavior would be reusing the wrong event pipe for an old sink that was not
+    /// redeclared.
+    func test_eventPipesAreOnlyReusedForSameSource() {
+        let host = WorkflowHost(workflow: SourceDifferentiatingWorkflow(step: .first))
+
+        //let initialScreen = host.rendering.value
+        XCTAssertEqual(0, host.rendering.value.count)
+
+        // Update to the second "step", which will cause a render update, with the sink not being declared.
+        host.update(workflow: SourceDifferentiatingWorkflow(step: .second))
+        // The state should be the same, even though it rendered again.
+        XCTAssertEqual(0, host.rendering.value.count)
+
+        // MANUAL TEST CASE
+        // This will fail, as the sink held by `initialScreen` has not be redeclared, even though the backing action is the same for the worker.
+        // Uncomment to validate this test fails with a fatal error.
+        //initialScreen.update()
+        XCTAssertEqual(0, host.rendering.value.count)
+
+        struct SourceDifferentiatingWorkflow: Workflow {
+
+            var step: Step
+            enum Step {
+                case first
+                case second
+            }
+
+            struct State {
+                var count: Int
+            }
+
+            func makeInitialState() -> State {
+                return State(count: 0)
+            }
+
+            func workflowDidChange(from previousWorkflow: SourceDifferentiatingWorkflow, state: inout State) {
+            }
+
+            enum Action: WorkflowAction {
+                typealias WorkflowType = SourceDifferentiatingWorkflow
+
+                case update
+
+                func apply(toState state: inout State) -> Never? {
+                    switch self {
+                    case .update:
+                        state.count += 1
+                        return nil
+                    }
+                }
+            }
+
+            struct DelayWorker: Worker {
+                typealias Output = Action
+
+                func run() -> SignalProducer<Output, NoError> {
+                    return SignalProducer(value: .update).delay(0.1, on: QueueScheduler.main)
+                }
+
+                func isEquivalent(to otherWorker: DelayWorker) -> Bool {
+                    return true
+                }
+            }
+
+            typealias Rendering = TestScreen
+
+            func render(state: State, context: RenderContext<SourceDifferentiatingWorkflow>) -> Rendering {
+                let update: () -> Void
+                switch step {
+
+                case .first:
+                    let sink = context.makeSink(of: Action.self)
+                    update = { sink.send(.update) }
+
+                case .second:
+                    update = {}
+                }
+
+                context.awaitResult(for: DelayWorker(), outputMap: { $0 })
+
+                return TestScreen(count: state.count, update: update)
+            }
+        }
+    }
+
+    // MARK - Test Types
+
     fileprivate class TestSignal {
         let (signal, observer) = Signal<Int, NoError>.pipe()
         var sent: Bool = false
@@ -169,7 +512,18 @@ final class ConcurrencyTests: XCTestCase {
         }
     }
 
+
+    fileprivate struct TestScreen {
+        var count: Int
+        var update: () -> Void
+    }
+
+
     fileprivate struct TestWorkflow: Workflow {
+
+        enum Output {
+            case emit
+        }
 
         init(running: Running = .idle, signal: TestSignal = TestSignal()) {
             self.running = running
@@ -194,11 +548,11 @@ final class ConcurrencyTests: XCTestCase {
             }
         }
 
-        func makeInitialState() -> ConcurrencyTests.TestWorkflow.State {
+        func makeInitialState() -> State {
             return State(count: 0, running: self.running, signal: self.signal)
         }
 
-        func workflowDidChange(from previousWorkflow: ConcurrencyTests.TestWorkflow, state: inout ConcurrencyTests.TestWorkflow.State) {
+        func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {
         }
 
         enum Action: WorkflowAction {
@@ -206,23 +560,18 @@ final class ConcurrencyTests: XCTestCase {
 
             case update
 
-            func apply(toState state: inout ConcurrencyTests.TestWorkflow.State) -> ConcurrencyTests.TestWorkflow.Output? {
+            func apply(toState state: inout State) -> Output? {
                 switch self {
                 case .update:
                     state.count += 1
-                    return nil
+                    return .emit
                 }
             }
         }
 
-        struct TestScreen {
-            var count: Int
-            var update: () -> Void
-        }
-
         typealias Rendering = TestScreen
 
-        func render(state: ConcurrencyTests.TestWorkflow.State, context: RenderContext<ConcurrencyTests.TestWorkflow>) -> ConcurrencyTests.TestWorkflow.TestScreen {
+        func render(state: State, context: RenderContext<TestWorkflow>) -> Rendering {
 
             switch state.running {
             case .idle:
@@ -246,11 +595,11 @@ final class ConcurrencyTests: XCTestCase {
         struct TestWorker: Worker {
             typealias Output = TestWorkflow.Action
 
-            func run() -> SignalProducer<ConcurrencyTests.TestWorkflow.Action, NoError> {
+            func run() -> SignalProducer<Output, NoError> {
                 return SignalProducer(value: .update)
             }
 
-            func isEquivalent(to otherWorker: ConcurrencyTests.TestWorkflow.TestWorker) -> Bool {
+            func isEquivalent(to otherWorker: TestWorker) -> Bool {
                 return true
             }
         }

--- a/swift/Workflow/Tests/WorkflowHostTests.swift
+++ b/swift/Workflow/Tests/WorkflowHostTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import Workflow
+
+
+final class WorkflowHostTests: XCTestCase {
+
+    func test_updatedInputCausesRenderPass() {
+        let host = WorkflowHost(workflow: TestWorkflow(step: .first))
+
+        XCTAssertEqual(1, host.rendering.value)
+
+        host.update(workflow: TestWorkflow(step: .second))
+
+        XCTAssertEqual(2, host.rendering.value)
+    }
+
+    fileprivate struct TestWorkflow: Workflow {
+        var step: Step
+        enum Step {
+            case first
+            case second
+        }
+
+        struct State {}
+        func makeInitialState() -> State {
+            return State()
+        }
+
+        func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {
+        }
+
+        typealias Rendering = Int
+
+        func render(state: State, context: RenderContext<TestWorkflow>) -> Rendering {
+            switch self.step {
+            case .first:
+                return 1
+            case .second:
+                return 2
+            }
+        }
+    }
+}


### PR DESCRIPTION
The UI receiving the screen or rendering from a workflow *should* synchronously update to use the newest sinks and closures on every render pass.

However, some declarative UI *may* not always update synchronously (for instance, will wait for the next render pass) which for very rapid UI originated events may result in an old sink being reused.

This change relaxes the strictness internally - as long as a subsequent render pass declares a sink of the same action type, it will be "reused" and thus proxy events from the prior sink through. If a sink of the same type is *not* declared, it will still be an error to send an action to a stale sink. This does not change the restriction for there only being a single action sent to a sink for each render pass.

Additionally, adds and `update` to `WorkflowHost` to allow the input to change (#351) as this facilitated some of the test cases (and is a current gap between the Swift and Kotlin implementations). Providing an update to the input in `ContainerViewController` will come in a followup PR.

Issue #443 
