### PR TITLE
Adds getRendering, getShowRendering.

### DIFF
--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/BuilderBinding.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/BuilderBinding.kt
@@ -21,7 +21,7 @@ import android.view.ViewGroup
 import kotlin.reflect.KClass
 
 /**
- * A [ViewBinding] that allows [ViewRegistry.buildView] to dispense [View]s that need
+ * A [ViewBinding] that allows a [ViewRegistry] to create [View]s that need
  * to be generated from code. (Use [LayoutRunner] to work with XML layout resources.)
  *
  * Typical usage is to have a custom builder or view's `companion object` implement
@@ -52,7 +52,11 @@ import kotlin.reflect.KClass
  *    )
  *
  * Note in particular the [ViewRegistry] argument to the [viewConstructor] lambda. This allows
- * nested renderings to be displayed via nested calls to [ViewRegistry.buildView].
+ * nested renderings to be displayed.
+ *
+ * It's simplest, and most typical, to pass the [ViewRegistry] to [WorkflowViewStub.update] to
+ * show nested renderings. When that's too constraining, more complex containers can
+ * call [ViewRegistry.buildView], [View.canShowRendering] and [View.showRendering] directly.
  */
 class BuilderBinding<RenderingT : Any>(
   override val type: KClass<RenderingT>,

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/LayoutRunner.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/LayoutRunner.kt
@@ -24,10 +24,10 @@ import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import kotlin.reflect.KClass
 
 /**
- * An object that handles [View.showRendering] calls for a view inflated
- * from a layout resource in response to [ViewRegistry.buildView].
- * (Use [BuilderBinding] if you want to build views from code rather than
- * layouts.)
+ * A delegate that implements a [showRendering] method to be called when a workflow rendering
+ * of type [RenderingT] is ready to be displayed in a view inflated from a layout resource
+ * by a [ViewRegistry]. (Use [BuilderBinding] if you want to build views from code rather
+ * than layouts.)
  *
  * Typical usage is to have a [LayoutRunner]'s `companion object` implement
  * [ViewBinding] by delegating to [LayoutRunner.bind], specifying the layout resource
@@ -53,10 +53,13 @@ import kotlin.reflect.KClass
  *        NewGameLayoutRunner, GamePlayLayoutRunner, GameOverLayoutRunner
  *    )
  *
- * Also note that two flavors of [contructor][LayoutRunner.Binding.runnerConstructor]
- * are accepted by [bind]. Every [LayoutRunner] constructor must accept an [View].
- * Optionally, they can also have a second [ViewRegistry] argument, to allow
- * nested renderings to be displayed via nested calls to [ViewRegistry.buildView].
+ * Every [LayoutRunner] must have a constructor that accepts a [View] as its first argument.
+ * The constructor may also have a second [ViewRegistry] argument, to allow
+ * nested renderings to be displayed in nested views.
+ *
+ * It's simplest, and most typical, to pass the [ViewRegistry] to [WorkflowViewStub.update] to
+ * show nested renderings. When that's too constraining, more complex containers can
+ * call [ViewRegistry.buildView], [View.canShowRendering] and [View.showRendering] directly.
  */
 interface LayoutRunner<RenderingT : Any> {
   fun showRendering(rendering: RenderingT)

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
@@ -25,7 +25,7 @@ import android.os.Parcelable.Creator
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import androidx.annotation.IdRes
 import androidx.annotation.StyleRes
@@ -52,12 +52,7 @@ abstract class ModalContainer<ModalRenderingT : Any>
   attributeSet: AttributeSet? = null
 ) : FrameLayout(context, attributeSet) {
   private val baseView: WorkflowViewStub = WorkflowViewStub(context).also {
-    it.layoutParams = (ViewGroup.LayoutParams(
-        ViewGroup.LayoutParams.MATCH_PARENT,
-        ViewGroup.LayoutParams.MATCH_PARENT
-    ))
-
-    addView(it)
+    addView(it, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
   }
 
   private var dialogs: List<DialogRef<ModalRenderingT>> = emptyList()

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
@@ -64,8 +64,11 @@ class WorkflowViewStub(
    * If the current replacement can't handle [rendering], a new view is put in place.
    *
    * @return the view that showed [rendering]
-   * @throws RuntimeException if [rendering] cannot be displayed, typically indicating
-   * a misconfigured [registry]
+   *
+   * @throws IllegalArgumentException if no binding can be find for the type of [rendering]
+   *
+   * @throws IllegalStateException if the matching [ViewBinding] fails to call
+   * [View.bindShowRendering] when constructing the view
    */
   fun update(
     rendering: Any,

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
@@ -23,7 +23,7 @@ import android.view.View
 import android.view.View.BaseSavedState
 import com.squareup.workflow.ui.Named
 import com.squareup.workflow.ui.backstack.ViewStateCache.SavedState
-import com.squareup.workflow.ui.showRenderingTag
+import com.squareup.workflow.ui.getRendering
 
 /**
  * Handles persistence chores for container views that manage a set of [Named] renderings,
@@ -174,6 +174,10 @@ class ViewStateCache private constructor(
 }
 
 private val View.namedKey: String
-  get() = checkNotNull((showRenderingTag?.initialRendering as? Named<*>)?.compatibilityKey) {
-    "Expected $this to be showing a Named rendering, found ${showRenderingTag?.initialRendering}"
+  get() {
+    val rendering = getRendering<Named<*>>()
+    return checkNotNull(rendering?.compatibilityKey) {
+      "Expected $this to be showing a ${Named::class.java.simpleName}<*> rendering, " +
+          "found $rendering"
+    }
   }


### PR DESCRIPTION
The rendering in a view's `ViewShowRendering` tag is now updated on each call
to `View.showRendering`. Access to that value and the `showRendering` function
itself is improved with new `View.getRendering` and `View.getShowRendering`
methods. With their introduction, we're able to make `View.showRenderingTag`
private.

Also updates `WorkflowLayout` to use `WorkflowStubView`. It's pretty thrilling
that this didn't break the view persistence code. Wasn't able to pull off the
same trick for BackStackContainer or ModalContainer, so the more fundamental
`ViewRegistry` and `ViewShowRendering.kt` methods are staying public. Punched
up their documentation. (Had to go with `fun` rather than `val` on the new
code due to all the param types.)

Another point for discussion: thought about changing `GameLayoutRunner` to
take advantage of the new methods instead of storing its own reference to the
latest rendering, but backed off because it just seemed sketchy, too magical
to encourage as a general practice.

So given that, why open up the API at all? We need access to both of  these
things when implementing the various containers, and expect that other
container authors will too.

Well, except for the change to keep the View's reference to the rendering  up
to date. So far we've been just fine having access to nothing but the original
rendering, but letting it stay stale like that just seems like a landmine.
