### PR TITLE
Update ReactiveSwift to 6.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
             targets: ["Workflow"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "5.0.0")
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.0.0")
     ],
     targets: [
         .target(

--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'swift/Workflow/Sources/*.swift'
 
-  s.dependency 'ReactiveSwift', '~> 5.0.0'
+  s.dependency 'ReactiveSwift', '~> 6.0.0'
  
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'swift/Workflow/Tests/**/*.swift'

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'swift/WorkflowTesting/Sources/*.swift'
 
-  s.dependency 'ReactiveSwift', '~> 5.0.0'
+  s.dependency 'ReactiveSwift', '~> 6.0.0'
   s.dependency 'Workflow', "#{s.version}"
   s.framework = 'XCTest'
 

--- a/docs/tutorial/adding-workflow-to-a-project.md
+++ b/docs/tutorial/adding-workflow-to-a-project.md
@@ -10,7 +10,6 @@ You'll need the following four libraries:
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 ```
 
 The easiest way to integrate these libraries is via Cocoapods. If you are using Cocoapods, you can
@@ -24,7 +23,6 @@ Pod::Spec.new do |s|
     s.dependency 'Workflow'
     s.dependency 'WorkflowUI'
     s.dependency 'ReactiveSwift'
-    s.dependency 'Result'
 
     # ...
 end

--- a/docs/tutorial/building-a-workflow.md
+++ b/docs/tutorial/building-a-workflow.md
@@ -187,7 +187,7 @@ struct RefreshWorker: Worker {
         case error(Error)
     }
 
-    func run() -> SignalProducer<RefreshWorker.Output, NoError> {
+    func run() -> SignalProducer<RefreshWorker.Output, Never> {
         return SignalProducer(value: .success("We did it!"))
             .delay(1.0, on: QueueScheduler.main)
     }

--- a/docs/tutorial/using-a-workflow-for-ui.md
+++ b/docs/tutorial/using-a-workflow-for-ui.md
@@ -12,7 +12,7 @@ Workflows and the UI that is ultimately displayed. On iOS, the container is impl
 public final class ContainerViewController<Output, ScreenType>: UIViewController where ScreenType: Screen {
 
     /// Emits output events from the bound workflow.
-    public let output: Signal<Output, NoError>
+    public let output: Signal<Output, Never>
 
     public convenience init<W: Workflow>(workflow: W, viewRegistry: ViewRegistry) where W.Rendering == ScreenType, W.Output == Output
 }

--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -1,7 +1,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -111,7 +110,7 @@ struct RefreshWorker: Worker {
         case error(Error)
     }
 
-    func run() -> SignalProducer<RefreshWorker.Output, NoError> {
+    func run() -> SignalProducer<RefreshWorker.Output, Never> {
         return SignalProducer(value: .success("We did it!"))
             .delay(1.0, on: QueueScheduler.main)
     }
@@ -200,12 +199,12 @@ extension DemoWorkflow {
 
 
 fileprivate class TimerSignal {
-    let signal: Signal<Void, NoError>
-    let observer: Signal<Void, NoError>.Observer
+    let signal: Signal<Void, Never>
+    let observer: Signal<Void, Never>.Observer
     let timer: Timer
 
     init() {
-        let (signal, observer) = Signal<Void, NoError>.pipe()
+        let (signal, observer) = Signal<Void, Never>.pipe()
 
         let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak observer] _ in
             observer?.send(value: ())

--- a/swift/Tooling/Templates/Workflow (Verbose).xctemplate/___FILEBASENAME___Workflow.swift
+++ b/swift/Tooling/Templates/Workflow (Verbose).xctemplate/___FILEBASENAME___Workflow.swift
@@ -3,7 +3,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -63,7 +62,7 @@ extension ___VARIABLE_productName___Workflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Workflow/Sources/RenderContext.swift
+++ b/swift/Workflow/Sources/RenderContext.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 
 /// `RenderContext` is the composition point for the workflow tree.
 ///
@@ -57,7 +56,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         fatalError()
     }
 
-    public func subscribe<Action>(signal: Signal<Action, NoError>) where Action : WorkflowAction, WorkflowType == Action.WorkflowType {
+    public func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, WorkflowType == Action.WorkflowType {
         fatalError()
     }
 
@@ -94,7 +93,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
             return implementation.makeSink(of: actionType)
         }
 
-        override func subscribe<Action>(signal: Signal<Action, NoError>) where WorkflowType == Action.WorkflowType, Action : WorkflowAction {
+        override func subscribe<Action>(signal: Signal<Action, Never>) where WorkflowType == Action.WorkflowType, Action : WorkflowAction {
             assertStillValid()
             return implementation.subscribe(signal: signal)
         }
@@ -121,7 +120,7 @@ internal protocol RenderContextType: class {
 
     func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
-    func subscribe<Action>(signal: Signal<Action, NoError>) where Action: WorkflowAction, Action.WorkflowType == WorkflowType
+    func subscribe<Action>(signal: Signal<Action, Never>) where Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
     

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -1,6 +1,5 @@
 import Dispatch
 import ReactiveSwift
-import Result
 
 extension WorkflowNode {
 
@@ -144,7 +143,7 @@ extension WorkflowNode.SubtreeManager {
         private let originalChildWorkers: [AnyChildWorker]
         private (set) internal var usedChildWorkers: [AnyChildWorker]
 
-        private (set) internal var eventSources: [Signal<AnyWorkflowAction<WorkflowType>, NoError>] = []
+        private (set) internal var eventSources: [Signal<AnyWorkflowAction<WorkflowType>, Never>] = []
 
         internal init(previousSinks: [ObjectIdentifier:AnyReusableSink], originalChildWorkflows: [ChildKey:AnyChildWorkflow], originalChildWorkers: [AnyChildWorker]) {
             self.eventPipes = []
@@ -214,7 +213,7 @@ extension WorkflowNode.SubtreeManager {
             return sink
         }
 
-        func subscribe<Action>(signal: Signal<Action, NoError>) where Action : WorkflowAction, WorkflowType == Action.WorkflowType {
+        func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, WorkflowType == Action.WorkflowType {
             eventSources.append(signal.map { AnyWorkflowAction($0) })
         }
 
@@ -419,7 +418,7 @@ extension WorkflowNode.SubtreeManager {
 
         let worker: W
 
-        let signalProducer: SignalProducer<W.Output, NoError>
+        let signalProducer: SignalProducer<W.Output, Never>
 
         private var outputMap: (W.Output) -> AnyWorkflowAction<WorkflowType>
 
@@ -463,7 +462,7 @@ extension WorkflowNode.SubtreeManager {
         private var (lifetime, token) = Lifetime.make()
         private (set) internal var eventPipe: EventPipe
 
-        init(eventSources: [Signal<AnyWorkflowAction<WorkflowType>, NoError>], eventPipe: EventPipe) {
+        init(eventSources: [Signal<AnyWorkflowAction<WorkflowType>, Never>], eventPipe: EventPipe) {
             self.eventPipe = eventPipe
 
             Signal

--- a/swift/Workflow/Sources/Worker.swift
+++ b/swift/Workflow/Sources/Worker.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 
 /// Workers define a unit of asynchronous work.
 ///
@@ -15,7 +14,7 @@ public protocol Worker {
     associatedtype Output
     
     /// Returns a signal producer to execute the work represented by this worker.
-    func run() -> SignalProducer<Output, NoError>
+    func run() -> SignalProducer<Output, Never>
 
     /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
     /// account whatever data is meaninful to the task. For example, a worker that loads a user account from a server

--- a/swift/Workflow/Sources/WorkflowHost.swift
+++ b/swift/Workflow/Sources/WorkflowHost.swift
@@ -1,5 +1,4 @@
 import ReactiveSwift
-import Result
 
 /// Defines a type that receives debug information about a running workflow hierarchy.
 public protocol WorkflowDebugger {
@@ -21,7 +20,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
 
     private let debugger: WorkflowDebugger?
 
-    private let (outputEvent, outputEventObserver) = Signal<WorkflowType.Output, NoError>.pipe()
+    private let (outputEvent, outputEventObserver) = Signal<WorkflowType.Output, Never>.pipe()
 
     private let rootNode: WorkflowNode<WorkflowType>
 
@@ -81,7 +80,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
     }
 
     /// A signal containing output events emitted by the root workflow in the hierarchy.
-    public var output: Signal<WorkflowType.Output, NoError> {
+    public var output: Signal<WorkflowType.Output, Never> {
         return outputEvent
     }
 

--- a/swift/Workflow/Tests/AnyWorkflowTests.swift
+++ b/swift/Workflow/Tests/AnyWorkflowTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import Workflow
 import ReactiveSwift
-import Result
 
 public class AnyWorkflowTests: XCTestCase {
 

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import Workflow
 
 import ReactiveSwift
-import Result
 
 
 final class ConcurrencyTests: XCTestCase {
@@ -468,7 +467,7 @@ final class ConcurrencyTests: XCTestCase {
             struct DelayWorker: Worker {
                 typealias Output = Action
 
-                func run() -> SignalProducer<Output, NoError> {
+                func run() -> SignalProducer<Output, Never> {
                     return SignalProducer(value: .update).delay(0.1, on: QueueScheduler.main)
                 }
 
@@ -501,7 +500,7 @@ final class ConcurrencyTests: XCTestCase {
     // MARK - Test Types
 
     fileprivate class TestSignal {
-        let (signal, observer) = Signal<Int, NoError>.pipe()
+        let (signal, observer) = Signal<Int, Never>.pipe()
         var sent: Bool = false
 
         func send(value: Int) {
@@ -595,7 +594,7 @@ final class ConcurrencyTests: XCTestCase {
         struct TestWorker: Worker {
             typealias Output = TestWorkflow.Action
 
-            func run() -> SignalProducer<Output, NoError> {
+            func run() -> SignalProducer<Output, Never> {
                 return SignalProducer(value: .update)
             }
 

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import Workflow
 import ReactiveSwift
-import Result
 
 
 final class SubtreeManagerTests: XCTestCase {
@@ -167,8 +166,8 @@ final class SubtreeManagerTests: XCTestCase {
 
                 typealias Output = Void
 
-                func run() -> SignalProducer<Void, NoError> {
-                    return SignalProducer<Void, NoError>({ [weak startExpectation, weak endExpectation] (observer, lifetime) in
+                func run() -> SignalProducer<Void, Never> {
+                    return SignalProducer<Void, Never>({ [weak startExpectation, weak endExpectation] (observer, lifetime) in
                         lifetime.observeEnded {
                             endExpectation?.fulfill()
                         }
@@ -214,7 +213,7 @@ final class SubtreeManagerTests: XCTestCase {
 
     func test_subscriptionsUnsubscribe() {
         struct SubscribingWorkflow: Workflow {
-            var signal: Signal<Void, NoError>?
+            var signal: Signal<Void, Never>?
 
             struct State {}
 
@@ -246,7 +245,7 @@ final class SubtreeManagerTests: XCTestCase {
             emittedExpectation.fulfill()
         }
 
-        let (signal, observer) = Signal<Void, NoError>.pipe()
+        let (signal, observer) = Signal<Void, Never>.pipe()
 
         let isSubscribing = manager.render { context -> Bool in
             SubscribingWorkflow(

--- a/swift/Workflow/Tests/WorkflowNodeTests.swift
+++ b/swift/Workflow/Tests/WorkflowNodeTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import Workflow
 
 import ReactiveSwift
-import Result
 
 
 final class WorkflowNodeTests: XCTestCase {
@@ -212,7 +211,7 @@ final class WorkflowNodeTests: XCTestCase {
                 return true
             }
 
-            func run() -> SignalProducer<Int, NoError> {
+            func run() -> SignalProducer<Int, Never> {
                 return SignalProducer{ observer, lifetime in
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
                         observer.send(value: 1)

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 @testable import Workflow
 
 
@@ -209,7 +208,7 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
     }
 
     func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where Action : WorkflowAction, T == Action.WorkflowType {
-        let (signal, observer) = Signal<AnyWorkflowAction<WorkflowType>, NoError>.pipe()
+        let (signal, observer) = Signal<AnyWorkflowAction<WorkflowType>, Never>.pipe()
         let sink = Sink<Action> { action in
             observer.send(value: AnyWorkflowAction(action))
         }
@@ -217,7 +216,7 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         return sink
     }
 
-    func subscribe<Action>(signal: Signal<Action, NoError>) where Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
+    func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
         signal
             .take(during: lifetime)
             .observeValues { [weak self] action in

--- a/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import ReactiveSwift
-import Result
 import Workflow
 import WorkflowTesting
 
@@ -260,7 +259,7 @@ fileprivate struct TestWorker: Worker {
         case failure
     }
 
-    func run() -> SignalProducer<Output, NoError> {
+    func run() -> SignalProducer<Output, Never> {
         return SignalProducer(value: .success)
     }
 

--- a/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
+++ b/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import ReactiveSwift
-import Result
 import Workflow
 
 
@@ -8,7 +7,7 @@ import Workflow
 public final class ContainerViewController<Output, ScreenType>: UIViewController where ScreenType: Screen {
 
     /// Emits output events from the bound workflow.
-    public let output: Signal<Output, NoError>
+    public let output: Signal<Output, Never>
 
     internal let rootViewController: ScreenViewController<ScreenType>
 
@@ -18,7 +17,7 @@ public final class ContainerViewController<Output, ScreenType>: UIViewController
 
     private let (lifetime, token) = Lifetime.make()
 
-    private init(workflowHost: Any, rendering: Property<ScreenType>, output: Signal<Output, NoError>, viewRegistry: ViewRegistry) {
+    private init(workflowHost: Any, rendering: Property<ScreenType>, output: Signal<Output, Never>, viewRegistry: ViewRegistry) {
         self.workflowHost = workflowHost
         self.rootViewController = viewRegistry.provideView(for: rendering.value)
         self.rendering = rendering

--- a/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 
 import ReactiveSwift
-import Result
 import Workflow
 @testable import WorkflowUI
 
@@ -29,7 +28,7 @@ class ContainerViewControllerTests: XCTestCase {
     }()
 
     func test_initialization_renders_workflow() {
-        let (signal, _) = Signal<Int, NoError>.pipe()
+        let (signal, _) = Signal<Int, Never>.pipe()
         let workflow = MockWorkflow(subscription: signal)
         let container = ContainerViewController(workflow: workflow, viewRegistry: registry)
 
@@ -40,7 +39,7 @@ class ContainerViewControllerTests: XCTestCase {
     }
 
     func test_workflow_update_causes_rerender() {
-        let (signal, observer) = Signal<Int, NoError>.pipe()
+        let (signal, observer) = Signal<Int, Never>.pipe()
         let workflow = MockWorkflow(subscription: signal)
         let container = ContainerViewController(workflow: workflow, viewRegistry: registry)
 
@@ -63,7 +62,7 @@ class ContainerViewControllerTests: XCTestCase {
 
     func test_workflow_output_causes_container_output() {
 
-        let (signal, observer) = Signal<Int, NoError>.pipe()
+        let (signal, observer) = Signal<Int, Never>.pipe()
         let workflow = MockWorkflow(subscription: signal)
         let container = ContainerViewController(workflow: workflow, viewRegistry: registry)
 
@@ -85,7 +84,7 @@ class ContainerViewControllerTests: XCTestCase {
 
 fileprivate struct MockWorkflow: Workflow {
 
-    var subscription: Signal<Int, NoError>
+    var subscription: Signal<Int, Never>
 
     typealias State = Int
 


### PR DESCRIPTION
Updating ReactiveSwift to 6.0.0
- Remove the dependency on `antitypical/Result` in favor of Swift 5's `Swift.Result`
- Replace `NoError` with `Swift.Never` since `Never` now conforms to `Swift.Error` [Swift Evolution Proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0215-conform-never-to-hashable-and-equatable.md)

