### PR TITLE
Make RxWorker and Flowable.asWorker use Publisher instead of Flowable.

### DIFF
--- a/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/PublisherWorker.kt
+++ b/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/PublisherWorker.kt
@@ -6,16 +6,19 @@ import io.reactivex.Flowable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
+import org.reactivestreams.Publisher
 
 /**
- * An convenience implementation of [Worker] that is expressed in terms of Rx [Flowable] instead
- * of [Flow].
+ * An convenience implementation of [Worker] that is expressed in terms of Reactive Streams'
+ * [Publisher] instead of [Flow].
+ *
+ * If you're using RxJava, [Flowable] is a [Publisher].
  *
  * Subclassing this is equivalent to just implementing [Worker.run] directly and calling [asFlow]
- * on your [Flowable], but doesn't require you to add
+ * on your [Publisher], but doesn't require you to add
  * `@UseExperimental(ExperimentalCoroutinesApi::class)` to your code.
  */
-abstract class RxWorker<out OutputT : Any> : Worker<OutputT> {
+abstract class PublisherWorker<out OutputT : Any> : Worker<OutputT> {
 
   /**
    * Returns a [Flowable] to execute the work represented by this worker.
@@ -27,8 +30,8 @@ abstract class RxWorker<out OutputT : Any> : Worker<OutputT> {
    * its parent [Workflow], or any ancestor [Workflow]s are torn down, the subscription will be
    * [disposed][io.reactivex.disposables.Disposable.dispose].
    */
-  abstract fun runRx(): Flowable<out OutputT>
+  abstract fun runPublisher(): Publisher<out OutputT>
 
   @UseExperimental(ExperimentalCoroutinesApi::class)
-  final override fun run(): Flow<OutputT> = runRx().asFlow()
+  final override fun run(): Flow<OutputT> = runPublisher().asFlow()
 }

--- a/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorkers.kt
+++ b/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorkers.kt
@@ -26,6 +26,7 @@ import io.reactivex.Single
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.rx2.await
+import org.reactivestreams.Publisher
 
 /**
  * Creates a [Worker] from this [Observable].
@@ -41,9 +42,9 @@ inline fun <reified T : Any> Observable<out T?>.asWorker(): Worker<T> =
   this.toFlowable(BUFFER).asWorker()
 
 /**
- * Creates a [Worker] from this [Flowable].
+ * Creates a [Worker] from this [Publisher] ([Flowable] is a [Publisher]).
  *
- * The [Flowable] will be subscribed to when the [Worker] is started, and cancelled when it is
+ * The [Publisher] will be subscribed to when the [Worker] is started, and cancelled when it is
  * cancelled.
  *
  * RxJava doesn't allow nulls, but it can't express that in its types. The receiver type parameter
@@ -51,11 +52,11 @@ inline fun <reified T : Any> Observable<out T?>.asWorker(): Worker<T> =
  * platform nullability.
  */
 @UseExperimental(ExperimentalCoroutinesApi::class)
-inline fun <reified T : Any> Flowable<out T?>.asWorker(): Worker<T> =
+inline fun <reified T : Any> Publisher<out T?>.asWorker(): Worker<T> =
 // This cast works because RxJava types don't actually allow nulls, it's just that they can't
   // express that in their types because Java.
   @Suppress("UNCHECKED_CAST")
-  (this as Flowable<T>).asFlow().asWorker()
+  (this as Publisher<T>).asFlow().asWorker()
 
 /**
  * Creates a [Worker] from this [Maybe].

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
@@ -6,18 +6,18 @@ import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.stateless
 import com.squareup.workflow.testing.testFromStart
 import io.reactivex.BackpressureStrategy.BUFFER
-import io.reactivex.Flowable
 import io.reactivex.subjects.PublishSubject
+import org.reactivestreams.Publisher
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-class RxWorkerTest {
+class PublisherWorkerTest {
 
   @Test fun works() {
     val subject = PublishSubject.create<String>()
-    val worker = object : RxWorker<String>() {
-      override fun runRx(): Flowable<out String> = subject.toFlowable(BUFFER)
+    val worker = object : PublisherWorker<String>() {
+      override fun runPublisher(): Publisher<out String> = subject.toFlowable(BUFFER)
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker === this
     }
 


### PR DESCRIPTION
`Publisher` is the non-rx-specific interface from the `reactive-streams` library
that `Flowable` implements, and that all the `Flow` extensions for `Flowable`
are actually defined on.