### PR TITLE
Embed the Droidcon NYC '19 video in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ this project becomes stable._
 While the API is not yet stable, this code is in heavy production use in Android and iOS
 apps with millions of users.
 
+<iframe title="vimeo-player" src="https://player.vimeo.com/video/362741019" width="640" height="360" frameborder="0" allowfullscreen></iframe>
+
 ## Using Workflows in your project
 
 ### Swift


### PR DESCRIPTION
It doesn't render correctly in github, but Mkdocs handles it fine.

![image](https://user-images.githubusercontent.com/101754/66233100-57477480-e69f-11e9-830e-b776e451be95.png)
