### PR TITLE
Remove runningWorkerUntilFinished.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -111,24 +111,6 @@ import kotlin.reflect.KClass
 interface Worker<out OutputT> {
 
   /**
-   * Used by [RenderContext.runningWorkerUntilFinished] to distinguish between the two events of a
-   * [Worker] emitting an output and finishing.
-   */
-  sealed class OutputOrFinished<out OutputT> {
-    /**
-     * Indicates that a [Worker] emitted an output value.
-     */
-    data class Output<out OutputT>(val value: OutputT) : OutputOrFinished<OutputT>()
-
-    /**
-     * Indicates that a [Worker] finished, and will not emit any more output values.
-     */
-    object Finished : OutputOrFinished<Nothing>() {
-      override fun toString(): String = "Finished"
-    }
-  }
-
-  /**
    * Returns a [Flow] to execute the work represented by this worker.
    *
    * The [Flow] is invoked in the context of the workflow runtime. When this [Worker], its parent

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -16,7 +16,6 @@
 package com.squareup.workflow.internal
 
 import com.squareup.workflow.Worker
-import com.squareup.workflow.Worker.OutputOrFinished
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import kotlinx.coroutines.Deferred
@@ -55,11 +54,11 @@ data class Behavior<StateT, out OutputT : Any> internal constructor(
   data class WorkerCase<T, StateT, out OutputT : Any> internal constructor(
     val worker: Worker<T>,
     val key: String,
-    val handler: (OutputOrFinished<T>) -> WorkflowAction<StateT, OutputT>
+    val handler: (T) -> WorkflowAction<StateT, OutputT>
   ) {
     @Suppress("UNCHECKED_CAST")
-    fun acceptUpdate(value: OutputOrFinished<*>): WorkflowAction<StateT, OutputT> =
-      handler(value as OutputOrFinished<T>)
+    fun acceptUpdate(value: Any?): WorkflowAction<StateT, OutputT> =
+      handler(value as T)
 
     /** Override `equals` so this class can be used as its own key. */
     override fun equals(other: Any?): Boolean =

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -21,7 +21,6 @@ import com.squareup.workflow.EventHandler
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Sink
 import com.squareup.workflow.Worker
-import com.squareup.workflow.Worker.OutputOrFinished
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.internal.Behavior.WorkerCase
@@ -97,10 +96,10 @@ class RealRenderContext<StateT, OutputT : Any>(
     return renderer.render(case, child, id, props)
   }
 
-  override fun <T> runningWorkerUntilFinished(
+  override fun <T> runningWorker(
     worker: Worker<T>,
     key: String,
-    handler: (OutputOrFinished<T>) -> WorkflowAction<StateT, OutputT>
+    handler: (T) -> WorkflowAction<StateT, OutputT>
   ) {
     checkNotFrozen()
     workerCases += WorkerCase(worker, key, handler)

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
@@ -16,20 +16,14 @@
 package com.squareup.workflow.internal
 
 import com.squareup.workflow.Worker
-import com.squareup.workflow.Worker.OutputOrFinished
-import com.squareup.workflow.Worker.OutputOrFinished.Finished
-import com.squareup.workflow.Worker.OutputOrFinished.Output
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.channels.onReceiveOrNull
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.produceIn
-import kotlinx.coroutines.selects.SelectBuilder
 
 /**
  * Launches a new coroutine that is a child of this node's scope, and calls
@@ -37,9 +31,8 @@ import kotlinx.coroutines.selects.SelectBuilder
  * will emit everything from the worker. The channel will be closed when the flow completes.
  */
 @UseExperimental(FlowPreview::class, ExperimentalCoroutinesApi::class)
-internal fun <T> CoroutineScope.launchWorker(worker: Worker<T>): ReceiveChannel<Output<T>> =
+internal fun <T> CoroutineScope.launchWorker(worker: Worker<T>): ReceiveChannel<T> =
   worker.run()
-      .map { Output(it) }
       .catch { e ->
         // Workers that failed (as opposed to just cancelled) should have their failure reason
         // re-thrown from the workflow runtime. If we don't unwrap the cause here, they'll just
@@ -49,18 +42,3 @@ internal fun <T> CoroutineScope.launchWorker(worker: Worker<T>): ReceiveChannel<
       }
       .buffer(RENDEZVOUS)
       .produceIn(this)
-
-/**
- * Wraps [ReceiveChannel.onReceiveOrNull] to detect if the channel is actually closed vs just
- * emitting a null value. Once `receiveOrClosed` support lands in the coroutines library, we should
- * use that instead.
- */
-@Suppress("EXPERIMENTAL_API_USAGE")
-internal inline fun <T, R> SelectBuilder<R>.onReceiveOutputOrFinished(
-  channel: ReceiveChannel<Output<T>>,
-  crossinline handler: (OutputOrFinished<T>) -> R
-) {
-  // TODO(https://github.com/square/workflow/issues/512) Replace with receiveOrClosed?
-  channel.onReceiveOrNull()
-      .invoke { maybeOutput -> handler(maybeOutput ?: Finished) }
-}

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -31,7 +31,6 @@ import com.squareup.workflow.internal.RealRenderContext.Renderer
 import com.squareup.workflow.internal.RealRenderContextTest.TestRenderer.Rendering
 import com.squareup.workflow.makeEventSink
 import com.squareup.workflow.renderChild
-import com.squareup.workflow.runningWorker
 import com.squareup.workflow.stateless
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkersTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkersTest.kt
@@ -17,94 +17,17 @@
 
 package com.squareup.workflow.internal
 
-import com.squareup.workflow.Worker.OutputOrFinished
-import com.squareup.workflow.Worker.OutputOrFinished.Finished
-import com.squareup.workflow.Worker.OutputOrFinished.Output
 import com.squareup.workflow.asWorker
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.yield
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 
 class WorkersTest {
-
-  @Test fun suspends() {
-    val channel = Channel<Output<String>>(1)
-
-    runBlocking {
-      val result = GlobalScope.async(Dispatchers.Unconfined) {
-        select<OutputOrFinished<String>> {
-          onReceiveOutputOrFinished(channel) { it }
-        }
-      }
-
-      assertFalse(result.isCompleted)
-
-      yield()
-
-      assertFalse(result.isCompleted)
-
-      result.cancel()
-    }
-  }
-
-  @Test fun `emits output`() {
-    val channel = Channel<Output<String>>(1)
-    channel.offer(Output("foo"))
-
-    val result = runBlocking {
-      select<OutputOrFinished<String>> {
-        onReceiveOutputOrFinished(channel) { it }
-      }
-    }
-
-    assertEquals(Output("foo"), result)
-  }
-
-  @Test fun `emits finished`() {
-    val channel = Channel<Output<String>>(0)
-    channel.close()
-
-    val result = runBlocking {
-      select<OutputOrFinished<String>> {
-        onReceiveOutputOrFinished(channel) { it }
-      }
-    }
-
-    assertEquals(Finished, result)
-  }
-
-  @Test fun `handles error`() {
-    val channel = Channel<Output<String>>()
-    channel.cancel(CancellationException(null, ExpectedException()))
-
-    assertFailsWith<CancellationException> {
-      runBlocking {
-        select<OutputOrFinished<String>> {
-          onReceiveOutputOrFinished(channel) { it }
-        }
-      }
-    }.also { error ->
-      // Search up the cause chain for the expected exception, since multiple CancellationExceptions
-      // may be chained together first.
-      val causeChain = generateSequence<Throwable>(error) { it.cause }
-      assertEquals(
-          1, causeChain.count { it is ExpectedException },
-          "Expected cancellation exception cause chain to include original cause."
-      )
-    }
-  }
 
   @Test fun `propagates backpressure`() {
     val channel = Channel<String>()
@@ -127,11 +50,11 @@ class WorkersTest {
       yield()
       assertEquals(1, counter.getAndIncrement())
 
-      assertEquals(Output("a"), workerOutputs.poll())
+      assertEquals("a", workerOutputs.poll())
       yield()
       assertEquals(3, counter.getAndIncrement())
 
-      assertEquals(Output("b"), workerOutputs.poll())
+      assertEquals("b", workerOutputs.poll())
       yield()
       assertEquals(6, counter.getAndIncrement())
 
@@ -139,6 +62,4 @@ class WorkersTest {
       workerOutputs.cancel()
     }
   }
-
-  private class ExpectedException : RuntimeException()
 }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RenderTesterTest.kt
@@ -89,7 +89,7 @@ class RenderTesterTest {
     val workflow = Workflow.stateful<Unit, String, String, Unit>(
         initialState = { _, _ -> fail() },
         render = { _, _ ->
-          runningWorkerUntilFinished(worker) {
+          runningWorker(worker) {
             WorkflowAction {
               state = "state: $it"
               "output: $it"
@@ -103,15 +103,9 @@ class RenderTesterTest {
       assertNoWorkflowsRendered()
       worker.assertRan()
 
-      // Output
       val (outputState, output) = worker.handleOutput("work!")
-      assertEquals("state: Output(value=work!)", outputState)
-      assertEquals("output: Output(value=work!)", output)
-
-      // Finish
-      val (finishState, finish) = worker.handleFinish()
-      assertEquals("state: Finished", finishState)
-      assertEquals("output: Finished", finish)
+      assertEquals("state: work!", outputState)
+      assertEquals("output: work!", output)
     }
   }
 


### PR DESCRIPTION
Closes #558, removes 1/2 of #512 TODOs, and closes #434.