### PR TITLE
[Swift] Apply child workflow output as an action in RenderTester

### DIFF
--- a/swift/WorkflowTesting/Sources/RenderExpectations.swift
+++ b/swift/WorkflowTesting/Sources/RenderExpectations.swift
@@ -107,7 +107,7 @@ public struct ExpectedWorkflow {
     let workflowType: Any.Type
     let key: String
     let rendering: Any
-    private let output: Any?
+    let output: Any?
 
     public init<WorkflowType: Workflow>(type: WorkflowType.Type, key: String = "", rendering: WorkflowType.Rendering, output: WorkflowType.Output? = nil) {
         self.workflowType = type

--- a/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -142,6 +142,25 @@ final class WorkflowRenderTesterTests: XCTestCase {
                 })
     }
 
+    func test_childWorkflowOutput() {
+        // Test that a child emitting an output is handled as an action by the parent
+        ParentWorkflow(initialText: "hello")
+            .renderTester()
+            .render(
+                expectedState: ExpectedState(state: ParentWorkflow.State(text: "Failed")),
+                expectedWorkflows: [
+                    ExpectedWorkflow(
+                        type: ChildWorkflow.self,
+                        rendering: "olleh",
+                        output: .failure)],
+                assertions: { rendering in
+                    XCTAssertEqual("olleh", rendering)
+            })
+        .assert{ state in
+            XCTAssertEqual("Failed", state.text)
+        }
+    }
+
     func test_implict_expectations() {
         TestWorkflow(initialText: "hello")
             .renderTester()
@@ -296,7 +315,7 @@ fileprivate struct ParentWorkflow: Workflow {
 
     var initialText: String
 
-    struct State {
+    struct State: Equatable {
         var text: String
     }
 


### PR DESCRIPTION
While the child output was specified, it wasn't being applied when
simulating a render pass.

Fixes #592