### PR TITLE
Add an RxWorker class so Workers can be implemented without using experimental Flow APIs.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -113,11 +113,10 @@ interface Worker<out OutputT> {
   /**
    * Returns a [Flow] to execute the work represented by this worker.
    *
-   * The [Flow] is invoked in the context of the workflow runtime. When this [Worker], its parent
+   * The [Flow] is collected in the context of the workflow runtime. When this [Worker], its parent
    * [Workflow], or any ancestor [Workflow]s are torn down, the coroutine in which this [Flow] is
    * being collected will be cancelled.
    */
-  @UseExperimental(ExperimentalCoroutinesApi::class)
   fun run(): Flow<OutputT>
 
   /**
@@ -156,7 +155,7 @@ interface Worker<out OutputT> {
      * Note: If your worker just needs to perform side effects and doesn't need to emit anything,
      * use [createSideEffect] instead (since `Nothing` can't be used as a reified type parameter).
      */
-    @UseExperimental(ExperimentalTypeInference::class, ExperimentalCoroutinesApi::class)
+    @UseExperimental(ExperimentalTypeInference::class)
     inline fun <reified OutputT> create(
       @BuilderInference noinline block: suspend FlowCollector<OutputT>.() -> Unit
     ): Worker<OutputT> = flow(block).asWorker()
@@ -176,7 +175,6 @@ interface Worker<out OutputT> {
      * }
      * ```
      */
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     fun createSideEffect(
       block: suspend () -> Unit
     ): Worker<Nothing> = TypedWorker(Nothing::class, flow { block() })
@@ -194,7 +192,7 @@ interface Worker<out OutputT> {
      * The returned [Worker] will equate to any other workers created with any of the [Worker]
      * builder functions that have the same output type.
      */
-    @UseExperimental(FlowPreview::class, ExperimentalCoroutinesApi::class)
+    @UseExperimental(FlowPreview::class)
     inline fun <reified OutputT> from(noinline block: suspend () -> OutputT): Worker<OutputT> =
       block.asFlow().asWorker()
 
@@ -205,7 +203,6 @@ interface Worker<out OutputT> {
      * The returned [Worker] will equate to any other workers created with any of the [Worker]
      * builder functions that have the same output type.
      */
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     inline fun <reified OutputT : Any> fromNullable(
         // This could be crossinline, but there's a coroutines bug that will cause the coroutine
         // to immediately resume on suspension inside block when it is crossinline.
@@ -231,7 +228,6 @@ interface Worker<out OutputT> {
 /**
  * Returns a [Worker] that will, when performed, emit whatever this [Flow] receives.
  */
-@UseExperimental(ExperimentalCoroutinesApi::class)
 inline fun <reified OutputT> Flow<OutputT>.asWorker(): Worker<OutputT> =
   TypedWorker(OutputT::class, this)
 

--- a/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorker.kt
+++ b/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorker.kt
@@ -1,0 +1,34 @@
+package com.squareup.workflow.rx2
+
+import com.squareup.workflow.Worker
+import com.squareup.workflow.Workflow
+import io.reactivex.Flowable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.reactive.asFlow
+
+/**
+ * An convenience implementation of [Worker] that is expressed in terms of Rx [Flowable] instead
+ * of [Flow].
+ *
+ * Subclassing this is equivalent to just implementing [Worker.run] directly and calling [asFlow]
+ * on your [Flowable], but doesn't require you to add
+ * `@UseExperimental(ExperimentalCoroutinesApi::class)` to your code.
+ */
+abstract class RxWorker<out OutputT : Any> : Worker<OutputT> {
+
+  /**
+   * Returns a [Flowable] to execute the work represented by this worker.
+   *
+   * If you have an [io.reactivex.Observable] instead, just call
+   * [toFlowable][io.reactivex.Observable.toFlowable] to convert it.
+   *
+   * The [Flowable] is subscribed to in the context of the workflow runtime. When this [Worker],
+   * its parent [Workflow], or any ancestor [Workflow]s are torn down, the subscription will be
+   * [disposed][io.reactivex.disposables.Disposable.dispose].
+   */
+  abstract fun runRx(): Flowable<out OutputT>
+
+  @UseExperimental(ExperimentalCoroutinesApi::class)
+  final override fun run(): Flow<OutputT> = runRx().asFlow()
+}

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkerTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/RxWorkerTest.kt
@@ -1,0 +1,41 @@
+package com.squareup.workflow.rx2
+
+import com.squareup.workflow.Worker
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.stateless
+import com.squareup.workflow.testing.testFromStart
+import io.reactivex.BackpressureStrategy.BUFFER
+import io.reactivex.Flowable
+import io.reactivex.subjects.PublishSubject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class RxWorkerTest {
+
+  @Test fun works() {
+    val subject = PublishSubject.create<String>()
+    val worker = object : RxWorker<String>() {
+      override fun runRx(): Flowable<out String> = subject.toFlowable(BUFFER)
+      override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker === this
+    }
+
+    fun action(value: String) = WorkflowAction<Nothing, String> { value }
+    val workflow = Workflow.stateless<Unit, String, Unit> {
+      runningWorker(worker) { action(it) }
+    }
+
+    workflow.testFromStart {
+      assertFalse(hasOutput)
+
+      subject.onNext("one")
+      assertEquals("one", awaitNextOutput())
+
+      subject.onNext("two")
+      subject.onNext("three")
+      assertEquals("two", awaitNextOutput())
+      assertEquals("three", awaitNextOutput())
+    }
+  }
+}


### PR DESCRIPTION
As I was upgrading us to 0.21.0 internally, realized that some code needing custom workers was calling `asFlow()`, which requires an experimental annotation. This is just to avoid that.