### PR TITLE
Better errors for render tester convenience method

### DIFF
--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -166,7 +166,7 @@ public final class RenderTester<WorkflowType: Workflow> {
             expectedWorkers: expectedWorkers,
             expectedWorkflows: expectedWorkflows)
 
-        return self.render(with: expectations, assertions: assertions)
+        return self.render(with: expectations, assertions: assertions, file: file, line: line)
     }
 
     /// Assert the internal state.


### PR DESCRIPTION
Plumbs the file and line to convenience render tester method.

This will cause errors to be reported at the calling site (in the test case) instead of within the library (was missed on the original addition)