### PR TITLE
[WIP] Adding ABI validation using japicmp.

### DIFF
--- a/kotlin/abi-validation/README.md
+++ b/kotlin/abi-validation/README.md
@@ -1,0 +1,3 @@
+# binary-validation
+
+TODO

--- a/kotlin/abi-validation/build.gradle
+++ b/kotlin/abi-validation/build.gradle
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import me.champeau.gradle.japicmp.JapicmpTask
+
+apply plugin: 'java-library'
+apply plugin: 'me.champeau.gradle.japicmp'
+
+configurations {
+  baseline
+  latest
+}
+
+dependencies {
+  [
+      ['workflow-core', 'workflow-core-jvm', 'runtimeElements'],
+      ['workflow-runtime', 'workflow-runtime-jvm', 'runtimeElements'],
+      ['workflow-testing', 'workflow-testing-jvm', 'runtimeElements'],
+      ['workflow-ui-core', 'workflow-ui-core-jvm', 'runtimeElements'],
+      ['workflow-ui-android', 'workflow-ui-android', 'releaseRuntimeElements'],
+      ['workflow-rx2', 'workflow-rx2', 'runtimeElements'],
+  ].forEach {
+    def moduleName = it[0]
+    def artifactName = it[1]
+    def configuration = it[2]
+
+    baseline("com.squareup.workflow:$artifactName:0.18.0") {
+      transitive = false
+      force = true
+    }
+    latest project(path: ":$moduleName", configuration: configuration)
+  }
+}
+
+// TODO This breaks for android modules because they don't have a jar task.
+task japicmp(type: JapicmpTask, dependsOn: 'jar') {
+  oldClasspath = configurations.baseline
+  newClasspath = configurations.latest
+  onlyBinaryIncompatibleModified = true
+  failOnModification = false
+  txtOutputFile = file("$buildDir/reports/japi.txt")
+  ignoreMissingClasses = true
+  includeSynthetic = true
+  packageExcludes = [
+      'com.squareup.workflow.internal',
+  ]
+}
+check.dependsOn japicmp

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -82,6 +82,7 @@ buildscript {
       'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
       // Source of "API 'variant.getJavaCompile()' is obsolete" warning, because of course it is.
       'mavenPublish': "com.vanniktech:gradle-maven-publish-plugin:0.8.0",
+      'japicmp': 'me.champeau.gradle:japicmp-gradle-plugin:0.2.8',
       'ktlint': "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:5.1.0",
       'lanterna': "com.googlecode.lanterna:lanterna:3.0.1",
       'detekt': "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC16",
@@ -107,6 +108,7 @@ buildscript {
     classpath deps.detekt
     classpath deps.dokka
     classpath deps.dokkaAndroid
+    classpath deps.japicmp
     classpath deps.kotlin.gradlePlugin
     classpath deps.ktlint
     classpath deps.mavenPublish

--- a/kotlin/settings.gradle
+++ b/kotlin/settings.gradle
@@ -15,6 +15,7 @@
  */
 rootProject.name = "workflow"
 
+include ':abi-validation'
 include ':legacy:legacy-workflow-core'
 include ':legacy:legacy-workflow-rx2'
 include ':legacy:legacy-workflow-test'


### PR DESCRIPTION
I added a module that just uses japicmp to perform binary diffing. Not ready to merge for a few reasons.

- This plugin only gives pass/fail results + a diff report. Since we don't actually want to block backwards-incompatible changes, the pass/fail isn't useful.
- Unlike the binary validator used by the kotlin standard and coroutines libraries, this tool does not produce a dump that can be diffed by git
  - So in order to view the changes we need to expose the diff report from the Travis build somehow.
  - We can only easily diff against the last-released version, which makes the output much less useful for individual builds.

While this tool can help us once we hit v1.0 and don't want to break binary compatibility, it is not useful for more informative reporting about how our ABI is changing from commit-to-commit. I would much rather use a tool like the one in kotlin's libraries, but that is just raw source they've copy/pasted around. Not convinced it's worth it at this time.