### PR TITLE
Adds dynamically configured master / detail behavior to To Do sample

### DIFF
--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -161,8 +161,7 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
                 state.errorMessage,
                 onLogin = { email, password -> sink.send(SubmitLogin(email, password)) },
                 onCancel = { sink.send(CancelLogin) }
-            ),
-            onGoBack = { sink.send(CancelLogin) }
+            )
         )
       }
 

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
@@ -56,6 +56,7 @@ class MainActivity : AppCompatActivity() {
   override fun onRetainCustomNonConfigurationInstance(): Any = rootWorkflow
 
   private companion object {
-    val viewRegistry = ViewRegistry(TodoEditorLayoutRunner) + TodoListsLayoutRunner
+    val viewRegistry =
+      ViewRegistry(TodoEditorLayoutRunner, TodoListsLayoutRunner, MasterDetailContainer)
   }
 }

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MasterDetailContainer.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MasterDetailContainer.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.mainactivity
+
+import android.view.View
+import com.squareup.sample.todo.MasterDetailAware.Companion.makeAware
+import com.squareup.sample.todo.MasterDetailConfig.Detail
+import com.squareup.sample.todo.MasterDetailConfig.Master
+import com.squareup.sample.todo.MasterDetailConfig.Only
+import com.squareup.sample.todo.MasterDetailScreen
+import com.squareup.sample.todo.R
+import com.squareup.workflow.ui.BackStackScreen
+import com.squareup.workflow.ui.LayoutRunner
+import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewRegistry
+import com.squareup.workflow.ui.WorkflowViewStub
+
+/**
+ * Displays [MasterDetailScreen] renderings in either split pane or single pane
+ * treatment, depending on the setup of the given [View]. The view must provide
+ * either a single [WorkflowViewStub] with id [R.id.master_detail_single_stub],
+ * or else two with ids [R.id.master_stub] and [R.id.detail_stub].
+ *
+ * For single pane layouts, [MasterDetailScreen] is repackaged as a [BackStackScreen]
+ * with [MasterDetailScreen.masterRendering] as the base of the stack.
+ */
+class MasterDetailContainer(
+  view: View,
+  private val registry: ViewRegistry
+) : LayoutRunner<MasterDetailScreen> {
+
+  private val masterStub: WorkflowViewStub? = view.findViewById(R.id.master_stub)
+  private val detailStub: WorkflowViewStub? = view.findViewById(R.id.detail_stub)
+  private val singleStub: WorkflowViewStub? = view.findViewById(R.id.master_detail_single_stub)
+
+  init {
+    check((singleStub == null) xor (masterStub == null && detailStub == null)) {
+      "Layout must define only R.id.master_detail_single_stub, " +
+          "or else both R.id.master_stub and R.id.detail_stub"
+    }
+  }
+
+  override fun showRendering(rendering: MasterDetailScreen) {
+    if (singleStub == null) renderSplitView(rendering)
+    else renderSingleView(rendering, singleStub)
+  }
+
+  private fun renderSplitView(rendering: MasterDetailScreen) {
+    if (rendering.detailRendering == null && rendering.selectDefault != null) {
+      rendering.selectDefault!!.invoke()
+    } else {
+      val aware = rendering.copy(
+          masterRendering = makeAware(rendering.masterRendering, Master),
+          detailRendering = makeAware(rendering.detailRendering, Detail)
+      )
+
+      masterStub!!.update(aware.masterRendering, registry)
+      aware.detailRendering?.let { detailStub!!.update(it, registry) }
+    }
+  }
+
+  private fun renderSingleView(
+    rendering: MasterDetailScreen,
+    stub: WorkflowViewStub
+  ) {
+    val asBackStack: BackStackScreen<Any> = rendering.detailRendering
+        ?.let { BackStackScreen(stack = listOf(rendering.masterRendering, makeAware(it, Only))) }
+        ?: run { BackStackScreen(only = makeAware(rendering.masterRendering, Only)) }
+
+    stub.update(asBackStack, registry)
+  }
+
+  companion object : ViewBinding<MasterDetailScreen> by LayoutRunner.Binding(
+      type = MasterDetailScreen::class,
+      layoutId = R.layout.master_detail,
+      runnerConstructor = ::MasterDetailContainer
+  )
+}

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoEditorLayoutRunner.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoEditorLayoutRunner.kt
@@ -24,6 +24,7 @@ import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
 import com.squareup.workflow.ui.backPressedHandler
