### PR TITLE
Change the return type of Worker.finished from T to Nothing.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -184,7 +184,7 @@ interface Worker<out OutputT> {
     /**
      * Returns a [Worker] that finishes immediately without emitting anything.
      */
-    fun <OutputT> finished(): Worker<OutputT> = FinishedWorker
+    fun finished(): Worker<Nothing> = FinishedWorker
 
     /**
      * Creates a [Worker] from a function that returns a single value.

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
@@ -231,7 +231,7 @@ class WorkerTest {
   }
 
   @Test fun `finished worker is equivalent to self`() {
-    assertTrue(Worker.finished<Unit>().doesSameWorkAs(Worker.finished<String>()))
+    assertTrue(Worker.finished().doesSameWorkAs(Worker.finished()))
   }
 
   @Test fun `transformed workers are equivalent with equivalent source`() {


### PR DESCRIPTION
This makes it easier to use when you don't actually care about the return type,
and serves as documentation that the worker never emits.