### PR TITLE
Update tutorials for Swift 5/ReactiveSwift 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -182,3 +182,18 @@ matrix:
         - swift build --verbose
       script:
         - swift test
+
+    - language: swift
+      name: "Swift - Tutorial - Cocoapods (Xcode 10.2)"
+      os: osx
+      osx_image: xcode10.2
+      xcode_workspace: Tutorial.xcworkspace
+      xcode_scheme: Tutorial
+      xcode_destination: platform=iOS Simulator,OS=12.2,name=iPad Pro (9.7-inch)
+      before_install:
+        - gem update --system
+        - gem install bundler
+        - bundle install
+        - cd swift/Samples/Tutorial
+        - bundle exec pod repo update
+        - bundle exec pod install

--- a/swift/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial1Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -16,7 +16,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -83,7 +82,7 @@ extension WelcomeWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -91,7 +90,7 @@ extension RootWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -16,7 +16,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -73,7 +72,7 @@ extension TodoListWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -16,7 +16,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -85,7 +84,7 @@ extension WelcomeWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -91,7 +90,7 @@ extension RootWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -108,7 +107,7 @@ extension TodoEditWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -117,7 +116,7 @@ extension TodoListWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -16,7 +16,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -85,7 +84,7 @@ extension WelcomeWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -91,7 +90,7 @@ extension RootWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -108,7 +107,7 @@ extension TodoEditWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -98,7 +97,7 @@ extension TodoListWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -133,7 +132,7 @@ extension TodoWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -16,7 +16,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -85,7 +84,7 @@ extension WelcomeWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -91,7 +90,7 @@ extension RootWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -108,7 +107,7 @@ extension TodoEditWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -98,7 +97,7 @@ extension TodoListWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
@@ -17,7 +17,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -133,7 +132,7 @@ extension TodoWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Welcome/WelcomeWorkflow.swift
@@ -16,7 +16,6 @@
 import Workflow
 import WorkflowUI
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output
@@ -90,7 +89,7 @@ extension WelcomeWorkflow {
 
         }
 
-        func run() -> SignalProducer<Output, NoError> {
+        func run() -> SignalProducer<Output, Never> {
             fatalError()
         }
 

--- a/swift/Samples/Tutorial/Tutorial3.md
+++ b/swift/Samples/Tutorial/Tutorial3.md
@@ -359,7 +359,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output

--- a/swift/Samples/Tutorial/Tutorial4.md
+++ b/swift/Samples/Tutorial/Tutorial4.md
@@ -29,7 +29,6 @@ import Workflow
 import WorkflowUI
 import BackStackContainer
 import ReactiveSwift
-import Result
 
 
 // MARK: Input and Output


### PR DESCRIPTION
Fixes #655 

* Remove all the `import Result`s from the tutorials and tutorial code
* Use `Never` instead of `NoError`