+import com.squareup.workflow.ui.isInBackStack
 
 internal class TodoEditorLayoutRunner(private val view: View) : LayoutRunner<TodoRendering> {
 
@@ -49,8 +50,12 @@ internal class TodoEditorLayoutRunner(private val view: View) : LayoutRunner<Tod
     titleText.text.replace(0, titleText.text.length, rendering.list.title)
     itemContainer.setRows(rendering.list.rows.map { Pair(it.done, it.text) })
 
-    toolbar.setNavigationOnClickListener { rendering.onGoBackClicked() }
-    view.backPressedHandler = { rendering.onGoBackClicked() }
+    if (rendering.isInBackStack) {
+      toolbar.setNavigationOnClickListener { rendering.onGoBackClicked() }
+      view.backPressedHandler = { rendering.onGoBackClicked() }
+    } else {
+      toolbar.navigationIcon = null
+    }
 
     titleText.setTextChangedListener { rendering.onTitleChanged(it) }
 

--- a/kotlin/samples/todo-android/app/src/main/res/color/list_selector.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/color/list_selector.xml
@@ -14,14 +14,8 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<vector
-    android:height="36dp"
-    android:width="36dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0"
-    android:tint="#FF0000"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
-</vector>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:state_activated="true" android:color="@color/colorAccent"/>
+  <item android:state_pressed="true" android:color="@color/colorPressed"/>
+  <item android:color="@android:color/background_light"/>
+</selector>

--- a/kotlin/samples/todo-android/app/src/main/res/layout-ldrtl/master_detail_split.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/layout-ldrtl/master_detail_split.xml
@@ -14,19 +14,30 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@android:color/white"
+    android:orientation="horizontal"
     >
 
-    <LinearLayout
-        android:id="@+id/todo_lists_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        />
+  <com.squareup.workflow.ui.WorkflowViewStub
+      android:id="@+id/detail_stub"
+      android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="70"
+      />
 
-</ScrollView>
+  <View
+      android:layout_width="1dp"
+      android:layout_height="match_parent"
+      android:background="@color/colorAccent"
+      />
+
+  <com.squareup.workflow.ui.WorkflowViewStub
+      android:id="@+id/master_stub"
+      android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="30"
+      />
+
+</LinearLayout>

--- a/kotlin/samples/todo-android/app/src/main/res/layout/master_detail_single.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/layout/master_detail_single.xml
@@ -14,14 +14,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<vector
-    android:height="36dp"
-    android:width="36dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0"
-    android:tint="#FF0000"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
-</vector>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent">
+
+  <com.squareup.workflow.ui.WorkflowViewStub
+      android:id="@+id/master_detail_single_stub"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"/>
+
+</FrameLayout>

--- a/kotlin/samples/todo-android/app/src/main/res/layout/master_detail_split.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/layout/master_detail_split.xml
@@ -14,19 +14,30 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@android:color/white"
+    android:orientation="horizontal"
     >
 
-    <LinearLayout
-        android:id="@+id/todo_lists_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        />
+  <com.squareup.workflow.ui.WorkflowViewStub
+      android:id="@+id/master_stub"
+      android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="30"
+      />
 
-</ScrollView>
+  <View
+      android:layout_width="1dp"
+      android:layout_height="match_parent"
+      android:background="@color/colorAccent"
+      />
+
+  <com.squareup.workflow.ui.WorkflowViewStub
+      android:id="@+id/detail_stub"
+      android:layout_width="0dp"
+      android:layout_height="match_parent"
+      android:layout_weight="70"
+      />
+
+</LinearLayout>

--- a/kotlin/samples/todo-android/app/src/main/res/layout/todo_lists_selectable_row_layout.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/layout/todo_lists_selectable_row_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2019 Square Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +13,15 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<TextView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     style="@android:style/Widget.Material.ListView"
+    android:background="@color/list_selector"
     android:layout_width="match_parent"
     android:layout_height="?attr/listPreferredItemHeightSmall"
     android:gravity="center_vertical"
     android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
     tools:text="Groceries"
     />

--- a/kotlin/samples/todo-android/app/src/main/res/layout/todo_lists_unselectable_row_layout.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/layout/todo_lists_unselectable_row_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2019 Square Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,14 +13,15 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<vector
-    android:height="36dp"
-    android:width="36dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0"
-    android:tint="#FF0000"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
-</vector>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@android:style/Widget.Material.ListView"
+    android:background="?attr/listChoiceBackgroundIndicator"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/listPreferredItemHeightSmall"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    tools:text="Groceries"
+    />

--- a/kotlin/samples/todo-android/app/src/main/res/values-land/layout.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/values-land/layout.xml
@@ -14,14 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<vector
-    android:height="36dp"
-    android:width="36dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0"
-    android:tint="#FF0000"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
-</vector>
+<resources>
+  <item name="master_detail" type="layout">@layout/master_detail_split</item>
+</resources>

--- a/kotlin/samples/todo-android/app/src/main/res/values-sw600dp/layout.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/values-sw600dp/layout.xml
@@ -14,14 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<vector
-    android:height="36dp"
-    android:width="36dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0"
-    android:tint="#FF0000"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
-</vector>
+<resources>
+  <item name="master_detail" type="layout">@layout/master_detail_split</item>
+</resources>

--- a/kotlin/samples/todo-android/app/src/main/res/values/colors.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/values/colors.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 <resources>
+    <color name="colorAccent">#FF4081</color>
+    <color name="colorPressed">#FCE4EC</color>
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>
-    <color name="colorAccent">#FF4081</color>
 </resources>

--- a/kotlin/samples/todo-android/app/src/main/res/values/layout.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/values/layout.xml
@@ -14,14 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<vector
-    android:height="36dp"
-    android:width="36dp"
-    android:viewportHeight="24.0"
-    android:viewportWidth="24.0"
-    android:tint="#FF0000"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-  <path
-      android:fillColor="#FF000000"
-      android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
-</vector>
+<resources>
+  <item name="master_detail" type="layout">@layout/master_detail_single</item>
+</resources>

--- a/kotlin/samples/todo-android/app/src/main/res/values/strings.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Copyright 2019 Square Inc.
   ~

--- a/kotlin/samples/todo-android/app/src/main/res/values/styles.xml
+++ b/kotlin/samples/todo-android/app/src/main/res/values/styles.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Copyright 2019 Square Inc.
   ~

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/MasterDetailAware.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/MasterDetailAware.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.todo
+
+/**
+ * Informs [MasterDetailAware] renderings whether they're children of a [MasterDetailScreen],
+ * and if so in what configuration.
+ */
+enum class MasterDetailConfig {
+  /**
+   * Rendering is in [MasterDetailScreen.masterRendering], running in split screen
+   * configuration.
+   */
+  Master,
+
+  /**
+   * Rendering is in [MasterDetailScreen.detailRendering], running in split screen
+   * configuration.
+   */
+  Detail,
+
+  /**
+   * Rendering is the only visible child in a [MasterDetailScreen] running in
+   * single screen configuration.
+   */
+  Only
+}
+
+/**
+ * Implemented by rendering types to allow them to customize appearance / behavior
+ * based on a [MasterDetailScreen] parent's [configuration][MasterDetailConfig].
+ */
+interface MasterDetailAware<T : MasterDetailAware<T>> {
+  /**
+   * The configuration of a possible [MasterDetailScreen] parent rendering. Should default to null,
+   * and be set only via [withMasterDetailConfig].
+   */
+  val masterDetailConfig: MasterDetailConfig?
+
+  /**
+   * Creates a copy of the receiver with [masterDetailConfig] set to the given [config].
+   * A container view that displays a [MasterDetailScreen] should use this method to
+   * transform each visible child before rendering it.
+   */
+  fun withMasterDetailConfig(config: MasterDetailConfig): T
+
+  companion object {
+    /**
+     * Convenience allowing [MasterDetailScreen] containers to call
+     * [withMasterDetailConfig] on conforming children before displaying them.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T> makeAware(
+      maybeAware: T,
+      config: MasterDetailConfig
+    ): T = when (maybeAware) {
+      is MasterDetailAware<*> -> maybeAware.withMasterDetailConfig(config) as T
+      else -> maybeAware
+    }
+  }
+}

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/MasterDetailScreen.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/MasterDetailScreen.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.todo
+
+/**
+ * Rendering type for master / detail containers. Containers may choose to display
+ * both children side by side, or repackage them in a [com.squareup.workflow.ui.BackStackScreen]
+ * in a single pane.
+ *
+ * @param masterRendering typically a selection list
+ *
+ * @param detailRendering typically the details of an item selected in the [masterRendering],
+ * or null if none has been selected. Common for this to be a
+ * [com.squareup.workflow.ui.BackStackScreen].
+ *
+ * @param selectDefault optional function that requests a selection be made to fill a
+ * null [detailRendering]. Split view containers may call this immediately to ensure
+ * that a detail rendering is always visible.
+ */
+data class MasterDetailScreen(
+  val masterRendering: Any,
+  val detailRendering: Any? = null,
+  val selectDefault: (() -> Unit)? = null
+)

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -27,6 +27,8 @@ import com.squareup.workflow.Sink
 import com.squareup.workflow.StatelessWorkflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowAction.Mutator
+import com.squareup.workflow.ui.BackStackAware
+import com.squareup.workflow.ui.BackStackConfig
 
 data class TodoList(
   val title: String,
@@ -77,14 +79,19 @@ sealed class TodoAction : WorkflowAction<Nothing, TodoEditorOutput> {
   }
 }
 
-class TodoRendering(
+data class TodoRendering(
   val list: TodoList,
+  override val backStackConfig: BackStackConfig? = null,
   val onTitleChanged: (title: String) -> Unit,
   val onDoneClicked: (index: Int) -> Unit,
   val onTextChanged: (index: Int, text: String) -> Unit,
   val onDeleteClicked: (index: Int) -> Unit,
   val onGoBackClicked: () -> Unit
-)
+) : BackStackAware<TodoRendering> {
+  override fun withBackStackConfig(config: BackStackConfig): TodoRendering {
+    return copy(backStackConfig = config)
+  }
+}
 
 sealed class TodoEditorOutput {
   data class ListUpdated(val newList: TodoList) : TodoEditorOutput()

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsScreen.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsScreen.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.todo
+
+/**
+ * Rendering of the list of [TodoList]s.
+ *
+ * Note that these renderings are created by [TodoListsWorkflow], which is unaware of the
+ * [selection], always leaving that field set to the default `-1` value.
+ *
+ * The entire concept of selection is owned by the parent [TodoListsAppWorkflow],
+ * which adds that info to a copy of the child workflow's rendering as it assembles
+ * its own composite [MasterDetailScreen] rendering.
+ */
+data class TodoListsScreen(
+  val lists: List<TodoList>,
+  val onRowClicked: (Int) -> Unit,
+  val selection: Int = -1,
+  override val masterDetailConfig: MasterDetailConfig? = null
+) : MasterDetailAware<TodoListsScreen> {
+  override fun withMasterDetailConfig(config: MasterDetailConfig): TodoListsScreen {
+    return copy(masterDetailConfig = config)
+  }
+}

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
@@ -20,19 +20,14 @@ import com.squareup.workflow.Sink
 import com.squareup.workflow.StatelessWorkflow
 import com.squareup.workflow.makeEventSink
 
-data class TodoListsRendering(
-  val lists: List<TodoList>,
-  val onRowClicked: (Int) -> Unit
-)
-
-class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsRendering>() {
+class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsScreen>() {
   override fun render(
     props: List<TodoList>,
     context: RenderContext<Nothing, Int>
-  ): TodoListsRendering {
+  ): TodoListsScreen {
     // A sink that emits the given index as the result of this workflow.
     val sink: Sink<Int> = context.makeEventSink { index: Int -> index }
 
-    return TodoListsRendering(lists = props, onRowClicked = sink::send)
+    return TodoListsScreen(lists = props, onRowClicked = sink::send)
   }
 }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/AlertContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/AlertContainer.kt
@@ -33,12 +33,13 @@ import com.squareup.workflow.ui.AlertScreen.Event.Canceled
 /**
  * Class returned by [ModalContainer.forAlertContainerScreen], qv for details.
  */
-internal class AlertContainer
-@JvmOverloads constructor(
+internal class AlertContainer @JvmOverloads constructor(
   context: Context,
   attributeSet: AttributeSet? = null,
+  defStyle: Int = 0,
+  defStyleRes: Int = 0,
   @StyleRes private val dialogThemeResId: Int = 0
-) : ModalContainer<AlertScreen>(context, attributeSet) {
+) : ModalContainer<AlertScreen>(context, attributeSet, defStyle, defStyleRes) {
 
   override fun buildDialog(
     initialModalRendering: AlertScreen,

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
@@ -46,11 +46,13 @@ import com.squareup.workflow.ui.ModalContainer.Companion.forContainerScreen
  *
  * @param ModalRenderingT the type of the nested renderings to be shown in a dialog window.
  */
-abstract class ModalContainer<ModalRenderingT : Any>
-@JvmOverloads constructor(
+abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
   context: Context,
-  attributeSet: AttributeSet? = null
-) : FrameLayout(context, attributeSet) {
+  attributeSet: AttributeSet? = null,
+  defStyle: Int = 0,
+  defStyleRes: Int = 0
+) : FrameLayout(context, attributeSet, defStyle, defStyleRes) {
+
   private val baseView: WorkflowViewStub = WorkflowViewStub(context).also {
     addView(it, ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
   }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalViewContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalViewContainer.kt
@@ -32,13 +32,14 @@ import kotlin.reflect.KClass
  * Class returned by [ModalContainer.forContainerScreen], qv for details.
  */
 @PublishedApi
-internal class ModalViewContainer
-@JvmOverloads constructor(
+internal class ModalViewContainer @JvmOverloads constructor(
   context: Context,
   attributeSet: AttributeSet? = null,
+  defStyle: Int = 0,
+  defStyleRes: Int = 0,
   @StyleRes private val dialogThemeResId: Int = 0,
   private val modalDecorator: (View) -> View = { it }
-) : ModalContainer<Any>(context, attributeSet) {
+) : ModalContainer<Any>(context, attributeSet, defStyle, defStyleRes) {
   override fun buildDialog(
     initialModalRendering: Any,
     viewRegistry: ViewRegistry

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
@@ -39,10 +39,12 @@ import android.view.ViewGroup
  *     }
  * ```
  */
-class WorkflowViewStub(
+class WorkflowViewStub @JvmOverloads constructor(
   context: Context,
-  attributeSet: AttributeSet? = null
-) : View(context, attributeSet) {
+  attributeSet: AttributeSet? = null,
+  defStyle: Int = 0,
+  defStyleRes: Int = 0
+) : View(context, attributeSet, defStyle, defStyleRes) {
   init {
     setWillNotDraw(true)
   }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/ViewStateCache.kt
@@ -72,7 +72,7 @@ class ViewStateCache private constructor(
     retainedRenderings: Collection<Named<*>>,
     oldViewMaybe: View?,
     newView: View
-  ): Boolean {
+  ) {
     val newKey = newView.namedKey
     val hiddenKeys = retainedRenderings.asSequence()
         .map { it.compatibilityKey }
@@ -83,12 +83,8 @@ class ViewStateCache private constructor(
           }
         }
 
-    val restored = viewStates.remove(newKey)
-        ?.let {
-          newView.restoreHierarchyState(it.viewState)
-          true
-        }
-        ?: false
+    viewStates.remove(newKey)
+        ?.let { newView.restoreHierarchyState(it.viewState) }
 
     if (oldViewMaybe != null) {
       oldViewMaybe.namedKey.takeIf { hiddenKeys.contains(it) }
@@ -99,8 +95,6 @@ class ViewStateCache private constructor(
     }
 
     pruneKeys(hiddenKeys)
-
-    return restored
   }
 
   /**

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackAware.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackAware.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui
+
+import com.squareup.workflow.ui.BackStackConfig.First
+import com.squareup.workflow.ui.BackStackConfig.Other
+
+/**
+ * Informs [BackStackAware] renderings whether they're children of a [BackStackScreen],
+ * and if so whether they're the [first frame][First] or [not][Other].
+ */
+enum class BackStackConfig {
+  /**
+   * This rendering is first frame in a [BackStackScreen]. Useful as a hint to disable
+   * "go back" behavior.
+   */
+  First,
+
+  /**
+   * This rendering in a [BackStackScreen] and is not the first rendering. Useful as
+   * a hint to enable "go back" behavior.
+   */
+  Other
+}
+
+/**
+ * Implemented by rendering types to allow them to customize appearance / behavior
+ * based on their presence in a [BackStackScreen] parent.
+ */
+interface BackStackAware<T : BackStackAware<T>> {
+  /**
+   * The configuration of a possible [BackStackScreen] parent rendering. Should default to null,
+   * and be set only via [withBackStackConfig].
+   */
+  val backStackConfig: BackStackConfig?
+
+  /**
+   * Creates a copy of the receiver with [backStackConfig] set to the [config].
+   * A container view that displays a [BackStackScreen] should use this method
+   * to transform each visible member of a [BackStackScreen.stack] before rendering it.
+   */
+  fun withBackStackConfig(config: BackStackConfig): T
+
+  companion object {
+    /**
+     * Convenience allowing [BackStackScreen] containers to call
+     * [withBackStackConfig] on conforming children before displaying them.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T> makeAware(
+      maybeAware: T,
+      config: BackStackConfig
+    ): T = when (maybeAware) {
+      is BackStackAware<*> -> maybeAware.withBackStackConfig(config) as T
+      else -> maybeAware
+    }
+  }
+}
+
+val BackStackAware<*>.isInBackStack: Boolean
+  get() = backStackConfig != null

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
@@ -18,29 +18,13 @@ package com.squareup.workflow.ui
 /**
  * @param stack: screens that are being or have been displayed, ending in the current screen.
  * Guaranteed not to be empty.
- *
- * @param onGoBack: function to call for a "go back" gesture. Null indicates such gestures
- * should be disabled.
  */
-data class BackStackScreen<StackedT : Any>(
-  val stack: List<StackedT>,
-  val onGoBack: ((Unit) -> Unit)? = null
-) {
-  constructor(
-    only: StackedT,
-    onGoBack: ((Unit) -> Unit)? = null
-  ) : this(listOf(only), onGoBack)
-
-  constructor(
-    vararg stack: StackedT,
-    onGoBack: ((Unit) -> Unit)? = null
-  ) : this(stack.toList(), onGoBack)
+data class BackStackScreen<StackedT : Any>(val stack: List<StackedT>) {
+  constructor(only: StackedT) : this(listOf(only))
+  constructor(vararg stack: StackedT) : this(stack.toList())
 
   init {
     require(stack.isNotEmpty()) { "Empty stacks are not allowed." }
-    require(!stack.asSequence().any { it is BackStackScreen<*> }) {
-      "BackStackScreen in a BackStackScreen is nonsensical: $this"
-    }
   }
 
   val top: StackedT = stack.last()


### PR DESCRIPTION
Introduces "Aware" interface pattern for renderings.

 * `BackStackAware` allows a rendering to be customized based on
   its presence in a `BackStackScreen`, and whether it's the
   first frame or not.

 * `MasterDetailAware` allows a rendering to be customized based
   on its presence in a `MasterDetailScreen`, and whether that
   parent is single pane or split view.

Notice how a workflow emitting `MasterDetailScreen` renderings never knows
whether it's being shown in two panes or one -- those concerns are entirely
managed by view code, and may change at any time. E.g., on phones this sample
swaps between single pane in portrait and master detail in landscape.

`MasterDetailContainer` chooses the split pane or single pane behavior based
on the views made available in its layout file, and repackages its children
into a `BackStackScreen` in single pane mode. The split pane layouts are also
RTL / LTR aware, all through conventional Android resource loading.

More notes:

 * With the introduction of `View.backPressedHandler`, the `onGoBack`
   callback in `BackStackScreen` had become vestigial -- it was never hooked up,
   and was clearly unnecessary. It's been deleted.

 * The choice of push or pop effect in `BackStackContainer` is no longer based
   on the fragile `ViewStateCache`. Instead we choose by comparing the previous
   rendering with the new one. This ensures the right choice across configuration
   changes.

 * Constructors of the container views are tweaked to make them friendly to
   the Android Studio layout editor.

Closes #660, closes #61.


![md](https://user-images.githubusercontent.com/1884445/66875529-78dc1200-ef63-11e9-8932-b8b75055b79c.gif)
