### PR TITLE
Remove robolectric dependency definition, we're never actually using it.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -118,7 +118,6 @@ buildscript {
           'hamcrestCore': "org.hamcrest:hamcrest-core:2.1",
           'junit': "junit:junit:4.12",
           'mockito': "org.mockito:mockito-core:3.1.0",
-          'robolectric': "org.robolectric:robolectric:4.3",
           'truth': "com.google.truth:truth:1.0",
       ]
   ]


### PR DESCRIPTION
Makes #675 obsolete (closes #675).