### PR TITLE
Remove all direct dependencies on Kotlin Reflect. 

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -71,7 +71,6 @@ buildscript {
               'rx2': "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${versions.kotlinCoroutines}",
               'test': "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinCoroutines}"
           ],
-          'reflect': "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}",
           'test': [
               'common': "org.jetbrains.kotlin:kotlin-test-common",
               'annotations': "org.jetbrains.kotlin:kotlin-test-annotations-common",
@@ -134,8 +133,15 @@ subprojects {
 
   apply plugin: "org.jlleitschuh.gradle.ktlint"
   apply plugin: "io.gitlab.arturbosch.detekt"
-  afterEvaluate {
+  afterEvaluate { project ->
     project.tasks.findByName('check')?.dependsOn 'detekt'
+
+    project.configurations.configureEach {
+      // No module depends on on Kotlin Reflect directly, but there could be transitive dependencies
+      // in tests with a lower version. This could cause problems with a newer Kotlin version that
+      // we use.
+      resolutionStrategy.force "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
+    }
   }
 
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/kotlin/legacy/legacy-workflow-core/build.gradle
+++ b/kotlin/legacy/legacy-workflow-core/build.gradle
@@ -27,7 +27,5 @@ dependencies {
   api deps.kotlin.stdLib.jdk6
   api deps.kotlin.coroutines.core
 
-  implementation deps.kotlin.reflect
-
   testImplementation deps.kotlin.test.jdk
 }

--- a/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Reactor.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/main/java/com/squareup/workflow/legacy/Reactor.kt
@@ -276,4 +276,4 @@ fun <S : Any, E : Any, O : Any> Reactor<S, E, O>.doLaunch(
   }
 }
 
-private fun Reactor<*, *, *>.getWorkflowCoroutineName() = "workflow(${this::class.qualifiedName})"
+private fun Reactor<*, *, *>.getWorkflowCoroutineName() = "workflow(${this::class::java.name})"

--- a/kotlin/legacy/legacy-workflow-rx2/build.gradle
+++ b/kotlin/legacy/legacy-workflow-rx2/build.gradle
@@ -34,7 +34,6 @@ dependencies {
   api deps.rxjava2.rxjava2
 
   implementation deps.kotlin.coroutines.rx2
-  implementation deps.kotlin.reflect
 
   testImplementation deps.kotlin.test.jdk
   testImplementation deps.kotlin.test.mockito

--- a/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Reactor.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/main/java/com/squareup/workflow/legacy/rx2/Reactor.kt
@@ -267,4 +267,4 @@ fun <S : Any, E : Any, O : Any> Reactor<S, E, O>.toCoroutineReactor() =
   }
 
 private fun Reactor<*, *, *>.getWorkflowCoroutineName(name: String?) =
-  "workflow(${name ?: this::class.qualifiedName})"
+  "workflow(${name ?: this::class::java.name})"

--- a/kotlin/samples/dungeon/app/build.gradle
+++ b/kotlin/samples/dungeon/app/build.gradle
@@ -46,7 +46,6 @@ dependencies {
   implementation "androidx.gridlayout:gridlayout:1.0.0"
   implementation deps.androidx.lifecycle
   implementation deps.kotlin.coroutines.rx2
-  implementation deps.kotlin.reflect
   implementation deps.okio
   implementation deps.rxandroid2
   implementation deps.rxjava2.rxjava2

--- a/kotlin/samples/dungeon/common/build.gradle
+++ b/kotlin/samples/dungeon/common/build.gradle
@@ -22,7 +22,6 @@ dependencies {
   implementation project(':workflow-rx2')
 
   implementation deps.kotlin.stdLib.jdk8
-  implementation deps.kotlin.reflect
   implementation deps.rxjava2.rxjava2
 
   testImplementation deps.test.hamcrestCore

--- a/kotlin/samples/tictactoe/app/build.gradle
+++ b/kotlin/samples/tictactoe/app/build.gradle
@@ -44,7 +44,6 @@ dependencies {
   implementation deps.androidx.constraint_layout
   implementation deps.androidx.lifecycle
   implementation deps.kotlin.coroutines.rx2
-  implementation deps.kotlin.reflect
   implementation deps.okio
   implementation deps.rxandroid2
   implementation deps.rxjava2.rxjava2

--- a/kotlin/samples/tictactoe/common/build.gradle
+++ b/kotlin/samples/tictactoe/common/build.gradle
@@ -22,7 +22,6 @@ dependencies {
   implementation project(':workflow-rx2')
 
   implementation deps.kotlin.stdLib.jdk6
-  implementation deps.kotlin.reflect
   implementation deps.rxjava2.rxjava2
 
   testImplementation deps.test.hamcrestCore

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameState.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameState.kt
@@ -23,7 +23,6 @@ import com.squareup.workflow.readUtf8WithLength
 import com.squareup.workflow.writeByteStringWithLength
 import com.squareup.workflow.writeUtf8WithLength
 import okio.ByteString
-import kotlin.reflect.jvm.jvmName
 
 /**
  * The state of a [RealRunGameWorkflow].
@@ -57,7 +56,7 @@ sealed class RunGameState {
 
   fun toSnapshot(): Snapshot {
     return Snapshot.write { sink ->
-      sink.writeUtf8WithLength(this::class.jvmName)
+      sink.writeUtf8WithLength(this::class.java.name)
 
       when (this) {
         is Playing -> {
@@ -89,26 +88,26 @@ sealed class RunGameState {
         val className = source.readUtf8WithLength()
 
         return when (className) {
-          Playing::class.jvmName -> Playing(
+          Playing::class.java.name -> Playing(
               PlayerInfo.fromSnapshot(source.readByteStringWithLength())
           )
 
-          NewGame::class.jvmName -> NewGame(
+          NewGame::class.java.name -> NewGame(
               source.readUtf8WithLength(),
               source.readUtf8WithLength()
           )
 
-          MaybeQuitting::class.jvmName -> MaybeQuitting(
+          MaybeQuitting::class.java.name -> MaybeQuitting(
               PlayerInfo.fromSnapshot(source.readByteStringWithLength()),
               CompletedGame.fromSnapshot(source.readByteStringWithLength())
           )
 
-          MaybeQuittingForSure::class.jvmName -> MaybeQuittingForSure(
+          MaybeQuittingForSure::class.java.name -> MaybeQuittingForSure(
               PlayerInfo.fromSnapshot(source.readByteStringWithLength()),
               CompletedGame.fromSnapshot(source.readByteStringWithLength())
           )
 
-          GameOver::class.jvmName -> GameOver(
+          GameOver::class.java.name -> GameOver(
               PlayerInfo.fromSnapshot(source.readByteStringWithLength()),
               CompletedGame.fromSnapshot(source.readByteStringWithLength())
           )

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainState.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainState.kt
@@ -20,7 +20,6 @@ import com.squareup.workflow.parse
 import com.squareup.workflow.readUtf8WithLength
 import com.squareup.workflow.writeUtf8WithLength
 import okio.ByteString
-import kotlin.reflect.jvm.jvmName
 
 /**
  * The state of [MainWorkflow]. Indicates which nested workflow is running, and records
@@ -33,7 +32,7 @@ sealed class MainState {
   internal object RunningGame : MainState()
 
   fun toSnapshot(): Snapshot {
-    return Snapshot.write { sink -> sink.writeUtf8WithLength(this::class.jvmName) }
+    return Snapshot.write { sink -> sink.writeUtf8WithLength(this::class.java.name) }
   }
 
   companion object {
@@ -41,8 +40,8 @@ sealed class MainState {
       val mainStateName = it.readUtf8WithLength()
 
       return when (mainStateName) {
-        Authenticating::class.jvmName -> Authenticating
-        RunningGame::class.jvmName -> RunningGame
+        Authenticating::class.java.name -> Authenticating
+        RunningGame::class.java.name -> RunningGame
         else -> throw IllegalArgumentException("Unrecognized state: $mainStateName")
       }
     }

--- a/kotlin/samples/todo-android/app/build.gradle
+++ b/kotlin/samples/todo-android/app/build.gradle
@@ -45,7 +45,6 @@ dependencies {
   implementation deps.androidx.material
   implementation deps.androidx.lifecycle
   implementation deps.kotlin.coroutines.rx2
-  implementation deps.kotlin.reflect
   implementation deps.okio
   implementation deps.rxandroid2
   implementation deps.rxjava2.rxjava2

--- a/kotlin/samples/todo-android/common/build.gradle
+++ b/kotlin/samples/todo-android/common/build.gradle
@@ -22,7 +22,6 @@ dependencies {
   implementation project(':workflow-rx2')
 
   implementation deps.kotlin.stdLib.jdk6
-  implementation deps.kotlin.reflect
   implementation deps.rxjava2.rxjava2
 
   testImplementation deps.test.hamcrestCore

--- a/kotlin/workflow-core/build.gradle
+++ b/kotlin/workflow-core/build.gradle
@@ -31,7 +31,5 @@ dependencies {
   // For Snapshot.
   api deps.okio
 
-  implementation deps.kotlin.reflect
-
   testImplementation deps.kotlin.test.jdk
 }

--- a/kotlin/workflow-runtime/build.gradle
+++ b/kotlin/workflow-runtime/build.gradle
@@ -30,7 +30,5 @@ dependencies {
   api deps.kotlin.stdLib.jdk6
   api deps.kotlin.coroutines.core
 
-  implementation deps.kotlin.reflect
-
   testImplementation deps.kotlin.test.jdk
 }

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
@@ -22,7 +22,6 @@ import com.squareup.workflow.writeUtf8WithLength
 import okio.Buffer
 import okio.ByteString
 import kotlin.reflect.KClass
-import kotlin.reflect.jvm.jvmName
 
 internal typealias AnyId = WorkflowId<*, *, *>
 
@@ -48,7 +47,7 @@ internal fun <W : Workflow<I, O, R>, I, O : Any, R>
 
 internal fun WorkflowId<*, *, *>.toByteString(): ByteString = Buffer()
     .also { sink ->
-      sink.writeUtf8WithLength(type.jvmName)
+      sink.writeUtf8WithLength(type.java.name)
       sink.writeUtf8WithLength(name)
     }
     .readByteString()

--- a/kotlin/workflow-rx2/build.gradle
+++ b/kotlin/workflow-rx2/build.gradle
@@ -32,7 +32,6 @@ dependencies {
   api deps.rxjava2.rxjava2
 
   implementation deps.kotlin.coroutines.rx2
-  implementation deps.kotlin.reflect
 
   testImplementation project(':workflow-testing')
   testImplementation deps.kotlin.test.jdk

--- a/kotlin/workflow-testing/build.gradle
+++ b/kotlin/workflow-testing/build.gradle
@@ -31,7 +31,6 @@ dependencies {
   api deps.kotlin.stdLib.jdk6
 
   implementation project(':workflow-runtime')
-  implementation deps.kotlin.reflect
 
   testImplementation deps.kotlin.test.jdk
 }

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -46,7 +46,6 @@ dependencies {
   implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.coroutines.core
   implementation deps.kotlin.coroutines.rx2
-  implementation deps.kotlin.reflect
 
   testImplementation deps.test.junit
   testImplementation deps.test.truth

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/HandlesBack.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/HandlesBack.kt
@@ -61,7 +61,7 @@ interface HandlesBack {
       // let's be strict.
       require(this !is HandlesBack) {
         "Cannot set back handlers on views that implement " +
-            HandlesBack::class.simpleName
+            HandlesBack::class.java.simpleName
       }
 
       setTag(R.id.workflow_back_handler, handlesBack)

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
@@ -102,7 +102,7 @@ class ViewRegistry private constructor(
           }
         }
         ?: throw IllegalArgumentException(
-            "A binding for ${initialRendering::class.qualifiedName} must be registered " +
+            "A binding for ${initialRendering::class.java.name} must be registered " +
                 "to display $initialRendering."
         )
   }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.rx2.asObservable
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.CancellationException
-import kotlin.reflect.jvm.jvmName
 
 @UseExperimental(ExperimentalCoroutinesApi::class)
 @ExperimentalWorkflowUi
@@ -101,6 +100,6 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
   internal fun getLastSnapshotForTest() = lastSnapshot
 
   private companion object {
-    val BUNDLE_KEY = WorkflowRunner::class.jvmName + "-workflow"
+    val BUNDLE_KEY = WorkflowRunner::class.java.name + "-workflow"
   }
 }

--- a/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
+++ b/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
@@ -56,7 +56,7 @@ class WorkflowRunnerViewModelTest {
       if (e is CancellationException) {
         cancelled = true
       } else throw AssertionError(
-          "Expected ${CancellationException::class.simpleName}", e
+          "Expected ${CancellationException::class.java.simpleName}", e
       )
     }
     val runner = WorkflowRunnerViewModel(scope, emptyFlow(), flowOf("fnord"), viewRegistry)
@@ -74,7 +74,7 @@ class WorkflowRunnerViewModelTest {
       if (e is CancellationException) {
         cancelled = true
       } else throw AssertionError(
-          "Expected ${CancellationException::class.simpleName}", e
+          "Expected ${CancellationException::class.java.simpleName}", e
       )
     }
     val runner = WorkflowRunnerViewModel(scope, emptyFlow(), emptyFlow(), viewRegistry)

--- a/kotlin/workflow-ui-core/build.gradle
+++ b/kotlin/workflow-ui-core/build.gradle
@@ -27,8 +27,6 @@ dependencies {
   api deps.kotlin.stdLib.jdk6
   api deps.okio
 
-  implementation deps.kotlin.reflect
-
   testImplementation deps.kotlin.test.jdk
   testImplementation deps.test.truth
 }

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Named.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/Named.kt
@@ -15,8 +15,6 @@
  */
 package com.squareup.workflow.ui
 
-import kotlin.reflect.jvm.jvmName
-
 /**
  * Allows renderings that do not implement [Compatible] themselves to be distinguished
  * by more than just their type. Instances are [compatible] if they have the same name
@@ -44,7 +42,7 @@ data class Named<W : Any>(
       value: Any,
       name: String = ""
     ): String {
-      return ((value as? Compatible)?.compatibilityKey ?: value::class.jvmName) + "-Named($name)"
+      return ((value as? Compatible)?.compatibilityKey ?: value::class.java.name) + "-Named($name)"
     }
   }
 }


### PR DESCRIPTION
Kotlin Reflect is a heavy dependency and the modules barely make use of it to justify the
dependency.