### PR TITLE
Embed the Swift API docs in the regular site.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ SampleApp.xcworkspace
 
 # Special Mkdocs files
 docs/kotlin/api/
+docs/swift/api/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,35 @@ matrix:
   include:
     # Verify the documentation site builds successfully, but don't deploy it.
     - language: python
+      name: "Documentation: Static site"
       python:
         - "2.7"
       install:
         - pip install mkdocs-material
       script:
         - mkdocs build
+    # Verify the Swift documentation builds successfully.
+    - language: swift
+      name: "Documentation: Swift API"
+      os: osx
+      osx_image: xcode10.2
+      install:
+        - gem update --system
+        - bundle install
+        - brew install sourcedocs
+        - cd swift/Samples/SampleApp
+        - bundle exec pod repo update
+      script:
+        - ../../../.buildscript/build_swift_docs.sh /tmp/swiftdocs
     # Ensure docs are formatted correctly.
     - language: ruby
+      name: "Documentation: Markdown lint"
       install:
         - gem install mdl
       script:
         - ./lint_docs.sh
     - language: android
-      name: "Android"
+      name: "Kotlin & Android"
       jdk: oraclejdk8
       env:
         - secure: "SWQBLsaI5fOfiM+48/oAOcynsnpa1hHADxs8Vsmt7gsqVrtL369znwsX+PkNOXTdAROPKHzfCw1PkMSKiWHwSB+Gc8fMqFoVjxPnpi0NAhm2b4q4pq6GLOed2xF93eLoQZ7x4UwcUie58Qlwif9ZSGyp+7V6fEy7/AexGLPAuD0="

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,9 +92,9 @@ consists of three parts:
    theming) is used to convert the Markdown to static, styled HTML.
 1. Kotlin API reference: Kdoc embedded in Kotlin source files is converted to GitHub-flavored
    Markdown by Dokka and then included in the statically-generated website.
