### PR TITLE
Remove some extra key parameters that snuck through the first cleanup.

### DIFF
--- a/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
+++ b/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
@@ -27,9 +27,8 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Worker
-import com.squareup.workflow.workflowAction
-import com.squareup.workflow.runningWorker
 import com.squareup.workflow.transform
+import com.squareup.workflow.workflowAction
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.transform
 import kotlin.random.Random


### PR DESCRIPTION
Cleaned up some obsolete documentation in that file too.

Follow-up to #606 (6ed4208a02f9e6f3788b106375195df273d04e3d).

Closes #605 (again).