### PR TITLE
Introduce WorkerSink for writing integration tests that involve worker outputs.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -139,15 +139,30 @@ interface Worker<out OutputT> {
   fun run(): Flow<OutputT>
 
   /**
-   * Override this method to define equivalence between [Worker]s. At the end of every render pass,
-   * the set of [Worker]s that were requested by the workflow are compared to the set from the last
-   * render pass using this method. Equivalent workers are allowed to keep running. New workers
-   * are started ([run] is called and the returned [Flow] is collected). Old workers are cancelled
-   * by cancelling their collecting coroutines.
+   * Override this method to define equivalence between [Worker]s.
+   *
+   * At the end of every render pass, the set of [Worker]s that were requested by the workflow are
+   * compared to the set from the last render pass using this method. Equivalent workers are allowed
+   * to keep running. New workers are started ([run] is called and the returned [Flow] is
+   * collected). Old workers are cancelled by cancelling their collecting coroutines.
    *
    * Implementations of this method should not be based on object identity. For example, a [Worker]
    * that performs a network request might check that two workers are requests to the same endpoint
    * and have the same request data.
+   *
+   * Most implementations of this method will check for concrete type equality, and then match
+   * on constructor parameters.
+   *
+   * E.g:
+   *
+   * ```
+   * class SearchWorker(private val query: String): Worker<SearchResult> {
+   *   // run omitted for example.
+   *
+   *   override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean =
+   *     otherWorker is SearchWorker && otherWorker.query == query
+   * }
+   * ```
    */
   fun doesSameWorkAs(otherWorker: Worker<*>): Boolean
 

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkerSink.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkerSink.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import com.squareup.workflow.Worker
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.sync.Mutex
+import kotlin.reflect.KClass
+
+/**
+ * Implementation of [Worker] for integration tests (using [testFromStart] or [testFromState]) that
+ * need to simply push values into the worker from the test.
+ *
+ * Instances of this class are considered equivalent if they have matching [type] and [name].
+ *
+ * These workers can not be run concurrently – they may only be run by a single workflow at a time,
+ * although they may be run multiple times sequentially. The [Flow] returned by [run] will throw an
+ * exception if it is collected more than once concurrently.
+ *
+ * @param name String used to distinguish this worker from other [WorkerSink]s being ran by the same
+ * workflow. Used to implement [doesSameWorkAs], see the kdoc on that method for more information.
+ */
+class WorkerSink<T>(
+  private val name: String,
+  private val type: KClass<*>
+) : Worker<T> {
+
+  private val channel = Channel<T>(capacity = UNLIMITED)
+  /** This could be an atomic boolean, but this way we don't need to deal with atomicfu. */
+  private var active = Mutex()
+
+  fun send(value: T) {
+    channel.offer(value)
+  }
+
+  override fun run(): Flow<T> = flow {
+    check(active.tryLock(this@WorkerSink)) { "Expected WorkerSink not to be run concurrently." }
+
+    // Don't use emitAll or consumeEach because we don't want to close the channel after the worker
+    // is cancelled.
+    try {
+      for (value in channel) emit(value)
+    } finally {
+      active.unlock(this@WorkerSink)
+    }
+  }
+
+  override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean =
+    otherWorker is WorkerSink &&
+        otherWorker.name == name &&
+        otherWorker.type == type
+
+  override fun toString(): String = "${super.toString()}<$type>(name=\"$name\")"
+}
+
+@Suppress("FunctionName")
+inline fun <reified T> WorkerSink(name: String): WorkerSink<T> = WorkerSink(name, T::class)

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkerSinkTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkerSinkTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.testing
+
+import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WorkerSinkTest {
+
+  @Test fun `workers are equivalent with matching type and name`() {
+    val fooWorker = WorkerSink<String>("foo")
+    val otherFooWorker = WorkerSink<String>("foo")
+    assertTrue(fooWorker.doesSameWorkAs(otherFooWorker))
+  }
+
+  @Test fun `workers are not equivalent with differing names`() {
+    val fooWorker = WorkerSink<String>("foo")
+    val barWorker = WorkerSink<String>("bar")
+    assertFalse(fooWorker.doesSameWorkAs(barWorker))
+  }
+
+  @Test fun `workers are not equivalent with differing types`() {
+    val stringWorker = WorkerSink<String>("foo")
+    val intWorker = WorkerSink<Int>("foo")
+    assertFalse(stringWorker.doesSameWorkAs(intWorker))
+  }
+
+  @Test fun `values sent before running are received`() {
+    val worker = WorkerSink<String>("foo")
+    worker.send("hello")
+    runBlocking {
+      assertEquals("hello", worker.run().first())
+    }
+  }
+
+  @Test fun `values sent after running are received`() {
+    val worker = WorkerSink<String>("foo")
+    runBlocking {
+      val deferred = async {
+        worker.run()
+            .first()
+      }
+      yield()
+      worker.send("hello")
+      assertEquals("hello", deferred.await())
+    }
+  }
+
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  @Test fun `multiple values are buffered`() {
+    val worker = WorkerSink<String>("foo")
+    worker.send("hello")
+    worker.send("world")
+    worker.send("goodbye")
+    runBlocking {
+      assertEquals(listOf("hello", "world", "goodbye"), worker.run().take(3).toList())
+    }
+  }
+
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  @Test fun `throws when consumed concurrently`() {
+    val worker = WorkerSink<String>("foo")
+
+    runBlocking {
+      launch(start = UNDISPATCHED) {
+        worker.run()
+            .collect()
+      }
+
+      assertFailsWith<IllegalStateException> {
+        worker.run()
+            .collect()
+      }
+
+      coroutineContext.cancelChildren()
+    }
+  }
+
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  @Test fun `can be consumed multiple times sequentially`() {
+    val worker = WorkerSink<String>("foo")
+    worker.send("foo")
+    worker.send("bar")
+
+    runBlocking {
+      assertEquals("foo", worker.run().first())
+      assertEquals("bar", worker.run().first())
+    }
+  }
+}


### PR DESCRIPTION
cc @joelbryceanderson