### PR TITLE
[DNM] Upgrade Dokka to 0.10.0.

### DIFF
--- a/kotlin/.buildscript/configure-dokka.gradle
+++ b/kotlin/.buildscript/configure-dokka.gradle
@@ -16,7 +16,8 @@
 
 /*
  * To generate and publish kdoc for a new module:
- *  - Apply either the 'org.jetbrains.dokka' or 'org.jetbrains.dokka-android' plugin.
+TODO now that there's only one plugin we can do this automatically in this script
+ *  - Apply the 'org.jetbrains.dokka' plugin.
  *  - Include this file with
  *      apply from: rootProject.file('.buildscript/configure-dokka.gradle')
  */
@@ -27,15 +28,18 @@ afterEvaluate { project ->
   project.tasks.dokka {
     outputDirectory = "$rootDir/../docs/kotlin/api"
     outputFormat = 'gfm'
-    reportUndocumented = false
-    skipDeprecated = true
-    jdkVersion = 8
-    packageOptions {
-      prefix = "com.squareup.workflow.internal"
-      suppress = true
-    }
-    if (project.file('Module.md').exists()) {
-      includes = ['Module.md']
+
+    configuration {
+      reportUndocumented = false
+      skipDeprecated = true
+      jdkVersion = 8
+      perPackageOption {
+        prefix = "com.squareup.workflow.internal"
+        suppress = true
+      }
+      if (project.file('Module.md').exists()) {
+        includes = ['Module.md']
+      }
     }
   }
 }

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -16,7 +16,7 @@
 buildscript {
   ext.versions = [
       'targetSdk': 29,
-      'dokka': '0.9.18',
+      'dokka': '0.10.0',
       'espresso': '3.1.0',
       'jmh': '1.21',
       'kotlin': '1.3.50',
@@ -83,7 +83,6 @@ buildscript {
               'mockito': "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
           ]
       ],
-      'dokkaAndroid': "org.jetbrains.dokka:dokka-android-gradle-plugin:${versions.dokka}",
       'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
       'jmh': [
           'gradlePlugin': "me.champeau.gradle:jmh-gradle-plugin:0.5.0-rc-2",
@@ -126,7 +125,6 @@ buildscript {
     classpath deps.android_gradle_plugin
     classpath deps.detekt
     classpath deps.dokka
-    classpath deps.dokkaAndroid
     classpath deps.jmh.gradlePlugin
     classpath deps.kotlin.gradlePlugin
     classpath deps.ktlint

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -15,7 +15,7 @@
  */
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'org.jetbrains.dokka-android'
+apply plugin: 'org.jetbrains.dokka'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Release notes [here](https://github.com/Kotlin/dokka/releases/tag/0.10.0).

Currently blocked by https://github.com/vanniktech/gradle-maven-publish-plugin/issues/69.

Closes #651.