-1. Swift API reference: Markup comments from Swift files are converted directly to HTML by
-   [Jazzy](https://github.com/realm/jazzy) _after_ the site is generated, but dropped into the same
-   directory structure as the generated HTML.
+1. Swift API reference: Markup comments from Swift files are converted Markdown by
+   [Sourcedocs](https://github.com/eneko/SourceDocs) and then included in the statically-generated
+   website.
 
 ### Setting up the site generators
 
@@ -110,17 +110,18 @@ cd kotlin
 ./gradlew dokka
 ```
 
-#### Swift: Jazzy
+#### Swift: Sourcedocs
 
-Jazzy is a RubyGem that generates an HTML site from Swift files. You need Ruby, rubygems,
-bundler (2.x), Xcode 10.1+, CocoaPods, and of course Jazzy itself, to run it. Assuming you've
+Sourcedocs generates a Markdown site from Swift files. You need Ruby, rubygems,
+bundler (2.x), Xcode 10.2+, CocoaPods, and of course Sourcedocs itself, to run it. Assuming you've
 already got Xcode, Ruby, and rubygems set up, install the rest of the dependencies:
 
 ```bash
-gem install bundler cocoapods jazzy
+gem install bundler cocoapods
+brew install sourcedocs
 ```
 
-If that succeeded, you need to generate an Xcode project before running Jazzy:
+If that succeeded, you need to generate an Xcode project before running Sourcedocs:
 
 ```bash
 cd swift/Samples/SampleApp/
@@ -133,7 +134,9 @@ You can manually generate the docs to verify everything is working correctly by 
 
 ```bash
 #cd swift/Samples/SampleApp/
-jazzy --xcodebuild-arguments "-scheme,Workflow,-workspace,SampleApp.xcworkspace"
+sourcedocs generate -- -scheme Workflow -workspace SampleApp.xcworkspace
+sourcedocs generate -- -scheme WorkflowUI -workspace SampleApp.xcworkspace
+sourcedocs generate -- -scheme WorkflowTesting -workspace SampleApp.xcworkspace
 ```
 
 #### mkdocs

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -22,7 +22,7 @@
 # pip install mkdocs mkdocs-material
 # Preview the site as you're editing it with:
 # mkdocs serve
-# It also uses CocoaPods and Jazzy to build the Swift docs.
+# It also uses CocoaPods and Sourcedocs to build the Swift docs.
 # See .buildscript/build_swift_docs.sh for setup info.
 #
 # Usage deploy_website.sh SHA_OR_REF_TO_DEPLOY
@@ -33,10 +33,9 @@ set -ex
 SHA=$(git rev-parse $1)
 REPO="git@github.com:square/workflow.git"
 DIR=mkdocs-clone
-SWIFT_API_DIR=swift/api
-SWIFT_SCHEMES="Workflow WorkflowUI WorkflowTesting"
-
-source .buildscript/build_swift_docs.sh
+# Need to use the absolute path for these.
+SWIFT_API_DIR="$(pwd)/$DIR/docs/swift/api"
+SWIFT_DOCS_SCRIPT="$(pwd)/.buildscript/build_swift_docs.sh"
 
 # Delete any existing temporary website clone.
 rm -rf $DIR
@@ -56,17 +55,14 @@ git checkout $SHA
 # Generate the Kotlin API docs.
 (cd kotlin && ./gradlew dokka)
 
+# Generate the Swift API docs.
+(cd swift/Samples/SampleApp && $SWIFT_DOCS_SCRIPT $SWIFT_API_DIR)
+
 # Build the site
 mkdocs gh-deploy
 # Remove Dokka markdown.
 git clean -fdx
 git checkout gh-pages
-
-# Generate the Swift API docs.
-# Clone local repo because this script doesn't need to push.
-build_swift_docs $SHA ".git" $SWIFT_API_DIR "$SWIFT_SCHEMES" && \
-    git add $SWIFT_API_DIR && \
-    git commit -m "Deployed Swift docs from $SHA"
 
 # Push the new files up to GitHub.
 git push origin gh-pages:gh-pages

--- a/lint_docs.sh
+++ b/lint_docs.sh
@@ -29,4 +29,5 @@ DIR=docs/
 find $DIR \
     -name '*.md' \
     -not -name 'CHANGELOG.md' \
-    | xargs mdl --style $STYLE --ignore-front-matter
+    | xargs mdl --style $STYLE --ignore-front-matter \
+    && echo "Success."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,10 +79,9 @@ nav:
       - 'workflow-testing': 'kotlin/api/workflow-testing/com.squareup.workflow.testing/index.md'
       - 'workflow-rx2': 'kotlin/api/workflow-rx2/com.squareup.workflow.rx2/index.md'
     - 'Swift':
-      # mkdocs will warn about these not existing, that's fine, deploy_website.sh manually adds them.
-      - 'Workflow ⏏': 'swift/api/Workflow/index.html'
-      - 'WorkflowUI ⏏': 'swift/api/WorkflowUI/index.html'
-      - 'WorkflowTesting ⏏': 'swift/api/WorkflowTesting/index.html'
+      - 'Workflow': 'swift/api/Workflow/README.md'
+      - 'WorkflowUI': 'swift/api/WorkflowUI/README.md'
+      - 'WorkflowTesting': 'swift/api/WorkflowTesting/README.md'
   - 'Kotlin':
     - 'Overview': kotlin/index.md
   - 'Swift':


### PR DESCRIPTION
Old: Generate mkdocs site, then use Jazzy to dump heterogeneous HTML into the right spot.
New: Use [Sourcedocs]() to generate Markdown for swift APIs _before_ running mkdocs, then build the site like normal.

The Swift docs are now also built in CI to verify they build correctly.

Closes #508.

![image](https://user-images.githubusercontent.com/101754/62168314-17989100-b2da-11e9-8eb5-a450ae33a7a2.png)
![image](https://user-images.githubusercontent.com/101754/62168323-1ff0cc00-b2da-11e9-8b9e-f5ae60b71b3f.png)
![image](https://user-images.githubusercontent.com/101754/62168342-2b43f780-b2da-11e9-8450-51a457aa9437.png)
