### PR TITLE
Fix benchmarks compilation errors, update gradle plugin version, and build in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,8 @@ matrix:
         - ./gradlew clean
         - ./gradlew build  --stacktrace
         - ./gradlew assembleAndroidTest --stacktrace
+        # Don't need to run the benchmarks but build them to ensure they don't get broken.
+        - ./gradlew jmhJar
 
       before_script:
         - android-wait-for-emulator

--- a/kotlin/.idea/misc.xml
+++ b/kotlin/.idea/misc.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
+    </configurations>
+  </component>
+  <component name="EntryPointsManager">
+    <list size="3">
+      <item index="0" class="java.lang.String" itemvalue="com.squareup.moshi.ToJson" />
+      <item index="1" class="java.lang.String" itemvalue="org.openjdk.jmh.annotations.Benchmark" />
+      <item index="2" class="java.lang.String" itemvalue="org.openjdk.jmh.annotations.BenchmarkMode" />
+    </list>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/build/classes" />
+  </component>
+  <component name="ProjectType">
+    <option name="id" value="Android" />
+  </component>
+</project>

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -82,7 +82,7 @@ buildscript {
       'dokkaAndroid': "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}",
       'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
       'jmh': [
-          'gradlePlugin': "me.champeau.gradle:jmh-gradle-plugin:0.4.8",
+          'gradlePlugin': "me.champeau.gradle:jmh-gradle-plugin:0.5.0-rc-2",
           'core': "org.openjdk.jmh:jmh-core:${versions.jmh}",
           'generator': "org.openjdk.jmh:jmh-generator-annprocess:${versions.jmh}",
       ],


### PR DESCRIPTION
The benchmarks won't actually run in CI, since CI is too unpredictable performance-wise
to generate consistent and meaningful data, and they are slow to run. But this should
prevent us from breaking them again in the future.

This also adds the `.idea/misc.xml` file to git, so we can persist the suppression of warnings about benchmarks not being used anywhere.