### PR TITLE
Eliminates WorkflowRunner.onSaveInstanceState.

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -56,6 +56,10 @@ buildscript {
           ],
           // Note that we're not using the actual androidx material dep yet, it's still alpha.
           'material': "com.google.android.material:material:1.0.0",
+          // Note that we are *not* using lifecycle-viewmodel-savedstate, which at this
+          // writing is still in beta and still fixing bad bugs. Probably we'll never bother to,
+          // it doesn't really add value for us.
+          'savedstate': "androidx.savedstate:savedstate:1.0.0",
           'transition': "androidx.transition:transition:1.2.0",
       ],
 

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -21,6 +21,7 @@ buildscript {
       'jmh': '1.21',
       'kotlin': '1.3.50',
       'kotlinCoroutines': '1.3.1',
+      'lifecycle': '2.1.0',
       'moshiVersion': '1.8.0',
   ]
 
@@ -49,8 +50,10 @@ buildscript {
           'annotations': "androidx.annotation:annotation:1.1.0",
           'appcompat': "androidx.appcompat:appcompat:1.1.0",
           'constraint_layout': "androidx.constraintlayout:constraintlayout:1.1.3",
-          'lifecycle': "androidx.lifecycle:lifecycle-extensions:2.1.0",
-          'lifecycleReactivestreams': "androidx.lifecycle:lifecycle-reactivestreams-ktx:2.1.0",
+          'lifecycle': [
+              'extensions': "androidx.lifecycle:lifecycle-extensions:${versions.lifecycle}",
+              'reactivestreams': "androidx.lifecycle:lifecycle-reactivestreams-ktx:${versions.lifecycle}",
+          ],
           // Note that we're not using the actual androidx material dep yet, it's still alpha.
           'material': "com.google.android.material:material:1.0.0",
           'transition': "androidx.transition:transition:1.2.0",

--- a/kotlin/samples/dungeon/app/build.gradle
+++ b/kotlin/samples/dungeon/app/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   implementation deps.androidx.constraint_layout
   implementation deps.androidx.material
   implementation "androidx.gridlayout:gridlayout:1.0.0"
-  implementation deps.androidx.lifecycle
+  implementation deps.androidx.lifecycle.extensions
   implementation deps.kotlin.coroutines.rx2
   implementation deps.okio
   implementation deps.rxandroid2

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/MainActivity.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/MainActivity.kt
@@ -23,8 +23,6 @@ import com.squareup.workflow.ui.setContentWorkflow
 
 class MainActivity : AppCompatActivity() {
 
-  private lateinit var workflowRunner: WorkflowRunner<*>
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
@@ -32,7 +30,7 @@ class MainActivity : AppCompatActivity() {
     val component = Component(applicationContext)
 
     val traceFile = getExternalFilesDir(null)?.resolve("workflow-trace-dungeon.json")!!
-    workflowRunner = setContentWorkflow(savedInstanceState) {
+    setContentWorkflow {
       WorkflowRunner.Config(
           workflow = component.appWorkflow,
           viewRegistry = component.viewRegistry,
@@ -40,10 +38,5 @@ class MainActivity : AppCompatActivity() {
           diagnosticListener = TracingDiagnosticListener(traceFile)
       )
     }
-  }
-
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    workflowRunner.onSaveInstanceState(outState)
   }
 }

--- a/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -20,8 +20,6 @@ import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Worker
 import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.runningWorker
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 
 /**
@@ -35,7 +33,6 @@ class BlinkingCursorWorkflow(
 
   private val cursorString = cursor.toString()
 
-  @UseExperimental(ExperimentalCoroutinesApi::class)
   private val intervalWorker = Worker.create {
     var on = true
     while (true) {

--- a/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflowActivity.kt
+++ b/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflowActivity.kt
@@ -25,20 +25,14 @@ import com.squareup.workflow.ui.setContentWorkflow
 private val viewRegistry = ViewRegistry(HelloLayoutRunner)
 
 class HelloWorkflowActivity : AppCompatActivity() {
-  private lateinit var runner: WorkflowRunner<Unit>
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    runner = setContentWorkflow(savedInstanceState) {
+    setContentWorkflow {
       WorkflowRunner.Config(
-          HelloWorkflow, viewRegistry,
+          HelloWorkflow,
+          viewRegistry,
           diagnosticListener = SimpleLoggingDiagnosticListener()
       )
     }
-  }
-
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    runner.onSaveInstanceState(outState)
   }
 }

--- a/kotlin/samples/tictactoe/app/build.gradle
+++ b/kotlin/samples/tictactoe/app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
   implementation deps.androidx.appcompat
   implementation deps.androidx.constraint_layout
-  implementation deps.androidx.lifecycle
+  implementation deps.androidx.lifecycle.extensions
   implementation deps.kotlin.coroutines.rx2
   implementation deps.okio
   implementation deps.rxandroid2

--- a/kotlin/samples/todo-android/app/build.gradle
+++ b/kotlin/samples/todo-android/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
   implementation deps.androidx.appcompat
   implementation deps.androidx.constraint_layout
   implementation deps.androidx.material
-  implementation deps.androidx.lifecycle
+  implementation deps.androidx.lifecycle.extensions
   implementation deps.kotlin.coroutines.rx2
   implementation deps.okio
   implementation deps.rxandroid2

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
@@ -27,33 +27,20 @@ import com.squareup.workflow.ui.setContentWorkflow
 
 class MainActivity : AppCompatActivity() {
 
-  private lateinit var rootWorkflow: TodoListsAppWorkflow
-  private lateinit var workflowRunner: WorkflowRunner<*>
-
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    // TODO: https://github.com/square/workflow/issues/603 Remove use of deprecated property.
-    @Suppress("DEPRECATION")
-    rootWorkflow = lastCustomNonConfigurationInstance as? TodoListsAppWorkflow
-        ?: TodoListsAppWorkflow()
-
     val traceFile = getExternalFilesDir(null)?.resolve("workflow-trace-todo.json")!!
-    workflowRunner = setContentWorkflow(savedInstanceState) {
+
+    setContentWorkflow {
       WorkflowRunner.Config(
-          rootWorkflow, viewRegistry,
+          TodoListsAppWorkflow,
+          viewRegistry,
           diagnosticListener = SimpleLoggingDiagnosticListener()
               .andThen(TracingDiagnosticListener(traceFile))
       )
     }
   }
-
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    workflowRunner.onSaveInstanceState(outState)
-  }
-
-  override fun onRetainCustomNonConfigurationInstance(): Any = rootWorkflow
 
   private companion object {
     val viewRegistry =

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -37,7 +37,7 @@ sealed class TodoListsAppState {
   ) : TodoListsAppState()
 }
 
-class TodoListsAppWorkflow :
+object TodoListsAppWorkflow :
     StatefulWorkflow<Unit, TodoListsAppState, Nothing, MasterDetailScreen>() {
   override fun initialState(
     props: Unit,

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -42,6 +42,7 @@ dependencies {
   implementation deps.androidx.appcompat
   implementation deps.androidx.lifecycle.extensions
   implementation deps.androidx.lifecycle.reactivestreams
+  implementation deps.androidx.savedstate
   implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.coroutines.core
   implementation deps.kotlin.coroutines.rx2

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -40,8 +40,8 @@ dependencies {
 
   implementation project(':workflow-runtime')
   implementation deps.androidx.appcompat
-  implementation deps.androidx.lifecycle
-  implementation deps.androidx.lifecycleReactivestreams
+  implementation deps.androidx.lifecycle.extensions
+  implementation deps.androidx.lifecycle.reactivestreams
   implementation deps.kotlin.coroutines.android
   implementation deps.kotlin.coroutines.core
   implementation deps.kotlin.coroutines.rx2

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
@@ -83,13 +83,8 @@ abstract class WorkflowFragment<PropsT, OutputT : Any> : Fragment() {
   override fun onActivityCreated(savedInstanceState: Bundle?) {
     super.onActivityCreated(savedInstanceState)
 
-    _runner = WorkflowRunner.startWorkflow(this, savedInstanceState, ::onCreateWorkflow)
+    _runner = WorkflowRunner.startWorkflow(this, ::onCreateWorkflow)
 
     (view as WorkflowLayout).start(runner.renderings, runner.viewRegistry)
-  }
-
-  override fun onSaveInstanceState(outState: Bundle) {
-    super.onSaveInstanceState(outState)
-    runner.onSaveInstanceState(outState)
   }
 }


### PR DESCRIPTION
We now use `androidx.savedstate` for persistence purposes, so the
`WorkflowRunner` Android integration API is as simple as it  will ever be.

Closes #431.
