### PR TITLE
Add swift tutorial on unit/integration testing workflows

### DIFF
--- a/swift/Samples/Tutorial/AppHost/TutorialTests/Info.plist
+++ b/swift/Samples/Tutorial/AppHost/TutorialTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/swift/Samples/Tutorial/AppHost/TutorialTests/TutorialTests.swift
+++ b/swift/Samples/Tutorial/AppHost/TutorialTests/TutorialTests.swift
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+
+class TutorialTests: XCTestCase {
+    func testExample() {
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Tests/TutorialTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Tests/TutorialTests.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+
+
+final class TutorialTests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertEqual(1, 1, "Placeholder test");
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import BackStackContainer
+import ReactiveSwift
+import Result
+
+
+// MARK: Input and Output
+
+struct RootWorkflow: Workflow {
+
+    enum Output {
+
+    }
+}
+
+
+// MARK: State and Initialization
+
+extension RootWorkflow {
+
+    // The state is an enum, and can either be on the welcome screen or the todo list.
+    // When on the todo list, it also includes the name provided on the welcome screen
+    enum State: Equatable {
+        // The welcome screen via the welcome workflow will be shown
+        case welcome
+        // The todo list screen via the todo list workflow will be shown. The name will be provided to the todo list.
+        case todo(name: String)
+    }
+
+    func makeInitialState() -> RootWorkflow.State {
+        return .welcome
+    }
+
+    func workflowDidChange(from previousWorkflow: RootWorkflow, state: inout State) {
+
+    }
+}
+
+
+// MARK: Actions
+
+extension RootWorkflow {
+
+    enum Action: WorkflowAction {
+
+        typealias WorkflowType = RootWorkflow
+
+        case login(name: String)
+        case logout
+
+        func apply(toState state: inout RootWorkflow.State) -> RootWorkflow.Output? {
+
+            switch self {
+            case .login(name: let name):
+                // When the `login` action is received, change the state to `todo`.
+                state = .todo(name: name)
+            case .logout:
+                // Return to the welcome state on logout.
+                state = .welcome
+            }
+            return nil
+
+        }
+    }
+}
+
+
+// MARK: Workers
+
+extension RootWorkflow {
+
+    struct RootWorker: Worker {
+
+        enum Output {
+
+        }
+
+        func run() -> SignalProducer<Output, NoError> {
+            fatalError()
+        }
+
+        func isEquivalent(to otherWorker: RootWorker) -> Bool {
+            return true
+        }
+
+    }
+
+}
+
+
+// MARK: Rendering
+
+extension RootWorkflow {
+
+    typealias Rendering = BackStackScreen
+
+    func render(state: RootWorkflow.State, context: RenderContext<RootWorkflow>) -> Rendering {
+        // Delete the `let sink = context.makeSink(of: ...) as we no longer need a sink.
+
+        // Our list of back stack items. Will always include the "WelcomeScreen".
+        var backStackItems: [BackStackScreen.Item] = []
+
+        let welcomeScreen = WelcomeWorkflow()
+            .mapOutput({ output -> Action in
+                switch output {
+                // When `WelcomeWorkflow` emits `didLogin`, turn it into our `login` action.
+                case .didLogin(name: let name):
+                    return .login(name: name)
+                }
+            })
+            .rendered(with: context)
+
+        let welcomeBackStackItem = BackStackScreen.Item(
+            key: "welcome",
+            screen: welcomeScreen,
+            // Hide the navigation bar.
+            barVisibility: .hidden)
+
+        // Always add the welcome back stack item.
+        backStackItems.append(welcomeBackStackItem)
+
+        switch state {
+        // When the state is `.welcome`, defer to the WelcomeWorkflow.
+        case .welcome:
+            // We always add the welcome screen to the backstack, so this is a no op.
+            break
+
+        // When the state is `.todo`, defer to the TodoListWorkflow.
+        case .todo(name: let name):
+
+            // was: let todoBackStackItems = TodoListWorkflow(name: name)
+            let todoBackStackItems = TodoWorkflow(name: name)
+                .mapOutput({ output -> Action in
+                    switch output {
+                    case .back:
+                        // When receiving a `.back` output, treat it as a `.logout` action.
+                        return .logout
+                    }
+                })
+                .rendered(with: context)
+
+            backStackItems.append(contentsOf: todoBackStackItems)
+        }
+
+        // Finally, return the BackStackScreen with a list of BackStackScreen.Items
+        return BackStackScreen(items: backStackItems)
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditScreen.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditScreen.swift
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import TutorialViews
+
+
+struct TodoEditScreen: Screen {
+    // The title of this todo item.
+    var title: String
+    // The contents, or "note" of the todo.
+    var note: String
+
+    // Callback for when the title or note changes
+    var onTitleChanged: (String) -> Void
+    var onNoteChanged: (String) -> Void
+}
+
+
+final class TodoEditViewController: ScreenViewController<TodoEditScreen> {
+    // The `todoEditView` has all the logic for displaying the todo and editing.
+    let todoEditView: TodoEditView
+
+    required init(screen: TodoEditScreen, viewRegistry: ViewRegistry) {
+        self.todoEditView = TodoEditView(frame: .zero)
+
+        super.init(screen: screen, viewRegistry: viewRegistry)
+        update(with: screen)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(todoEditView)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        todoEditView.frame = view.bounds.inset(by: view.safeAreaInsets)
+    }
+
+    override func screenDidChange(from previousScreen: TodoEditScreen) {
+        update(with: screen)
+    }
+
+    private func update(with screen: TodoEditScreen) {
+        // Update the view with the data from the screen.
+        todoEditView.title = screen.title
+        todoEditView.note = screen.note
+        todoEditView.onTitleChanged = screen.onTitleChanged
+        todoEditView.onNoteChanged = screen.onNoteChanged
+    }
+
+}
+
+
+extension ViewRegistry {
+
+    public mutating func registerTodoEditScreen() {
+        self.register(screenViewControllerType: TodoEditViewController.self)
+    }
+
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import BackStackContainer
+import ReactiveSwift
+import Result
+
+
+// MARK: Input and Output
+
+struct TodoEditWorkflow: Workflow {
+
+    // The "Todo" passed from our parent.
+    var initialTodo: TodoModel
+
+    enum Output {
+        case discard
+        case save(TodoModel)
+    }
+}
+
+
+// MARK: State and Initialization
+
+extension TodoEditWorkflow {
+
+    struct State {
+        // The workflow's copy of the Todo item. Changes are local to this workflow.
+        var todo: TodoModel
+    }
+
+    func makeInitialState() -> TodoEditWorkflow.State {
+        return State(todo: initialTodo)
+    }
+
+    func workflowDidChange(from previousWorkflow: TodoEditWorkflow, state: inout State) {
+
+        // The `Todo` from our parent changed. Update our internal copy so we are starting from the same item.
+        // The "correct" behavior depends on the business logic - would we only want to update if the
+        // users hasn't changed the todo from the initial one? Or is it ok to delete whatever edits
+        // were in progress if the state from the parent changes?
+        if previousWorkflow.initialTodo != self.initialTodo {
+            state.todo = self.initialTodo
+        }
+    }
+}
+
+
+// MARK: Actions
+
+extension TodoEditWorkflow {
+
+    enum Action: WorkflowAction {
+
+        typealias WorkflowType = TodoEditWorkflow
+
+        case titleChanged(String)
+        case noteChanged(String)
+        case discardChanges
+        case saveChanges
+
+        func apply(toState state: inout TodoEditWorkflow.State) -> TodoEditWorkflow.Output? {
+
+            switch self {
+
+            case .titleChanged(let title):
+                state.todo.title = title
+
+            case .noteChanged(let note):
+                state.todo.note = note
+
+            case .discardChanges:
+                // Return the .discard output when the discard action is received.
+                return .discard
+
+            case .saveChanges:
+                // Return the .save output with the current todo state when the save action is received.
+                return .save(state.todo)
+            }
+
+            return nil
+        }
+    }
+}
+
+
+// MARK: Workers
+
+extension TodoEditWorkflow {
+
+    struct TodoEditWorker: Worker {
+
+        enum Output {
+
+        }
+
+        func run() -> SignalProducer<Output, NoError> {
+            fatalError()
+        }
+
+        func isEquivalent(to otherWorker: TodoEditWorker) -> Bool {
+            return true
+        }
+
+    }
+
+}
+
+// MARK: Rendering
+
+extension TodoEditWorkflow {
+
+    typealias Rendering = BackStackScreen.Item
+
+    func render(state: TodoEditWorkflow.State, context: RenderContext<TodoEditWorkflow>) -> Rendering {
+        // The sink is used to send actions back to this workflow.
+        let sink = context.makeSink(of: Action.self)
+
+        let todoEditScreen = TodoEditScreen(
+            title: state.todo.title,
+            note: state.todo.note,
+            onTitleChanged: { title in
+                sink.send(.titleChanged(title))
+            },
+            onNoteChanged: { note in
+                sink.send(.noteChanged(note))
+            })
+
+        let backStackItem = BackStackScreen.Item(
+            key: "edit",
+            screen: todoEditScreen,
+            barContent: BackStackScreen.BarContent(
+                title: "Edit",
+                leftItem: .button(.back(handler: {
+                    sink.send(.discardChanges)
+                })),
+                rightItem: .button(BackStackScreen.BarContent.Button(
+                    content: .text("Save"),
+                    handler: {
+                        sink.send(.saveChanges)
+                }))))
+        return backStackItem
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListScreen.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListScreen.swift
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import TutorialViews
+
+
+struct TodoListScreen: Screen {
+    // The titles of the todo items
+    var todoTitles: [String]
+
+    // Callback when a todo is selected
+    var onTodoSelected: (Int) -> Void
+}
+
+
+final class TodoListViewController: ScreenViewController<TodoListScreen> {
+    let todoListView: TodoListView
+
+    required init(screen: TodoListScreen, viewRegistry: ViewRegistry) {
+        self.todoListView = TodoListView(frame: .zero)
+        super.init(screen: screen, viewRegistry: viewRegistry)
+        update(with: screen)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(todoListView)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        todoListView.frame = view.bounds.inset(by: view.safeAreaInsets)
+    }
+
+    override func screenDidChange(from previousScreen: TodoListScreen) {
+        update(with: screen)
+    }
+
+    private func update(with screen: TodoListScreen) {
+        // Update the todoList on the view with what the screen provided:
+        todoListView.todoList = screen.todoTitles
+        todoListView.onTodoSelected = screen.onTodoSelected
+    }
+
+}
+
+
+extension ViewRegistry {
+
+    public mutating func registerTodoListScreen() {
+        self.register(screenViewControllerType: TodoListViewController.self)
+    }
+
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import BackStackContainer
+import ReactiveSwift
+import Result
+
+
+// MARK: Input and Output
+
+struct TodoListWorkflow: Workflow {
+
+    // The name is an input.
+    var name: String
+    // Use the list of todo items passed from our parent.
+    var todos: [TodoModel]
+
+    enum Output {
+        case back
+        case selectTodo(index: Int)
+        case newTodo
+    }
+}
+
+
+// MARK: State and Initialization
+
+extension TodoListWorkflow {
+
+    struct State {
+    }
+
+    func makeInitialState() -> TodoListWorkflow.State {
+        return State()
+    }
+
+    func workflowDidChange(from previousWorkflow: TodoListWorkflow, state: inout State) {
+
+    }
+}
+
+
+// MARK: Actions
+
+extension TodoListWorkflow {
+
+    enum Action: WorkflowAction {
+
+        typealias WorkflowType = TodoListWorkflow
+
+        case onBack
+        case selectTodo(index: Int)
+        case new
+
+        func apply(toState state: inout TodoListWorkflow.State) -> TodoListWorkflow.Output? {
+
+            switch self {
+
+            case .onBack:
+                // When a `.onBack` action is received, emit a `.back` output
+                return .back
+
+            case .selectTodo(index: let index):
+                // Tell our parent that a todo item was selected.
+                return .selectTodo(index: index)
+
+            case .new:
+                // Tell our parent a new todo item should be created.
+                return .newTodo
+            }
+
+        }
+    }
+}
+
+
+// MARK: Workers
+
+extension TodoListWorkflow {
+
+    struct TodoListWorker: Worker {
+
+        enum Output {
+
+        }
+
+        func run() -> SignalProducer<Output, NoError> {
+            fatalError()
+        }
+
+        func isEquivalent(to otherWorker: TodoListWorker) -> Bool {
+            return true
+        }
+
+    }
+
+}
+
+// MARK: Rendering
+
+extension TodoListWorkflow {
+
+    typealias Rendering = BackStackScreen.Item
+
+    func render(state: TodoListWorkflow.State, context: RenderContext<TodoListWorkflow>) -> Rendering {
+
+        // Define a sink to be able to send the .onBack action.
+        let sink = context.makeSink(of: Action.self)
+
+        let titles = todos.map { (todoModel) -> String in
+            return todoModel.title
+        }
+        let todoListScreen = TodoListScreen(
+            todoTitles: titles,
+            onTodoSelected: { index in
+                // Send the `selectTodo` action when a todo is selected in the UI.
+                sink.send(.selectTodo(index: index))
+        })
+
+        let todoListItem = BackStackScreen.Item(
+            key: "list",
+            screen: todoListScreen,
+            barContent: BackStackScreen.BarContent(
+                title: "Welcome \(name)",
+                leftItem: .button(.back(handler: {
+                    // When the left button is tapped, send the .onBack action.
+                    sink.send(.onBack)
+                })),
+                rightItem: .button(BackStackScreen.BarContent.Button(
+                    content: .text("New Todo"),
+                    handler: {
+                        sink.send(.new)
+                }))))
+
+        return todoListItem
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Model/TodoModel.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Model/TodoModel.swift
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+struct TodoModel: Equatable {
+    var title: String
+    var note: String
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import BackStackContainer
+import ReactiveSwift
+import Result
+
+
+// MARK: Input and Output
+
+struct TodoWorkflow: Workflow {
+    var name: String
+
+    enum Output {
+        case back
+    }
+}
+
+
+// MARK: State and Initialization
+
+extension TodoWorkflow {
+
+    struct State: Equatable {
+        var todos: [TodoModel]
+        var step: Step
+        enum Step: Equatable {
+            // Showing the list of todo items.
+            case list
+            // Editing a single item. The state holds the index so it can be updated when a save action is received.
+            case edit(index: Int)
+        }
+    }
+
+    func makeInitialState() -> TodoWorkflow.State {
+        return State(
+            todos: [TodoModel(
+                title: "Take the cat for a walk",
+                note: "Cats really need their outside sunshine time. Don't forget to walk Charlie. Hamilton is less excited about the prospect.")
+            ],
+            step: .list)
+    }
+
+    func workflowDidChange(from previousWorkflow: TodoWorkflow, state: inout State) {
+
+    }
+}
+
+
+// MARK: Actions
+
+extension TodoWorkflow {
+
+    enum ListAction: WorkflowAction {
+
+        typealias WorkflowType = TodoWorkflow
+
+        case back
+        case editTodo(index: Int)
+        case newTodo
+
+        func apply(toState state: inout TodoWorkflow.State) -> TodoWorkflow.Output? {
+
+            switch self {
+            case .back:
+                return .back
+
+            case .editTodo(index: let index):
+                state.step = .edit(index: index)
+
+            case .newTodo:
+                // Append a new todo model to the end of the list.
+                state.todos.append(TodoModel(
+                    title: "New Todo",
+                    note: ""))
+            }
+
+            return nil
+        }
+    }
+
+    enum EditAction: WorkflowAction {
+
+        typealias WorkflowType = TodoWorkflow
+
+        case discardChanges
+        case saveChanges(index: Int, todo: TodoModel)
+
+        func apply(toState state: inout TodoWorkflow.State) -> TodoWorkflow.Output? {
+            guard case .edit = state.step else {
+                fatalError("Received edit action when state was not `.edit`.")
+            }
+
+            switch self {
+
+            case .discardChanges:
+                state.step = .list
+
+            case .saveChanges(index: let index, todo: let updatedTodo):
+                state.todos[index] = updatedTodo
+
+            }
+            // Return to the list view for either a discard or save action.
+            state.step = .list
+
+            return nil
+        }
+    }
+}
+
+
+// MARK: Workers
+
+extension TodoWorkflow {
+
+    struct TodoWorker: Worker {
+
+        enum Output {
+
+        }
+
+        func run() -> SignalProducer<Output, NoError> {
+            fatalError()
+        }
+
+        func isEquivalent(to otherWorker: TodoWorker) -> Bool {
+            return true
+        }
+
+    }
+
+}
+
+// MARK: Rendering
+
+extension TodoWorkflow {
+
+    typealias Rendering = [BackStackScreen.Item]
+
+    func render(state: TodoWorkflow.State, context: RenderContext<TodoWorkflow>) -> Rendering {
+
+        let todoListItem = TodoListWorkflow(
+            name: name,
+            todos: state.todos)
+            .mapOutput({ output -> ListAction in
+                switch output {
+
+                case .back:
+                    return .back
+
+                case .selectTodo(index: let index):
+                    return .editTodo(index: index)
+
+                case .newTodo:
+                    return .newTodo
+                }
+            })
+            .rendered(with: context)
+
+        switch state.step {
+
+        case .list:
+            // Return only the list item.
+            return [todoListItem]
+
+        case .edit(index: let index):
+
+            let todoEditItem = TodoEditWorkflow(
+                initialTodo: state.todos[index])
+                .mapOutput({ output -> EditAction in
+                    switch output {
+                    case .discard:
+                        return .discardChanges
+
+                    case .save(let updatedTodo):
+                        return .saveChanges(index: index, todo: updatedTodo)
+                    }
+                })
+                .rendered(with: context)
+
+            // Return both the list item and edit.
+            return [todoListItem, todoEditItem]
+        }
+
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/TutorialContainerViewController.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/TutorialContainerViewController.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import UIKit
+import Workflow
+import WorkflowUI
+import BackStackContainer
+
+
+public final class TutorialContainerViewController: UIViewController {
+    let containerViewController: UIViewController
+
+    public init() {
+        // Create a view registry. This will allow the infrastructure to map `Screen` types to their respective view controller type.
+        var viewRegistry = ViewRegistry()
+        // Register the `WelcomeScreen` and view controller with the convenience method the template provided.
+        viewRegistry.registerWelcomeScreen()
+        // Register the `TodoListScreen` and view controller with the convenience method the template provided.
+        viewRegistry.registerTodoListScreen()
+        // Register the `BackStackContainer`, which provides a container for the `BackStackScreen`.
+        viewRegistry.registerBackStackContainer()
+        // Register the `TodoEditScreen` and view controller with the convenience method the template provided.
+        viewRegistry.registerTodoEditScreen()
+
+        // Create a `ContainerViewController` with the `RootWorkflow` as the root workflow, with the view registry we just created.
+        containerViewController = ContainerViewController(
+            workflow: RootWorkflow(),
+            viewRegistry: viewRegistry)
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .white
+
+        addChild(containerViewController)
+        view.addSubview(containerViewController.view)
+        containerViewController.didMove(toParent: self)
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        containerViewController.view.frame = view.bounds
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeScreen.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeScreen.swift
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import TutorialViews
+
+
+struct WelcomeScreen: Screen {
+    /// The current name that has been entered.
+    var name: String
+    /// Callback when the name changes in the UI.
+    var onNameChanged: (String) -> Void
+    /// Callback when the login button is tapped.
+    var onLoginTapped: () -> Void
+}
+
+
+final class WelcomeViewController: ScreenViewController<WelcomeScreen> {
+
+    var welcomeView: WelcomeView
+
+    required init(screen: WelcomeScreen, viewRegistry: ViewRegistry) {
+        self.welcomeView = WelcomeView(frame: .zero)
+        super.init(screen: screen, viewRegistry: viewRegistry)
+        update(with: screen)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(welcomeView)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        welcomeView.frame = view.bounds.inset(by: view.safeAreaInsets)
+    }
+
+    override func screenDidChange(from previousScreen: WelcomeScreen) {
+        update(with: screen)
+    }
+
+    private func update(with screen: WelcomeScreen) {
+        /// Update UI
+        welcomeView.name = screen.name
+        welcomeView.onNameChanged = screen.onNameChanged
+        welcomeView.onLoginTapped = screen.onLoginTapped
+    }
+
+}
+
+
+extension ViewRegistry {
+
+    public mutating func registerWelcomeScreen() {
+        self.register(screenViewControllerType: WelcomeViewController.self)
+    }
+
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Workflow
+import WorkflowUI
+import ReactiveSwift
+import Result
+
+
+// MARK: Input and Output
+
+struct WelcomeWorkflow: Workflow {
+    enum Output: Equatable {
+        case didLogin(name: String)
+    }
+}
+
+
+// MARK: State and Initialization
+
+extension WelcomeWorkflow {
+
+    struct State: Equatable {
+        var name: String
+    }
+
+    func makeInitialState() -> WelcomeWorkflow.State {
+        return State(name: "")
+    }
+
+    func workflowDidChange(from previousWorkflow: WelcomeWorkflow, state: inout State) {
+
+    }
+}
+
+
+// MARK: Actions
+
+extension WelcomeWorkflow {
+
+    enum Action: WorkflowAction {
+
+        typealias WorkflowType = WelcomeWorkflow
+
+        case nameChanged(name: String)
+        case didLogin
+
+        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+
+            switch self {
+            case .nameChanged(name: let name):
+                // Update our state with the updated name.
+                state.name = name
+                // Return `nil` for the output, we want to handle this action only at the level of this workflow.
+                return nil
+
+            case .didLogin:
+                if state.name.count != 0 {
+                    // Return an output of `didLogin` with the name if it's not empty.
+                    return .didLogin(name: state.name)
+                } else {
+                    // Don't log in if the name isn't filled in.
+                    return nil
+                }
+            }
+        }
+    }
+}
+
+
+// MARK: Workers
+
+extension WelcomeWorkflow {
+
+    struct WelcomeWorker: Worker {
+
+        enum Output {
+
+        }
+
+        func run() -> SignalProducer<Output, NoError> {
+            fatalError()
+        }
+
+        func isEquivalent(to otherWorker: WelcomeWorker) -> Bool {
+            return true
+        }
+
+    }
+
+}
+
+// MARK: Rendering
+
+extension WelcomeWorkflow {
+    typealias Rendering = WelcomeScreen
+
+    func render(state: WelcomeWorkflow.State, context: RenderContext<WelcomeWorkflow>) -> Rendering {
+
+        // Create a "sink" of type `Action`. A sink is what we use to send actions to the workflow.
+        let sink = context.makeSink(of: Action.self)
+
+        return WelcomeScreen(
+            name: state.name,
+            onNameChanged: { name in
+                sink.send(.nameChanged(name: name))
+        },
+            onLoginTapped: {
+                // Whenever the login button is tapped, emit the `.didLogin` action.
+                sink.send(.didLogin)
+        })
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/RootWorkflowTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/RootWorkflowTests.swift
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import Tutorial5
+import WorkflowTesting
+// Import `BackStackContainer` as testable so that the items in the `BackStackScreen` can be inspected.
+@testable import BackStackContainer
+// Import `WorkflowUI` as testable so that the wrappedScreen in `AnyScreen` can be accessed.
+@testable import WorkflowUI
+import Workflow
+
+class RootWorkflowTests: XCTestCase {
+
+    func testWelcomeRendering() {
+        RootWorkflow()
+            // Start in the `.welcome` state
+            .renderTester(initialState: RootWorkflow.State.welcome)
+            .render(
+                // Expect the state to stay as `.welcome`.
+                expectedState: ExpectedState(state: RootWorkflow.State.welcome),
+                // No output is expected from the root workflow.
+                expectedOutput: nil,
+                // There are no workers that should be run.
+                expectedWorkers: [],
+                // The `WelcomeWorkflow` is expected to be started in this render.
+                expectedWorkflows: [
+                    ExpectedWorkflow(
+                        type: WelcomeWorkflow.self,
+                        // Simulate this as the `WelcomeScreen` returned by the `WelcomeWorkflow`. The callback can be stubbed out, as they won't be used.
+                        rendering: WelcomeScreen(
+                            name: "MyName",
+                            onNameChanged: { _ in },
+                            onLoginTapped: {}))
+                    ],
+                // Now, validate that there is a single item in the BackStackScreen, which is our welcome screen.
+                assertions: { rendering in
+                    XCTAssertEqual(1, rendering.items.count)
+                    guard let welcomeScreen = rendering.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                        XCTFail("Expected first screen to be a `WelcomeScreen`")
+                        return
+                    }
+                    XCTAssertEqual("MyName", welcomeScreen.name)
+                })
+    }
+
+    func testLogin() {
+        RootWorkflow()
+            // Start in the `.welcome` state
+            .renderTester(initialState: RootWorkflow.State.welcome)
+            .render(
+                // Expect the state to transition to `.todo`
+                expectedState: ExpectedState(state: RootWorkflow.State.todo(name: "MyName")),
+                // No output is expected from the root workflow.
+                expectedOutput: nil,
+                // There are no workers that should be run.
+                expectedWorkers: [],
+                // The `WelcomeWorkflow` is expected to be started in this render.
+                expectedWorkflows: [
+                    ExpectedWorkflow(
+                        type: WelcomeWorkflow.self,
+                        // Simulate this as the `WelcomeScreen` returned by the `WelcomeWorkflow`. The callback can be stubbed out, as they won't be used.
+                        rendering: WelcomeScreen(
+                            name: "MyName",
+                            onNameChanged: { _ in },
+                            onLoginTapped: {}),
+                        // Simulate the `WelcomeWorkflow` sending an output of `.didLogin` as if the login button was tapped.
+                        output: .didLogin(name: "MyName"))
+                ],
+                // Now, validate that there is a single item in the BackStackScreen, which is our welcome screen (prior to the output).
+                assertions: { rendering in
+                    XCTAssertEqual(1, rendering.items.count)
+                    guard let welcomeScreen = rendering.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                        XCTFail("Expected first screen to be a `WelcomeScreen`")
+                        return
+                    }
+                    XCTAssertEqual("MyName", welcomeScreen.name)
+            })
+        .assert(state: { state in
+            XCTAssertEqual(.todo(name: "MyName"), state)
+        })
+
+    }
+
+    func testAppFlow() {
+        let workflowHost = WorkflowHost(workflow: RootWorkflow())
+
+        // First rendering is just the welcome screen. Update the name.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(1, backStack.items.count)
+
+            guard let welcomeScreen = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected initial screen of `WelcomeScreen`")
+                return
+            }
+
+            welcomeScreen.onNameChanged("MyName")
+        }
+
+        // Log in and go to the welcome list
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(1, backStack.items.count)
+
+            guard let welcomeScreen = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected initial screen of `WelcomeScreen`")
+                return
+            }
+
+            welcomeScreen.onLoginTapped()
+        }
+
+        // Expect the todo list. Edit the first todo.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(2, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let todoScreen = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+            XCTAssertEqual(1, todoScreen.todoTitles.count)
+            // Select the first todo:
+            todoScreen.onTodoSelected(0)
+        }
+
+        // Selected a todo to edit. Expect the todo edit screen.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(3, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let _ = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+
+            guard let editScreen = backStack.items[2].screen.wrappedScreen as? TodoEditScreen else {
+                XCTFail("Expected second screen of `TodoEditScreen`")
+                return
+            }
+
+            // Update the title:
+            editScreen.onTitleChanged("New Title")
+        }
+
+        // Save the selected todo.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(3, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let _ = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+
+            guard let _ = backStack.items[2].screen.wrappedScreen as? TodoEditScreen else {
+                XCTFail("Expected second screen of `TodoEditScreen`")
+                return
+            }
+
+            // Save the changes by tapping the right bar button.
+            // This also validates that the navigation bar was described as expected.
+            switch backStack.items[2].barVisibility {
+
+            case .hidden:
+                XCTFail("Expected a visible navigation bar")
+
+            case .visible(let barContent):
+                switch barContent.rightItem {
+
+                case .none:
+                    XCTFail("Expected a right bar button")
+
+                case .button(let button):
+
+                    switch button.content {
+
+                    case .text(let text):
+                        XCTAssertEqual("Save", text)
+
+                    case .icon:
+                        XCTFail("Expected the right bar button to have a title of `Save`")
+                    }
+                    // Tap the right bar button to save.
+                    button.handler()
+                }
+            }
+        }
+
+        // Expect the todo list. Validate the title was updated.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(2, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let todoScreen = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+            XCTAssertEqual(1, todoScreen.todoTitles.count)
+            XCTAssertEqual("New Title", todoScreen.todoTitles[0])
+
+        }
+
+    }
+
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoEditWorkflowTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoEditWorkflowTests.swift
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import Tutorial5
+import WorkflowTesting
+
+
+class TodoEditWorkflowTests: XCTestCase {
+
+    func testAction() {
+        TodoEditWorkflow
+            .Action
+            // Start with a todo of "Title" "Note"
+            .tester(
+                withState: TodoEditWorkflow.State(
+                    todo: TodoModel(title: "Title", note: "Note")))
+            .assertState { state in
+                XCTAssertEqual("Title", state.todo.title)
+                XCTAssertEqual("Note", state.todo.note)
+            }
+            // Update the title to "Updated Title"
+            .send(action: .titleChanged("Updated Title")) { output in
+                XCTAssertNil(output)
+            }
+            // Validate that only the title changed.
+            .assertState { state in
+                XCTAssertEqual("Updated Title", state.todo.title)
+                XCTAssertEqual("Note", state.todo.note)
+            }
+            // Update the note.
+            .send(action: .noteChanged("Updated Note")) { output in
+                XCTAssertNil(output)
+            }
+            // Validate that the note updated.
+            .assertState { state in
+                XCTAssertEqual("Updated Title", state.todo.title)
+                XCTAssertEqual("Updated Note", state.todo.note)
+            }
+            // Send a `.discardChanges` action, which will emit a `.discard` output.
+            .send(action: .discardChanges) { output in
+                switch output {
+                case .discard?:
+                    break // Expected
+                default:
+                    XCTFail("Expected an output of `.discard`")
+                }
+            }
+            // Send a `.saveChanges` action, which will emit a `.save` output with the updated todo model.
+            .send(action: .saveChanges) { output in
+                switch output {
+                case .save(let todo)?:
+                    XCTAssertEqual("Updated Title", todo.title)
+                    XCTAssertEqual("Updated Note", todo.note)
+                default:
+                    XCTFail("Expected an output of `.save`")
+                }
+            }
+    }
+
+    func testChangedPropertyUpdatesLocalState() {
+        let initialWorkflow = TodoEditWorkflow(initialTodo: TodoModel(title: "Title", note: "Note"))
+        var state = initialWorkflow.makeInitialState()
+        // The initial state is a copy of the provided todo:
+        XCTAssertEqual("Title", state.todo.title)
+        XCTAssertEqual("Note", state.todo.note)
+
+        // Mutate the internal state, simulating the change from actions:
+        state.todo.title = "Updated Title"
+
+        // Update the workflow properties with the same value. The state should not be updated:
+        initialWorkflow.workflowDidChange(from: initialWorkflow, state: &state)
+        XCTAssertEqual("Updated Title", state.todo.title)
+        XCTAssertEqual("Note", state.todo.note)
+
+        // The parent provided different properties. The internal state should be updated with the newly provided properties.
+        let updatedWorkflow = TodoEditWorkflow(initialTodo: TodoModel(title: "New Title", note: "New Note"))
+        updatedWorkflow.workflowDidChange(from: initialWorkflow, state: &state)
+
+        XCTAssertEqual("New Title", state.todo.title)
+        XCTAssertEqual("New Note", state.todo.note)
+    }
+
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoListWorkflowTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoListWorkflowTests.swift
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import Tutorial5
+import WorkflowTesting
+
+
+class TodoListWorkflowTests: XCTestCase {
+
+    func testActions() {
+        TodoListWorkflow
+            .Action
+            .tester(withState: TodoListWorkflow.State())
+            .send(action: .onBack) { output in
+                // The `.onBack` action should emit an output of `.back`.
+                switch output {
+                case .back?:
+                    break // Expected
+                default:
+                    XCTFail("Expected an output of `.back`")
+                }
+            }
+            .send(action: .selectTodo(index: 7)) { output in
+                // The `.selectTodo` action should emit a `.selectTodo` output.
+                switch output {
+                case .selectTodo(let index)?:
+                    XCTAssertEqual(7, index)
+                default:
+                    XCTFail("Expected an output of `.selectTodo`")
+                }
+            }
+            .send(action: .new) { output in
+                // The`.new` action should emit a `.newTodo` output.
+                switch output {
+                case .newTodo?:
+                break // Expected
+                default:
+                    XCTFail("Expected an output of `.newTodo`")
+                }
+            }
+    }
+
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import Tutorial5
+import BackStackContainer
+import WorkflowTesting
+
+
+class TodoWorkflowTests: XCTestCase {
+
+    func testSelectingTodo() {
+        let todos: [TodoModel] = [TodoModel(title: "Title", note: "Note")]
+
+        TodoWorkflow(name: "MyName")
+            // Start from the list step to validate selecting a todo:
+            .renderTester(initialState: TodoWorkflow.State(
+                todos: todos,
+                step: .list))
+            .render(
+                // Only specify the expected workflows for this render:
+                expectedWorkflows: [
+                    // We only expect the TodoListWorkflow
+                    ExpectedWorkflow(
+                        type: TodoListWorkflow.self,
+                        rendering: BackStackScreen.Item(
+                            screen: TodoListScreen(
+                                todoTitles: ["Title"],
+                                onTodoSelected: { _ in })),
+                        // Simulate selecting the first todo:
+                        output: TodoListWorkflow.Output.selectTodo(index: 0)),
+                ],
+                assertions: { items in
+                    // Just validate that there is one item in the backstack.
+                    // Additional validation could be done on the screens returned if so desired.
+                    XCTAssertEqual(1, items.count)
+            })
+            // Validate that the state was updated after the last render pass with the output from the TodoEditWorkflow.
+            .assert { state in
+                XCTAssertEqual(
+                    TodoWorkflow.State(
+                        todos: [TodoModel(title: "Title", note: "Note")],
+                        step: .edit(index: 0)),
+                    state)
+        }
+    }
+
+    func testSavingTodo() {
+        let todos: [TodoModel] = [TodoModel(title: "Title", note: "Note")]
+
+        TodoWorkflow(name: "MyName")
+            // Start from the edit step so we can simulate saving:
+            .renderTester(initialState: TodoWorkflow.State(
+                todos: todos,
+                step: .edit(index: 0)))
+            .render(
+                // Only specify the expected workflows for this render:
+                expectedWorkflows: [
+                    // We always expect the TodoListWorkflow
+                    ExpectedWorkflow(
+                        type: TodoListWorkflow.self,
+                        rendering: BackStackScreen.Item(
+                            screen: TodoListScreen(
+                                todoTitles: ["Title"],
+                                onTodoSelected: { _ in }))),
+                    // Expect the TodoEditWorkflow. Additionally, simulate it emitting an output of ".save" to update the state.
+                    ExpectedWorkflow(
+                        type: TodoEditWorkflow.self,
+                        rendering: BackStackScreen.Item(screen: TodoEditScreen(
+                            title: "Title",
+                            note: "Note",
+                            onTitleChanged: { _ in },
+                            onNoteChanged: { _ in })),
+                        output: TodoEditWorkflow.Output.save(TodoModel(
+                            title: "Updated Title",
+                            note: "Updated Note")))
+                ],
+                assertions: { items in
+                    // Just validate that there are two items in the backstack.
+                    // Additional validation could be done on the screens returned if so desired.
+                    XCTAssertEqual(2, items.count)
+                })
+            // Validate that the state was updated after the last render pass with the output from the TodoEditWorkflow.
+            .assert { state in
+                XCTAssertEqual(
+                    TodoWorkflow.State(
+                        todos: [TodoModel(title: "Updated Title", note: "Updated Note")],
+                        step: .list),
+                    state)
+            }
+    }
+
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TutorialTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TutorialTests.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+
+
+final class TutorialTests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertEqual(1, 1, "Placeholder test");
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/WelcomeWorkflowTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/WelcomeWorkflowTests.swift
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+@testable import Tutorial5
+import WorkflowTesting
+
+
+class WelcomeWorkflowTests: XCTestCase {
+
+    func testNameUpdates() {
+        WelcomeWorkflow.Action
+            .tester(withState: WelcomeWorkflow.State(name: ""))
+            .assertState { state in
+                // The initial state provided was an empty name.
+                XCTAssertEqual("", state.name)
+            }
+            .send(action: .nameChanged(name: "myName")) { output in
+                // No output is expected when the name changes.
+                XCTAssertNil(output)
+            }
+            .assertState { state in
+                // The `name` has been updated from the action.
+                XCTAssertEqual("myName", state.name)
+            }
+    }
+
+    func testLogin() {
+        WelcomeWorkflow.Action
+            .tester(withState: WelcomeWorkflow.State(name: ""))
+            .send(action: .didLogin) { output in
+                // Since the name is empty, `.didLogin` will not emit an output.
+                XCTAssertNil(output)
+            }
+            .assertState { state in
+                // The name is empty, as was specified in the initial state.
+                XCTAssertEqual("", state.name)
+            }
+            .send(action: .nameChanged(name: "MyName")) { output in
+                // Update the name.
+                XCTAssertNil(output)
+            }
+            .assertState { state in
+                // Validate the name was updated.
+                XCTAssertEqual("MyName", state.name)
+            }
+            .send(action: .didLogin) { output in
+                // Now a `.didLogin` output should be emitted when the `.didLogin` action was received.
+                switch output {
+                case .didLogin(let name)?:
+                    XCTAssertEqual("MyName", name)
+                case nil:
+                    XCTFail("Did not receive an output for .didLogin")
+                }
+        }
+    }
+
+    func testRendering() {
+        WelcomeWorkflow()
+            // Use the initial state provided by the welcome workflow
+            .renderTester()
+        .render(assertions: { screen in
+            XCTAssertEqual("", screen.name)
+            // Simulate tapping the login button. No output will be emitted, as the name is empty:
+            screen.onLoginTapped()
+        })
+        // Next, simulate the name updating, expecting the state to be changed to reflect the updated name:
+        .render(
+            expectedState: ExpectedState(state: WelcomeWorkflow.State(name: "myName")),
+            assertions: { screen in
+                screen.onNameChanged("myName")
+            })
+        // Finally, validate that `.didLogin` is sent when login is tapped with a non-empty name:
+        .render(
+            expectedOutput: ExpectedOutput(output: .didLogin(name: "myName")),
+            assertions: { screen in
+                screen.onLoginTapped()
+            })
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tutorial5.podspec
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tutorial5.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = 'Tutorial4'
+  s.name         = 'Tutorial5'
   s.version      = '1.0.0.LOCAL'
   s.summary      = 'See the README.'
   s.homepage     = 'https://github.com/square/workflow'
@@ -25,5 +25,6 @@ Pod::Spec.new do |s|
     test_spec.source_files = 'Tests/**/*.swift'
 
     test_spec.framework = 'XCTest'
+    test_spec.dependency 'WorkflowTesting'
   end
 end

--- a/swift/Samples/Tutorial/Frameworks/TutorialBase/Tests/TutorialTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/TutorialBase/Tests/TutorialTests.swift
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+
+
+final class TutorialTests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertEqual(1, 1, "Placeholder test");
+    }
+}

--- a/swift/Samples/Tutorial/Frameworks/TutorialBase/TutorialBase.podspec
+++ b/swift/Samples/Tutorial/Frameworks/TutorialBase/TutorialBase.podspec
@@ -19,4 +19,10 @@ Pod::Spec.new do |s|
   s.dependency 'Workflow'
   s.dependency 'WorkflowUI'
   s.dependency 'BackStackContainer'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+
+    test_spec.framework = 'XCTest'
+  end
 end

--- a/swift/Samples/Tutorial/Podfile
+++ b/swift/Samples/Tutorial/Podfile
@@ -8,9 +8,14 @@ target 'Tutorial' do
     pod 'BackStackContainer', path: '../BackStackContainer/BackStackContainer.podspec'
 
     pod 'TutorialViews', path: 'Frameworks/TutorialViews/TutorialViews.podspec'
-    pod 'TutorialBase', path: 'Frameworks/TutorialBase/TutorialBase.podspec'
+    pod 'TutorialBase', path: 'Frameworks/TutorialBase/TutorialBase.podspec', :testspecs => ['Tests']
     pod 'Tutorial1', path: 'Frameworks/Tutorial1Complete/Tutorial1.podspec'
     pod 'Tutorial2', path: 'Frameworks/Tutorial2Complete/Tutorial2.podspec'
     pod 'Tutorial3', path: 'Frameworks/Tutorial3Complete/Tutorial3.podspec'
-    pod 'Tutorial4', path: 'Frameworks/Tutorial4Complete/Tutorial4.podspec'
+    pod 'Tutorial4', path: 'Frameworks/Tutorial4Complete/Tutorial4.podspec', :testspecs => ['Tests']
+    pod 'Tutorial5', path: 'Frameworks/Tutorial5Complete/Tutorial5.podspec', :testspecs => ['Tests']
+end
+
+target 'TutorialTests' do
+    pod 'WorkflowTesting', path: '../../../WorkflowTesting.podspec', :testspecs => ['Tests']
 end

--- a/swift/Samples/Tutorial/README.md
+++ b/swift/Samples/Tutorial/README.md
@@ -26,3 +26,4 @@ The tutorial uses cocoapods as the dependency management. To get set up, run `bu
 - [Tutorial 2](Tutorial2.md) - Multiple views and navigation
 - [Tutorial 3](Tutorial3.md) - State throughout a tree of workflows
 - [Tutorial 4](Tutorial4.md) - Refactoring
+- [Tutorial 5](Tutorial5.md) - Testing

--- a/swift/Samples/Tutorial/Tutorial.xcodeproj/project.pbxproj
+++ b/swift/Samples/Tutorial/Tutorial.xcodeproj/project.pbxproj
@@ -3,25 +3,43 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		57AD55D94D909BD627910D7B /* libPods-TutorialTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EF26974165B129BC6DE52E1 /* libPods-TutorialTests.a */; };
 		E85390AB2314AF2D001B6313 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E85390AA2314AF2D001B6313 /* AppDelegate.swift */; };
 		E85390B22314AF2E001B6313 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E85390B12314AF2E001B6313 /* Assets.xcassets */; };
 		E85390B52314AF2E001B6313 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E85390B32314AF2E001B6313 /* LaunchScreen.storyboard */; };
+		E8907A49231F162B00F1BB2E /* TutorialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8907A48231F162B00F1BB2E /* TutorialTests.swift */; };
 		F77B18B3E43BEC102E47DEE6 /* libPods-Tutorial.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A115B9BFAF3DE7B7D706ACB7 /* libPods-Tutorial.a */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		E8907A4B231F162B00F1BB2E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E853909F2314AF2D001B6313 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E85390A62314AF2D001B6313;
+			remoteInfo = Tutorial;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		5EF26974165B129BC6DE52E1 /* libPods-TutorialTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TutorialTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		89B9987CFE631DF2BA454704 /* Pods-Tutorial.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial.release.xcconfig"; path = "Target Support Files/Pods-Tutorial/Pods-Tutorial.release.xcconfig"; sourceTree = "<group>"; };
 		A115B9BFAF3DE7B7D706ACB7 /* libPods-Tutorial.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tutorial.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BAD7C45E831F2461DD722CB8 /* Pods-Tutorial.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tutorial.debug.xcconfig"; path = "Target Support Files/Pods-Tutorial/Pods-Tutorial.debug.xcconfig"; sourceTree = "<group>"; };
+		CB24A23238CDD92FC7B1717B /* Pods-TutorialTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TutorialTests.release.xcconfig"; path = "Target Support Files/Pods-TutorialTests/Pods-TutorialTests.release.xcconfig"; sourceTree = "<group>"; };
+		DB10D9654B0E3B8B61678123 /* Pods-TutorialTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TutorialTests.debug.xcconfig"; path = "Target Support Files/Pods-TutorialTests/Pods-TutorialTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E85390A72314AF2D001B6313 /* Tutorial.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tutorial.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E85390AA2314AF2D001B6313 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E85390B12314AF2E001B6313 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E85390B42314AF2E001B6313 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E85390B62314AF2E001B6313 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E8907A46231F162B00F1BB2E /* TutorialTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TutorialTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E8907A48231F162B00F1BB2E /* TutorialTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialTests.swift; sourceTree = "<group>"; };
+		E8907A4A231F162B00F1BB2E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -33,6 +51,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E8907A43231F162B00F1BB2E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57AD55D94D909BD627910D7B /* libPods-TutorialTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -40,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				A115B9BFAF3DE7B7D706ACB7 /* libPods-Tutorial.a */,
+				5EF26974165B129BC6DE52E1 /* libPods-TutorialTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -49,8 +76,9 @@
 			children = (
 				BAD7C45E831F2461DD722CB8 /* Pods-Tutorial.debug.xcconfig */,
 				89B9987CFE631DF2BA454704 /* Pods-Tutorial.release.xcconfig */,
+				DB10D9654B0E3B8B61678123 /* Pods-TutorialTests.debug.xcconfig */,
+				CB24A23238CDD92FC7B1717B /* Pods-TutorialTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -60,6 +88,7 @@
 				E85390BE2314B001001B6313 /* Configuration */,
 				E85390BD2314AFE7001B6313 /* Resources */,
 				E85390BC2314AFC8001B6313 /* Sources */,
+				E8907A47231F162B00F1BB2E /* TutorialTests */,
 				E85390A82314AF2D001B6313 /* Products */,
 				96383393E09F25B5773BDA71 /* Pods */,
 				388F8A674EF339ECE9A5D046 /* Frameworks */,
@@ -70,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				E85390A72314AF2D001B6313 /* Tutorial.app */,
+				E8907A46231F162B00F1BB2E /* TutorialTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -102,6 +132,16 @@
 			path = AppHost/Configuration;
 			sourceTree = "<group>";
 		};
+		E8907A47231F162B00F1BB2E /* TutorialTests */ = {
+			isa = PBXGroup;
+			children = (
+				E8907A48231F162B00F1BB2E /* TutorialTests.swift */,
+				E8907A4A231F162B00F1BB2E /* Info.plist */,
+			);
+			name = TutorialTests;
+			path = AppHost/TutorialTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -124,6 +164,25 @@
 			productReference = E85390A72314AF2D001B6313 /* Tutorial.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E8907A45231F162B00F1BB2E /* TutorialTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E8907A4F231F162B00F1BB2E /* Build configuration list for PBXNativeTarget "TutorialTests" */;
+			buildPhases = (
+				F31716859C0BC0B7AA34707F /* [CP] Check Pods Manifest.lock */,
+				E8907A42231F162B00F1BB2E /* Sources */,
+				E8907A43231F162B00F1BB2E /* Frameworks */,
+				E8907A44231F162B00F1BB2E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E8907A4C231F162B00F1BB2E /* PBXTargetDependency */,
+			);
+			name = TutorialTests;
+			productName = TutorialTests;
+			productReference = E8907A46231F162B00F1BB2E /* TutorialTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -136,6 +195,10 @@
 				TargetAttributes = {
 					E85390A62314AF2D001B6313 = {
 						CreatedOnToolsVersion = 10.2.1;
+					};
+					E8907A45231F162B00F1BB2E = {
+						CreatedOnToolsVersion = 10.2.1;
+						TestTargetID = E85390A62314AF2D001B6313;
 					};
 				};
 			};
@@ -153,6 +216,7 @@
 			projectRoot = "";
 			targets = (
 				E85390A62314AF2D001B6313 /* Tutorial */,
+				E8907A45231F162B00F1BB2E /* TutorialTests */,
 			);
 		};
 /* End PBXProject section */
@@ -164,6 +228,13 @@
 			files = (
 				E85390B52314AF2E001B6313 /* LaunchScreen.storyboard in Resources */,
 				E85390B22314AF2E001B6313 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E8907A44231F162B00F1BB2E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -209,6 +280,28 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Tutorial/Pods-Tutorial-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		F31716859C0BC0B7AA34707F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TutorialTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -220,7 +313,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E8907A42231F162B00F1BB2E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E8907A49231F162B00F1BB2E /* TutorialTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E8907A4C231F162B00F1BB2E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E85390A62314AF2D001B6313 /* Tutorial */;
+			targetProxy = E8907A4B231F162B00F1BB2E /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		E85390B32314AF2E001B6313 /* LaunchScreen.storyboard */ = {
@@ -386,6 +495,46 @@
 			};
 			name = Release;
 		};
+		E8907A4D231F162B00F1BB2E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DB10D9654B0E3B8B61678123 /* Pods-TutorialTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = AppHost/TutorialTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.TutorialTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tutorial.app/Tutorial";
+			};
+			name = Debug;
+		};
+		E8907A4E231F162B00F1BB2E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CB24A23238CDD92FC7B1717B /* Pods-TutorialTests.release.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = AppHost/TutorialTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.squareup.TutorialTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tutorial.app/Tutorial";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -403,6 +552,15 @@
 			buildConfigurations = (
 				E85390BA2314AF2E001B6313 /* Debug */,
 				E85390BB2314AF2E001B6313 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E8907A4F231F162B00F1BB2E /* Build configuration list for PBXNativeTarget "TutorialTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E8907A4D231F162B00F1BB2E /* Debug */,
+				E8907A4E231F162B00F1BB2E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/swift/Samples/Tutorial/Tutorial.xcodeproj/xcshareddata/xcschemes/Tutorial.xcscheme
+++ b/swift/Samples/Tutorial/Tutorial.xcodeproj/xcshareddata/xcschemes/Tutorial.xcscheme
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E85390A62314AF2D001B6313"
+               BuildableName = "Tutorial.app"
+               BlueprintName = "Tutorial"
+               ReferencedContainer = "container:Tutorial.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0E0BD3926F3C1BA169C89ABC428B9020"
+               BuildableName = "TutorialBase-Unit-Tests.xctest"
+               BlueprintName = "TutorialBase-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "01B7DCF9AC15D037ECB90629096159ED"
+               BuildableName = "Tutorial4-Unit-Tests.xctest"
+               BlueprintName = "Tutorial4-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5FA173E901A79986D7EFFF6B88337188"
+               BuildableName = "Tutorial5-Unit-Tests.xctest"
+               BlueprintName = "Tutorial5-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E8907A45231F162B00F1BB2E"
+               BuildableName = "TutorialTests.xctest"
+               BlueprintName = "TutorialTests"
+               ReferencedContainer = "container:Tutorial.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E85390A62314AF2D001B6313"
+            BuildableName = "Tutorial.app"
+            BlueprintName = "Tutorial"
+            ReferencedContainer = "container:Tutorial.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E85390A62314AF2D001B6313"
+            BuildableName = "Tutorial.app"
+            BlueprintName = "Tutorial"
+            ReferencedContainer = "container:Tutorial.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E85390A62314AF2D001B6313"
+            BuildableName = "Tutorial.app"
+            BlueprintName = "Tutorial"
+            ReferencedContainer = "container:Tutorial.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/swift/Samples/Tutorial/Tutorial1.md
+++ b/swift/Samples/Tutorial/Tutorial1.md
@@ -4,9 +4,9 @@ _Let's get something on the screen..._
 
 ## Setup
 
-Start by getting the project set up, by running `bundle exec pod install` in `Tutorial` to get the cocoapods installed.
-
-Then open `Tutorial.xcworkspace` and run the target `Tutorial` to ensure that it builds.
+To follow this tutorial:
+- Open your terminal and run `bundle exec pod install` in the `swift/Samples/Tutorial` directory.
+- Open `Tutorial.xcworkspace` and build the `Tutorial` Scheme.
 
 The `TutorialBase` pod in `Frameworks` will be our starting place to build from.
 

--- a/swift/Samples/Tutorial/Tutorial2.md
+++ b/swift/Samples/Tutorial/Tutorial2.md
@@ -4,7 +4,11 @@ _Multiple Screens and Navigation_
 
 ## Setup
 
-Start from the completed code from Tutorial 1, or if you're jumping ahead, the completed `Tutorial1` pod.
+To follow this tutorial:
+- Open your terminal and run `bundle exec pod install` in the `swift/Samples/Tutorial` directory.
+- Open `Tutorial.xcworkspace` and build the `Tutorial` Scheme.
+
+Start from implementation of `Tutorial1` if you're skipping ahead. You can run this by updating the `AppDelegate` to import `Tutorial1` instead of `TutorialBase`.
 
 ## Second Workflow
 

--- a/swift/Samples/Tutorial/Tutorial3.md
+++ b/swift/Samples/Tutorial/Tutorial3.md
@@ -4,7 +4,11 @@ _State throughout a tree of workflows_
 
 ## Setup
 
-Start from the completed code from Tutorial 2, or if you're jumping ahead, the completed `Tutorial2` pod.
+To follow this tutorial:
+- Open your terminal and run `bundle exec pod install` in the `swift/Samples/Tutorial` directory.
+- Open `Tutorial.xcworkspace` and build the `Tutorial` Scheme.
+
+Start from implementation of `Tutorial2` if you're skipping ahead. You can run this by updating the `AppDelegate` to import `Tutorial2` instead of `TutorialBase`.
 
 ## Editing TODO items
 

--- a/swift/Samples/Tutorial/Tutorial4.md
+++ b/swift/Samples/Tutorial/Tutorial4.md
@@ -4,7 +4,11 @@ _Refactoring and rebalancing a tree of Workflows_
 
 ## Setup
 
-Start from the completed code from Tutorial 3, or if you're jumping ahead, the completed `Tutorial3` pod.
+To follow this tutorial:
+- Open your terminal and run `bundle exec pod install` in the `swift/Samples/Tutorial` directory.
+- Open `Tutorial.xcworkspace` and build the `Tutorial` Scheme.
+
+Start from implementation of `Tutorial3` if you're skipping ahead. You can run this by updating the `AppDelegate` to import `Tutorial3` instead of `TutorialBase`.
 
 ## Adding new TODO items
 

--- a/swift/Samples/Tutorial/Tutorial5.md
+++ b/swift/Samples/Tutorial/Tutorial5.md
@@ -1,0 +1,843 @@
+# Step 5
+
+_Unit and Integration Testing Workflows_
+
+## Setup
+
+To follow this tutorial:
+- Open your terminal and run `bundle exec pod install` in the `swift/Samples/Tutorial` directory.
+- Open `Tutorial.xcworkspace` and build the `Tutorial` Scheme.
+- The unit tests will run from the default scheme when pressing `cmd+shift+u`.
+
+Start from implementation of `Tutorial4` if you're skipping ahead. You can run this by updating the `AppDelegate` to import `Tutorial4` instead of `TutorialBase`.
+
+# Testing
+
+`Workflow`s being easily testable was a design requirement. It is essential to building scalable, reliable software.
+
+The `WorkflowTesting` library is provided to allow easy unit and integration testing.
+
+## Unit Tests (Actions)
+
+A `WorkflowAction`'s `apply` function is effectively a reducer. Given a current state and action, it returns a new state (and optionally an output). Because `apply` function should almost always be a "pure" function, it is a great candidate for unit testing.
+
+The `WorkflowActionTester` is provided to facilitate writing unit tests against actions.
+
+## WorkflowActionTester
+
+The `WorkflowActionTester` is an extension on `WorkflowAction` which provides an easy to use harness for testing a series of actions and the resulting state updates. From the example in the source:
+```swift
+/// TestedWorklfow.Action
+///     .tester(withState: .firstState)
+///     .assertState { state in
+///         XCTAssertEqual(.firstState, state)
+///     }
+///     .send(action: .exampleEvent) { output in
+///         XCTAssertEqual(.finished, output)
+///     }
+///     .assertState { state in
+///         XCTAssertEqual(.differentState, state)
+///     }
+```
+
+It's provided with an initial state, and drives the state forward by sending one action at a time. The `Output` can be validated after each action is sent, as well as the `State`.
+
+### WelcomeWorkflow Tests
+
+Start by creating a new Unit test file called `WelcomeWorkflowTests`. Import `WorkflowTesting` as well as a `@testable import` for the `Tutorial` pod you're testing:
+
+We'll use the `@testable import` to be able to test the our workflows which are not exposed publicly.
+
+```swift
+import XCTest
+@testable import TutorialBase
+import WorkflowTesting
+
+
+class WelcomeWorkflowTests: XCTestCase {
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+}
+```
+
+For the `WelcomeWorkflow`, we will start by testing that the `name` property is updated on the state every time a `.nameChanged` action is received:
+
+```swift
+import XCTest
+@testable import TutorialBase
+import WorkflowTesting
+
+
+class WelcomeWorkflowTests: XCTestCase {
+
+    func testNameUpdates() {
+        WelcomeWorkflow.Action
+            .tester(withState: WelcomeWorkflow.State(name: ""))
+            .assertState { state in
+                // The initial state provided was an empty name.
+                XCTAssertEqual("", state.name)
+            }
+            .send(action: .nameChanged(name: "myName")) { output in
+                // No output is expected when the name changes.
+                XCTAssertNil(output)
+            }
+            .assertState { state in
+                // The `name` has been updated from the action.
+                XCTAssertEqual("myName", state.name)
+            }
+    }
+
+}
+```
+
+The `Output` of an action can also be tested. Next, we'll add a test for the `.didLogin` action.
+
+```swift
+    func testLogin() {
+        WelcomeWorkflow.Action
+            .tester(withState: WelcomeWorkflow.State(name: ""))
+            .send(action: .didLogin) { output in
+                switch output {
+                // When the `.didLogin` action is received, it should emit the `didLogin(name)` output.
+                case .didLogin(let name)?:
+                    XCTAssertEqual("", name)
+                case nil:
+                    XCTFail("Did not receive an output for .didLogin")
+                }
+        }
+    }
+```
+
+We have now validated that an output is emitted when the `.didLogin` action is received. However, while writing this test, it probably doesn't make sense to allow someone to log in without providing a name. Let's update the test to ensure that login is only allowed when there is a name:
+
+```swift
+    func testLogin() {
+        WelcomeWorkflow.Action
+            .tester(withState: WelcomeWorkflow.State(name: ""))
+            .send(action: .didLogin) { output in
+                // Since the name is empty, `.didLogin` will not emit an output.
+                XCTAssertNil(output)
+            }
+            .assertState { state in
+                // The name is empty, as was specified in the initial state.
+                XCTAssertEqual("", state.name)
+            }
+            .send(action: .nameChanged(name: "MyName")) { output in
+                // Update the name.
+                XCTAssertNil(output)
+            }
+            .assertState { state in
+                // Validate the name was updated.
+                XCTAssertEqual("MyName", state.name)
+            }
+            .send(action: .didLogin) { output in
+                // Now a `.didLogin` output should be emitted when the `.didLogin` action was received.
+                switch output {
+                case .didLogin(let name)?:
+                    XCTAssertEqual("MyName", name)
+                case nil:
+                    XCTFail("Did not receive an output for .didLogin")
+                }
+        }
+    }
+```
+
+The test will now fail, as a `.didLogin` action will still cause `.didLogin` output when the name is blank. Update the `WelcomeWorkflow` logic to reflect the new behavior we want:
+
+```swift
+// MARK: Actions
+
+extension WelcomeWorkflow {
+
+    enum Action: WorkflowAction {
+
+        typealias WorkflowType = WelcomeWorkflow
+
+        case nameChanged(name: String)
+        case didLogin
+
+        func apply(toState state: inout WelcomeWorkflow.State) -> WelcomeWorkflow.Output? {
+
+            switch self {
+            case .nameChanged(name: let name):
+                // Update our state with the updated name.
+                state.name = name
+                // Return `nil` for the output, we want to handle this action only at the level of this workflow.
+                return nil
+
+            case .didLogin:
+                if state.name.count != 0 {
+                    // Return an output of `didLogin` with the name if it's not empty.
+                    return .didLogin(name: state.name)
+                } else {
+                    // Don't log in if the name isn't filled in.
+                    return nil
+                }
+            }
+        }
+    }
+}
+```
+
+Run the test again and ensure that it passes. Additionally, try the app to see that it also reflects the updated behavior.
+
+### TodoListWorkflow
+
+Add tests for the `TodoListWorkflow`. They'll be pretty simple, as this workflow is stateless and all actions are simply forwarded to the parent as outputs:
+
+```swift
+import XCTest
+@testable import TutorialBase
+import WorkflowTesting
+
+
+class TodoListWorkflowTests: XCTestCase {
+
+    func testActions() {
+        TodoListWorkflow
+            .Action
+            .tester(withState: TodoListWorkflow.State())
+            .send(action: .onBack) { output in
+                // The `.onBack` action should emit an output of `.back`.
+                switch output {
+                case .back?:
+                    break // Expected
+                default:
+                    XCTFail("Expected an output of `.back`")
+                }
+            }
+            .send(action: .selectTodo(index: 7)) { output in
+                // The `.selectTodo` action should emit a `.selectTodo` output.
+                switch output {
+                case .selectTodo(let index)?:
+                    XCTAssertEqual(7, index)
+                default:
+                    XCTFail("Expected an output of `.selectTodo`")
+                }
+            }
+            .send(action: .new) { output in
+                // The`.new` action should emit a `.newTodo` output.
+                switch output {
+                case .newTodo?:
+                break // Expected
+                default:
+                    XCTFail("Expected an output of `.newTodo`")
+                }
+            }
+    }
+
+}
+```
+
+### TodoEditWorkflow
+
+The `TodoEditWorkflow` has a bit more complexity since it holds a local copy of the todo to be edited. Start by adding tests for the actions:
+
+```swift
+import XCTest
+@testable import TutorialBase
+import WorkflowTesting
+
+
+class TodoEditWorkflowTests: XCTestCase {
+
+    func testAction() {
+        TodoEditWorkflow
+            .Action
+            // Start with a todo of "Title" "Note"
+            .tester(
+                withState: TodoEditWorkflow.State(
+                    todo: TodoModel(title: "Title", note: "Note")))
+            .assertState { state in
+                XCTAssertEqual("Title", state.todo.title)
+                XCTAssertEqual("Note", state.todo.note)
+            }
+            // Update the title to "Updated Title"
+            .send(action: .titleChanged("Updated Title")) { output in
+                XCTAssertNil(output)
+            }
+            // Validate that only the title changed.
+            .assertState { state in
+                XCTAssertEqual("Updated Title", state.todo.title)
+                XCTAssertEqual("Note", state.todo.note)
+            }
+            // Update the note.
+            .send(action: .noteChanged("Updated Note")) { output in
+                XCTAssertNil(output)
+            }
+            // Validate that the note updated.
+            .assertState { state in
+                XCTAssertEqual("Updated Title", state.todo.title)
+                XCTAssertEqual("Updated Note", state.todo.note)
+            }
+            // Send a `.discardChanges` action, which will emit a `.discard` output.
+            .send(action: .discardChanges) { output in
+                switch output {
+                case .discard?:
+                    break // Expected
+                default:
+                    XCTFail("Expected an output of `.discard`")
+                }
+            }
+            // Send a `.saveChanges` action, which will emit a `.save` output with the updated todo model.
+            .send(action: .saveChanges) { output in
+                switch output {
+                case .save(let todo)?:
+                    XCTAssertEqual("Updated Title", todo.title)
+                    XCTAssertEqual("Updated Note", todo.note)
+                default:
+                    XCTFail("Expected an output of `.save`")
+                }
+            }
+    }
+
+}
+```
+
+The `TodoEditWorkflow` also uses the `workflowDidChange` to update the internal state if its parent provides it with a different `todo`. Validate that this works as expected:
+
+```swift
+    func testChangedPropertyUpdatesLocalState() {
+        let initialWorkflow = TodoEditWorkflow(initialTodo: TodoModel(title: "Title", note: "Note"))
+        var state = initialWorkflow.makeInitialState()
+        // The initial state is a copy of the provided todo:
+        XCTAssertEqual("Title", state.todo.title)
+        XCTAssertEqual("Note", state.todo.note)
+
+        // Mutate the internal state, simulating the change from actions:
+        state.todo.title = "Updated Title"
+
+        // Update the workflow properties with the same value. The state should not be updated:
+        initialWorkflow.workflowDidChange(from: initialWorkflow, state: &state)
+        XCTAssertEqual("Updated Title", state.todo.title)
+        XCTAssertEqual("Note", state.todo.note)
+
+        // The parent provided different properties. The internal state should be updated with the newly provided properties.
+        let updatedWorkflow = TodoEditWorkflow(initialTodo: TodoModel(title: "New Title", note: "New Note"))
+        updatedWorkflow.workflowDidChange(from: initialWorkflow, state: &state)
+
+        XCTAssertEqual("New Title", state.todo.title)
+        XCTAssertEqual("New Note", state.todo.note)
+    }
+```
+
+## Testing Rendering
+
+Testing actions is very useful for validating all of the state transitions of a workflow, but it is beneficial to validate that the screens from `render` are expected. Since the `render` method uses a private implementation of a `RenderContext`, there is a `RenderTester` to facilitate testing.
+
+## RenderTester
+
+The `renderTester` extension on `Workflow` provides an easy way to test the rendering from a workflow. The simple usage of validating a rendering is shown in the doc comments:
+```swift
+workflow
+    .renderTester()
+    .render(
+    with: RenderExpectations(),
+    assertions: { rendering in
+        XCTAssertEqual("expected text on rendering", rendering.text)
+    }
+```
+
+It also provides a means to test that closures passed to screens cause the correct actions and state changes:
+
+```swift
+workflow
+    .renderTester()
+    .render(
+        with: RenderExpectations(
+            expectedState: ExpectedState(state: TestWorkflow.State(text: "updated")),
+        assertions: { rendering in
+            XCTAssertEqual("expected text on rendering", rendering.text)
+            rendering.updateText("updated")
+        }
+```
+
+The full API allows for expected states, output, workers, and (child) workflows:
+```swift
+workflow
+    .renderTester(initialState: State())
+    .render(
+        expectedState: ExpectedState(state: TestWorkflow.State(text: "updated")),
+        expectedOutput: ExpectedOutput(output: .completed),
+        expectedWorkers: [ExpectedWorker(worker: TestWorker(), output: .finished)],
+        expectedWorkflows: [ExpectedWorkflow(workflow: ChildWorkflow.self, rendering: ChildScreen(), output: .closed)],
+        assertions: { rendering in
+            XCTAssertEqual("expected text on rendering", rendering.text)
+        })
+```
+
+### WelcomeWorkflow
+
+Add a test for the rendering of the `WelcomeWorkflow`:
+
+```swift
+// WelcomeWorkflowTests.swift
+
+    func testRendering() {
+        WelcomeWorkflow()
+            // Use the initial state provided by the welcome workflow
+            .renderTester()
+        .render(assertions: { screen in
+            XCTAssertEqual("", screen.name)
+            // Simulate tapping the login button. No output will be emitted, as the name is empty:
+            screen.onLoginTapped()
+        })
+        // Next, simulate the name updating, expecting the state to be changed to reflect the updated name:
+        .render(
+            expectedState: ExpectedState(
+                state: WelcomeWorkflow.State(name: "myName"),
+                isEquivalent: { (expected, actual) -> Bool in
+                    return expected.name == actual.name
+            }), assertions: { screen in
+                screen.onNameChanged("myName")
+            })
+        // Finally, validate that `.didLogin` is sent when login is tapped with a non-empty name:
+        .render(
+            expectedOutput: ExpectedOutput(output: .didLogin(name: "myName"), isEquivalent: { (expected, actual) in
+                switch (expected, actual) {
+                case (.didLogin(name: let expectedName), .didLogin(name: let actualName)):
+                    return expectedName == actualName
+                }
+            }),
+            assertions: { screen in
+                screen.onLoginTapped()
+            })
+    }
+```
+
+Since the `State` and `Output` on the `WelcomeWorkflow` aren't equatable, we had to write our own equivalence method for them. To simplify this test, instead let's have both conform to `Equatable` to make the test a bit easier to read:
+
+```swift
+// MARK: Input and Output
+
+struct WelcomeWorkflow: Workflow {
+    enum Output: Equatable {
+        case didLogin(name: String)
+    }
+}
+
+
+// MARK: State and Initialization
+
+extension WelcomeWorkflow {
+
+    struct State: Equatable {
+        var name: String
+    }
+
+// ... rest of the implementation ...
+```
+
+Update the test to take advantage of the `Equatable` conformance:
+
+
+```swift
+func testRendering() {
+        WelcomeWorkflow()
+            // Use the initial state provided by the welcome workflow
+            .renderTester()
+        .render(assertions: { screen in
+            XCTAssertEqual("", screen.name)
+            // Simulate tapping the login button. No output will be emitted, as the name is empty:
+            screen.onLoginTapped()
+        })
+        // Next, simulate the name updating, expecting the state to be changed to reflect the updated name:
+        .render(
+            expectedState: ExpectedState(state: WelcomeWorkflow.State(name: "myName")),
+            assertions: { screen in
+                screen.onNameChanged("myName")
+            })
+        // Finally, validate that `.didLogin` is sent when login is tapped with a non-empty name:
+        .render(
+            expectedOutput: ExpectedOutput(output: .didLogin(name: "myName")),
+            assertions: { screen in
+                screen.onLoginTapped()
+            })
+    }
+```
+
+Add tests against the `render` methods of the `TodoEdit` and `TodoList` workflows as desired.
+
+## Composition Testing
+
+We've demonstrated how to test leaf workflows for their actions and renderings. However, the power of workflow is the ability to compose a tree of workflows. The `RenderTester` provides the tools to test workflows with children.
+
+The `ExpectedWorkflow` allows a child workflow to be described that is expected for the next render. It is given the type of child, and optional key, and the mock rendering to return. It can also provide an optional output:
+```swift
+public struct ExpectedWorkflow {
+
+    public init<WorkflowType: Workflow>(type: WorkflowType.Type, key: String = "", rendering: WorkflowType.Rendering, output: WorkflowType.Output? = nil)
+
+}
+```
+
+### RootWorkflow Tests
+
+The `RootWorkflow` is responsible for the entire state of our app. We can skip testing the actions with the `ActionTester`, as that will be handled by testing the rendering.
+
+Start by adding `Equatable` conformance to the `State` to simplify the tests:
+
+```swift
+extension RootWorkflow {
+
+    // The state is an enum, and can either be on the welcome screen or the todo list.
+    // When on the todo list, it also includes the name provided on the welcome screen
+    enum State: Equatable {
+        // The welcome screen via the welcome workflow will be shown
+        case welcome
+        // The todo list screen via the todo list workflow will be shown. The name will be provided to the todo list.
+        case todo(name: String)
+    }
+```
+
+And first we can test the `.welcome` state on its own:
+
+```swift
+import XCTest
+@testable import TutorialBase
+import WorkflowTesting
+// Import `BackStackContainer` as testable so that the items in the `BackStackScreen` can be inspected.
+@testable import BackStackContainer
+// Import `WorkflowUI` as testable so that the wrappedScreen in `AnyScreen` can be accessed.
+@testable import WorkflowUI
+
+class RootWorkflowTests: XCTestCase {
+
+    func testWelcomeRendering() {
+        RootWorkflow()
+            // Start in the `.welcome` state
+            .renderTester(initialState: RootWorkflow.State.welcome)
+            .render(
+                // Expect the state to stay as `.welcome`.
+                expectedState: ExpectedState(state: RootWorkflow.State.welcome),
+                // No output is expected from the root workflow.
+                expectedOutput: nil,
+                // There are no workers that should be run.
+                expectedWorkers: [],
+                // The `WelcomeWorkflow` is expected to be started in this render.
+                expectedWorkflows: [
+                    ExpectedWorkflow(
+                        type: WelcomeWorkflow.self,
+                        // Simulate this as the `WelcomeScreen` returned by the `WelcomeWorkflow`. The callback can be stubbed out, as they won't be used.
+                        rendering: WelcomeScreen(
+                            name: "MyName",
+                            onNameChanged: { _ in },
+                            onLoginTapped: {}))
+                    ],
+                // Now, validate that there is a single item in the BackStackScreen, which is our welcome screen.
+                assertions: { rendering in
+                    XCTAssertEqual(1, rendering.items.count)
+                    guard let welcomeScreen = rendering.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                        XCTFail("Expected first screen to be a `WelcomeScreen`")
+                        return
+                    }
+                    XCTAssertEqual("MyName", welcomeScreen.name)
+                })
+    }
+
+}
+```
+
+We needed to use a few `@testable` imports to inspect the underlying screen (since both the `BackStackScreen` and `AnyScreen` use type-erasure), but we've been able to validate that the `RootWorkflow` renders as expected.
+
+Now, we can also test the transition from the `.welcome` state to the `.todo` state:
+
+```swift
+    func testLogin() {
+        RootWorkflow()
+            // Start in the `.welcome` state
+            .renderTester(initialState: RootWorkflow.State.welcome)
+            .render(
+                // Expect the state to transition to `.todo`
+                expectedState: ExpectedState(state: RootWorkflow.State.todo(name: "MyName")),
+                // No output is expected from the root workflow.
+                expectedOutput: nil,
+                // There are no workers that should be run.
+                expectedWorkers: [],
+                // The `WelcomeWorkflow` is expected to be started in this render.
+                expectedWorkflows: [
+                    ExpectedWorkflow(
+                        type: WelcomeWorkflow.self,
+                        // Simulate this as the `WelcomeScreen` returned by the `WelcomeWorkflow`. The callback can be stubbed out, as they won't be used.
+                        rendering: WelcomeScreen(
+                            name: "MyName",
+                            onNameChanged: { _ in },
+                            onLoginTapped: {}),
+                        // Simulate the `WelcomeWorkflow` sending an output of `.didLogin` as if the login button was tapped.
+                        output: .didLogin(name: "MyName"))
+                ],
+                // Now, validate that there is a single item in the BackStackScreen, which is our welcome screen (prior to the output).
+                assertions: { rendering in
+                    XCTAssertEqual(1, rendering.items.count)
+                    guard let welcomeScreen = rendering.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                        XCTFail("Expected first screen to be a `WelcomeScreen`")
+                        return
+                    }
+                    XCTAssertEqual("MyName", welcomeScreen.name)
+            })
+        .assert(state: { state in
+            XCTAssertEqual(.todo(name: "MyName"), state)
+        })
+
+    }
+```
+
+By simulating the output from the `WelcomeWorkflow`, we were able to drive the `RootWorkflow` forward. This was much more of an integration test than a "pure" unit test, but we have now validated the same behavior we see by testing the app by hand.
+
+### TodoWorkflow Render Tests
+
+Now add tests for the `TodoWorkflow`, so that we have relatively full coverage. These are two examples, of selecting and saving a TODO to validate the transitions between screens, as well as updating the state in the parent (Add `Equatable` conformance to `TodoWorkflow.State` to simplify the tests):
+
+```swift
+import XCTest
+@testable import TutorialBase
+import BackStackContainer
+import WorkflowTesting
+
+
+class TodoWorkflowTests: XCTestCase {
+
+    func testSelectingTodo() {
+        let todos: [TodoModel] = [TodoModel(title: "Title", note: "Note")]
+
+        TodoWorkflow(name: "MyName")
+            // Start from the list step to validate selecting a todo:
+            .renderTester(initialState: TodoWorkflow.State(
+                todos: todos,
+                step: .list))
+            .render(
+                // Only specify the expected workflows for this render:
+                expectedWorkflows: [
+                    // We only expect the TodoListWorkflow
+                    ExpectedWorkflow(
+                        type: TodoListWorkflow.self,
+                        rendering: BackStackScreen.Item(
+                            screen: TodoListScreen(
+                                todoTitles: ["Title"],
+                                onTodoSelected: { _ in })),
+                        // Simulate selecting the first todo:
+                        output: TodoListWorkflow.Output.selectTodo(index: 0)),
+                ],
+                assertions: { items in
+                    // Just validate that there is one item in the backstack.
+                    // Additional validation could be done on the screens returned if so desired.
+                    XCTAssertEqual(1, items.count)
+            })
+            // Validate that the state was updated after the last render pass with the output from the TodoEditWorkflow.
+            .assert { state in
+                XCTAssertEqual(
+                    TodoWorkflow.State(
+                        todos: [TodoModel(title: "Title", note: "Note")],
+                        step: .edit(index: 0)),
+                    state)
+        }
+    }
+
+    func testSavingTodo() {
+        let todos: [TodoModel] = [TodoModel(title: "Title", note: "Note")]
+
+        TodoWorkflow(name: "MyName")
+            // Start from the edit step so we can simulate saving:
+            .renderTester(initialState: TodoWorkflow.State(
+                todos: todos,
+                step: .edit(index: 0)))
+            .render(
+                // Only specify the expected workflows for this render:
+                expectedWorkflows: [
+                    // We always expect the TodoListWorkflow
+                    ExpectedWorkflow(
+                        type: TodoListWorkflow.self,
+                        rendering: BackStackScreen.Item(
+                            screen: TodoListScreen(
+                                todoTitles: ["Title"],
+                                onTodoSelected: { _ in }))),
+                    // Expect the TodoEditWorkflow. Additionally, simulate it emitting an output of ".save" to update the state.
+                    ExpectedWorkflow(
+                        type: TodoEditWorkflow.self,
+                        rendering: BackStackScreen.Item(screen: TodoEditScreen(
+                            title: "Title",
+                            note: "Note",
+                            onTitleChanged: { _ in },
+                            onNoteChanged: { _ in })),
+                        output: TodoEditWorkflow.Output.save(TodoModel(
+                            title: "Updated Title",
+                            note: "Updated Note")))
+                ],
+                assertions: { items in
+                    // Just validate that there are two items in the backstack.
+                    // Additional validation could be done on the screens returned if so desired.
+                    XCTAssertEqual(2, items.count)
+                })
+            // Validate that the state was updated after the last render pass with the output from the TodoEditWorkflow.
+            .assert { state in
+                XCTAssertEqual(
+                    TodoWorkflow.State(
+                        todos: [TodoModel(title: "Updated Title", note: "Updated Note")],
+                        step: .list),
+                    state)
+            }
+    }
+
+}
+```
+
+## Integration Testing
+
+The `RenderTester` allows easy "mocking" of child workflows and workers. However, this means that we are not exercising the full infrastructure (even though we could get a fairly high confidence from the tests). Sometimes, it may be worth putting together integration tests that test a full tree of Workflows.
+
+Add another test to `RootWorkflowTests`. We will run the tree of workflows in a `WorkflowHost`, which is what the infrastructure uses for a `ContainerViewController`. This will be a "black box" test, as we can only test the behaviors from the rendering and will not be able to inspect the underlying states. This may be a useful test for validation when refactoring a tree of workflows to ensure they behave the same way.
+
+```swift
+// RootWorkflowTests.swift
+    func testAppFlow() {
+        let workflowHost = WorkflowHost(workflow: RootWorkflow())
+
+        // First rendering is just the welcome screen. Update the name.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(1, backStack.items.count)
+
+            guard let welcomeScreen = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected initial screen of `WelcomeScreen`")
+                return
+            }
+
+            welcomeScreen.onNameChanged("MyName")
+        }
+
+        // Log in and go to the welcome list
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(1, backStack.items.count)
+
+            guard let welcomeScreen = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected initial screen of `WelcomeScreen`")
+                return
+            }
+
+            welcomeScreen.onLoginTapped()
+        }
+
+        // Expect the todo list. Edit the first todo.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(2, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let todoScreen = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+            XCTAssertEqual(1, todoScreen.todoTitles.count)
+            // Select the first todo:
+            todoScreen.onTodoSelected(0)
+        }
+
+        // Selected a todo to edit. Expect the todo edit screen.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(3, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let _ = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+
+            guard let editScreen = backStack.items[2].screen.wrappedScreen as? TodoEditScreen else {
+                XCTFail("Expected second screen of `TodoEditScreen`")
+                return
+            }
+
+            // Update the title:
+            editScreen.onTitleChanged("New Title")
+        }
+
+        // Save the selected todo.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(3, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let _ = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+
+            guard let _ = backStack.items[2].screen.wrappedScreen as? TodoEditScreen else {
+                XCTFail("Expected second screen of `TodoEditScreen`")
+                return
+            }
+
+            // Save the changes by tapping the right bar button.
+            // This also validates that the navigation bar was described as expected.
+            switch backStack.items[2].barVisibility {
+
+            case .hidden:
+                XCTFail("Expected a visible navigation bar")
+
+            case .visible(let barContent):
+                switch barContent.rightItem {
+
+                case .none:
+                    XCTFail("Expected a right bar button")
+
+                case .button(let button):
+
+                    switch button.content {
+
+                    case .text(let text):
+                        XCTAssertEqual("Save", text)
+
+                    case .icon:
+                        XCTFail("Expected the right bar button to have a title of `Save`")
+                    }
+                    // Tap the right bar button to save.
+                    button.handler()
+                }
+            }
+        }
+
+        // Expect the todo list. Validate the title was updated.
+        do {
+            let backStack = workflowHost.rendering.value
+            XCTAssertEqual(2, backStack.items.count)
+
+            guard let _ = backStack.items[0].screen.wrappedScreen as? WelcomeScreen else {
+                XCTFail("Expected first screen of `WelcomeScreen`")
+                return
+            }
+
+            guard let todoScreen = backStack.items[1].screen.wrappedScreen as? TodoListScreen else {
+                XCTFail("Expected second screen of `TodoListScreen`")
+                return
+            }
+            XCTAssertEqual(1, todoScreen.todoTitles.count)
+            XCTAssertEqual("New Title", todoScreen.todoTitles[0])
+
+        }
+
+    }
+```
+
+This test was *very* verbose, and rather long. Generally, it's not recommended to do full integration tests like this (the action tests and render tests can give pretty solid coverage of a workflow's behavior). However, this is an example of how it might be done in the case that it's needed.
+
+# Conclusion
+
+This was intended as a guide of how testing can be facilitated with the `WorkflowTesting` library provided for workflows. As always, it is up to the judgement of the developer of what and how their software should be tested.


### PR DESCRIPTION
Relevant things to review are:
`*Tests.swift`
Tutorial5.md

The other additions are effectively a copy of the resulting code from Tutorial 4 (which would be the starting point for this tutorial).