### PR TITLE
Make onEvent, makeActionSink, and makeEventSink include what action was lost to when they receive more than one event.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -167,7 +167,7 @@ fun <EventT, StateT, OutputT : Any> RenderContext<StateT, OutputT>.makeEventSink
   val actionSink = makeActionSink<WorkflowAction<StateT, OutputT>>()
 
   return actionSink.contraMap { event ->
-    WorkflowAction({ "eventSink" }) { block.invoke(this, event) }
+    WorkflowAction({ "eventSink" }) { block(event) }
   }
 }
 

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
@@ -164,7 +164,7 @@ class WorkflowNodeTest {
     assertEquals("tick:event", result)
   }
 
-  @Test fun `throws on subsequent events on same rendering`() {
+  @Test fun `onEvent throws on subsequent events on same rendering`() {
     lateinit var sink: Sink<String>
     val workflow = object : StringWorkflow() {
       override fun initialState(
@@ -193,7 +193,6 @@ class WorkflowNodeTest {
       sink.send("event2")
     }
     assertTrue(e.message!!.startsWith("Expected to successfully deliver "))
-    assertTrue(e.message!!.endsWith("Are you using an old rendering?"))
   }
 
   @Test fun `worker gets value`() {


### PR DESCRIPTION
Fixes #539.