### PR TITLE
Introduce an anonymous, lambda-based LifecycleWorker builder.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/LifecycleWorker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/LifecycleWorker.kt
@@ -25,6 +25,26 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  *
  * A [Worker] is stopped when its parent [Workflow] finishes a render pass without running the
  * worker, or when the parent workflow is itself torn down.
+ *
+ * This function is inline, and creates a unique (considered distinct by
+ * [doesSameWorkAs][LifecycleWorker.doesSameWorkAs]) worker at each _call site_.
+ */
+@Suppress("FunctionName")
+inline fun LifecycleWorker(
+  crossinline onStarted: () -> Unit = {},
+  crossinline onStopped: () -> Unit = {}
+): LifecycleWorker = object : LifecycleWorker() {
+  override fun onStarted() = onStarted.invoke()
+  override fun onStopped() = onStopped.invoke()
+}
+
+/**
+ * [Worker] that performs some action when the worker is started and/or stopped.
+ *
+ * A [Worker] is stopped when its parent [Workflow] finishes a render pass without running the
+ * worker, or when the parent workflow is itself torn down.
+ *
+ * By default, [doesSameWorkAs] treats all instances _of the same **concrete** type_ as equivalent.
  */
 abstract class LifecycleWorker : Worker<Nothing> {
 


### PR DESCRIPTION
I saw someone making a worker out of a `Completable` just to dispose a `CompositeDisposable` – this feels more kotlin-y than an explicit anonymous `LifecycleWorker` object, but maybe it's overkill?