### PR TITLE
Upgrade coroutines to latest version (1.3.0-RC).

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -18,7 +18,7 @@ buildscript {
       'targetSdk': 29,
       'dokka': '0.9.18',
       'kotlin': '1.3.41',
-      'kotlinCoroutines': '1.3.0-M2',
+      'kotlinCoroutines': '1.3.0-RC',
   ]
 
   rootProject.ext.defaultAndroidConfig = {

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.onReceiveOrNull
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -59,5 +60,7 @@ internal inline fun <T, R> SelectBuilder<R>.onReceiveOutputOrFinished(
   channel: ReceiveChannel<Output<T>>,
   crossinline handler: (OutputOrFinished<T>) -> R
 ) {
-  channel.onReceiveOrNull { maybeOutput -> handler(maybeOutput ?: Finished) }
+  // TODO(https://github.com/square/workflow/issues/512) Replace with receiveOrClosed?
+  channel.onReceiveOrNull()
+      .invoke { maybeOutput -> handler(maybeOutput ?: Finished) }
 }

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
@@ -87,7 +87,8 @@ internal object RealWorkflowLoop : WorkflowLoop {
           output = select {
             // Stop trying to read from the inputs channel after it's closed.
             if (!inputsClosed) {
-              @Suppress("EXPERIMENTAL_API_USAGE")
+              // TODO(https://github.com/square/workflow/issues/512) Replace with receiveOrClosed.
+              @Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
               inputsChannel.onReceiveOrNull { newInput ->
                 if (newInput == null) {
                   inputsClosed = true


### PR DESCRIPTION
This is the first version of the library in which `receiveOrClosed` is available, but it's still internal. See #512.

Changelog: https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.0-rc