### PR TITLE
Make it possible to pass just the snapshot for the root workflow into the test methods.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Snapshot.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Snapshot.kt
@@ -152,7 +152,7 @@ fun <T : Enum<T>> BufferedSink.writeEnumByOrdinal(enumVal: T): BufferedSink {
   return writeInt(enumVal.ordinal)
 }
 
-fun <T> BufferedSink.writeList(
+inline fun <T> BufferedSink.writeList(
   values: List<T>,
   writer: BufferedSink.(T) -> Unit
 ): BufferedSink = apply {
@@ -160,7 +160,7 @@ fun <T> BufferedSink.writeList(
   values.forEach { writer(it) }
 }
 
-fun <T> BufferedSource.readList(
+inline fun <T> BufferedSource.readList(
   reader: BufferedSource.() -> T
 ): List<T> = List(readInt()) { reader() }
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/TreeSnapshots.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/TreeSnapshots.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.parse
+import com.squareup.workflow.readByteStringWithLength
+import com.squareup.workflow.readList
+import com.squareup.workflow.writeByteStringWithLength
+import com.squareup.workflow.writeList
+import okio.ByteString
+
+/**
+ * Returns a [Snapshot] that lazily aggregates a root snapshot and the snapshots of all its children
+ * into a single [ByteString].
+ *
+ * The component snapshots can be restored with [parseTreeSnapshot].
+ *
+ * @see parseTreeSnapshot
+ */
+internal fun createTreeSnapshot(
+  rootSnapshot: Snapshot,
+  childSnapshots: List<Pair<AnyId, Snapshot>>
+): Snapshot = Snapshot.write { sink ->
+  sink.writeByteStringWithLength(rootSnapshot.bytes)
+  sink.writeList(childSnapshots) { (childId, childSnapshot) ->
+    writeByteStringWithLength(childId.toByteString())
+    writeByteStringWithLength(childSnapshot.bytes)
+  }
+}
+
+/**
+ * Parses a "root" snapshot and the list of child snapshots with associated [WorkflowId]s from a
+ * [ByteString] returned by [createTreeSnapshot].
+ *
+ * Never returns an empty root snapshot: if the root snapshot is empty it will be null.
+ * Child snapshots, however, are always returned as-is. They must be recursively passed to this
+ * function to continue parsing the tree.
+ *
+ * @see createTreeSnapshot
+ */
+internal fun parseTreeSnapshot(
+  treeSnapshotBytes: ByteString
+): Pair<ByteString?, List<Pair<AnyId, ByteString>>> = treeSnapshotBytes.parse { source ->
+  val rootSnapshot = source.readByteStringWithLength()
+  val childSnapshots = source.readList {
+    val id = restoreId(readByteStringWithLength())
+    val childSnapshot = readByteStringWithLength()
+    return@readList Pair(id, childSnapshot)
+  }
+  // Empty snapshot means no snapshot.
+  val nonEmptyRootSnapshot = rootSnapshot.takeIf { it.size > 0 }
+  return Pair(nonEmptyRootSnapshot, childSnapshots)
+}

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -173,7 +173,7 @@ class SubtreeManagerTest {
     assertEquals(0, workflow.snapshots)
 
     manager.track(listOf(case))
-    manager.createChildrenSnapshot()
+    manager.createChildSnapshots()
     assertEquals(1, workflow.snapshots)
   }
 
@@ -186,10 +186,10 @@ class SubtreeManagerTest {
     assertEquals(0, workflow.serializes)
 
     manager.track(listOf(case))
-    val snapshot = manager.createChildrenSnapshot()
+    val snapshots = manager.createChildSnapshots()
     assertEquals(0, workflow.serializes)
 
-    snapshot.bytes
+    snapshots.forEach { (_, snapshot) -> snapshot.bytes }
     assertEquals(1, workflow.serializes)
   }
 }

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/TreeSnapshotsTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/TreeSnapshotsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.Workflow
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TreeSnapshotsTest {
+
+  @Test fun `serialize and deserialize`() {
+    val rootSnapshot = Snapshot.of("roo")
+    val childSnapshots = listOf(
+        WorkflowId(Workflow1::class) to Snapshot.of("one"),
+        WorkflowId(Workflow2::class) to Snapshot.of("two"),
+        WorkflowId(Workflow2::class, name = "b") to Snapshot.of("three")
+    )
+
+    val treeSnapshot = createTreeSnapshot(rootSnapshot, childSnapshots)
+    val (restoredRoot, restoredChildren) = parseTreeSnapshot(treeSnapshot.bytes)
+
+    assertEquals(rootSnapshot.bytes, restoredRoot)
+    assertEquals(Workflow1::class, restoredChildren[0].first.type)
+    assertEquals(Workflow2::class, restoredChildren[1].first.type)
+    assertEquals(Workflow2::class, restoredChildren[2].first.type)
+
+    assertEquals("", restoredChildren[0].first.name)
+    assertEquals("", restoredChildren[1].first.name)
+    assertEquals("b", restoredChildren[2].first.name)
+
+    assertEquals("one", restoredChildren[0].second.utf8())
+    assertEquals("two", restoredChildren[1].second.utf8())
+    assertEquals("three", restoredChildren[2].second.utf8())
+  }
+
+  @Test fun `deserialize empty root returns null`() {
+    val rootSnapshot = Snapshot.EMPTY
+
+    val treeSnapshot = createTreeSnapshot(rootSnapshot, emptyList())
+    val (restoredRoot, _) = parseTreeSnapshot(treeSnapshot.bytes)
+
+    assertNull(restoredRoot)
+  }
+}
+
+private interface Workflow1 : Workflow<Unit, Nothing, Unit>
+private interface Workflow2 : Workflow<Unit, Nothing, Unit>

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/WorkflowTester.kt
@@ -144,6 +144,9 @@ class WorkflowTester<PropsT, OutputT : Any, RenderingT> @TestOnly internal const
   /**
    * Blocks until the workflow emits a snapshot, then returns it.
    *
+   * The returned snapshot will be the snapshot only of the root workflow. It will be null if
+   * `snapshotState` returned an empty [Snapshot].
+   *
    * @param timeoutMs The maximum amount of time to wait for a snapshot to be emitted. If null,
    * [DEFAULT_TIMEOUT_MS] will be used instead.
    * @param skipIntermediate If true, and the workflow has emitted multiple snapshots, all but the

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
@@ -16,7 +16,7 @@
 package com.squareup.workflow
 
 import com.squareup.workflow.testing.WorkflowTestParams
-import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromSnapshot
+import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromCompleteSnapshot
 import com.squareup.workflow.testing.testFromStart
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -43,7 +43,7 @@ class SnapshottingIntegrationTest {
 
     root.testFromStart(
         props = "unused props",
-        testParams = WorkflowTestParams(startFrom = StartFromSnapshot(snapshot!!))
+        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot!!))
     ) {
       assertEquals("root:new data", awaitNextRendering().data)
     }
@@ -74,7 +74,7 @@ class SnapshottingIntegrationTest {
 
     root.testFromStart(
         props = "unused props",
-        testParams = WorkflowTestParams(startFrom = StartFromSnapshot(snapshot!!))
+        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot!!))
     ) {
       awaitNextRendering()
           .let {
@@ -130,7 +130,7 @@ class SnapshottingIntegrationTest {
 
     root.testFromStart(
         props = "unused props",
-        testParams = WorkflowTestParams(startFrom = StartFromSnapshot(snapshot!!))
+        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot!!))
     ) {
       awaitNextRendering()
           .let {
@@ -172,8 +172,8 @@ class SnapshottingIntegrationTest {
       sendProps("props2")
       val snapshot3 = awaitNextSnapshot()
 
-      assertNotEquals(snapshot1.bytes, snapshot2.bytes)
-      assertEquals(snapshot2.bytes, snapshot3.bytes)
+      assertNotEquals(snapshot1, snapshot2)
+      assertEquals(snapshot2, snapshot3)
     }
   }
 }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkflowTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/WorkflowTesterTest.kt
@@ -22,7 +22,7 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.asWorker
 import com.squareup.workflow.stateful
 import com.squareup.workflow.stateless
-import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromSnapshot
+import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromWorkflowSnapshot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
@@ -137,16 +137,11 @@ class WorkflowTesterTest {
           }
         },
         render = {},
-        snapshot = { Snapshot.of("dummy snapshot") }
+        snapshot = { Snapshot.EMPTY }
     )
+    val snapshot = Snapshot.of("dummy snapshot")
 
-    // Get a valid snapshot (can't use the raw snapshot directly,
-    // see https://github.com/square/workflow/issues/538).
-    val snapshot = workflow.testFromStart {
-      awaitNextSnapshot()
-    }
-
-    workflow.testFromStart(WorkflowTestParams(startFrom = StartFromSnapshot(snapshot))) {
+    workflow.testFromStart(WorkflowTestParams(startFrom = StartFromWorkflowSnapshot(snapshot))) {
       awaitFailure()
           .let { error ->
             val causeChain = generateSequence(error) { it.cause }


### PR DESCRIPTION
This PR gives you the option of starting a workflow test session with either just the snapshot for the root workflow itself, or the complete snapshot of the entire tree from a previous workflow run.

Fixes #538.