### PR TITLE
Rename LifecycleWorker.onCancelled to onStopped.

### DIFF
--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/LifecycleWorkerTest.kt
@@ -50,7 +50,7 @@ class LifecycleWorkerTest {
   @Test fun `onCancelled called on cancel`() {
     var onCancelledCalled = false
     val worker = object : LifecycleWorker() {
-      override fun onCancelled() {
+      override fun onStopped() {
         onCancelledCalled = true
       }
     }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -55,7 +55,7 @@ class WorkerCompositionIntegrationTest {
   @Test fun `worker cancelled when dropped`() {
     var cancelled = false
     val worker = object : LifecycleWorker() {
-      override fun onCancelled() {
+      override fun onStopped() {
         cancelled = true
       }
     }
@@ -78,7 +78,7 @@ class WorkerCompositionIntegrationTest {
         starts++
       }
 
-      override fun onCancelled() {
+      override fun onStopped() {
         stops++
       }
     }
@@ -108,7 +108,7 @@ class WorkerCompositionIntegrationTest {
         starts++
       }
 
-      override fun onCancelled() {
+      override fun onStopped() {
         stops++
       }
     }


### PR DESCRIPTION
Added notes in the kdoc about the order in which these methods are called.

Closes #503.

@pyricau Tried to address your documentation feedback, PTAL.