### PR TITLE
Compile time assurance that BackStackScreen is not empty.

### DIFF
--- a/kotlin/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/kotlin/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -107,7 +107,8 @@ class TicTacToeEspressoTest {
     onView(withId(R.id.login_password)).type("password")
     rotate()
     onView(withId(R.id.login_email)).check(matches(withText("foo@bar")))
-    onView(withId(R.id.login_password)).check(matches(withText("password")))
+    // Don't save fields that shouldn't be.
+    onView(withId(R.id.login_password)).check(matches(withText("")))
   }
 
   @Test fun backStackPopRestoresViewState() {

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
@@ -55,8 +55,9 @@ class MainActivity : AppCompatActivity() {
           WorkflowRunner.Config(
               component.mainWorkflow,
               viewRegistry,
-              diagnosticListener = SimpleLoggingDiagnosticListener()
-                  .andThen(TracingDiagnosticListener(traceFile))
+              diagnosticListener = object : SimpleLoggingDiagnosticListener() {
+                override fun println(text: String) = Timber.v(text)
+              }.andThen(TracingDiagnosticListener(traceFile))
           )
         },
         // The sample MainWorkflow emits a Unit output when it is done, which means it's

--- a/kotlin/samples/tictactoe/app/src/main/res/layout/login_layout.xml
+++ b/kotlin/samples/tictactoe/app/src/main/res/layout/login_layout.xml
@@ -56,6 +56,7 @@
       android:gravity="center"
       android:hint="@string/login_password_hint"
       android:inputType="textPassword"
+      android:saveEnabled="false"
       />
 
   <Button

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MasterDetailContainer.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/MasterDetailContainer.kt
@@ -77,8 +77,8 @@ class MasterDetailContainer(
     stub: WorkflowViewStub
   ) {
     val asBackStack: BackStackScreen<Any> = rendering.detailRendering
-        ?.let { BackStackScreen(stack = listOf(rendering.masterRendering, makeAware(it, Only))) }
-        ?: run { BackStackScreen(only = makeAware(rendering.masterRendering, Only)) }
+        ?.let { BackStackScreen(rendering.masterRendering, makeAware(it, Only)) }
+        ?: run { BackStackScreen(makeAware(rendering.masterRendering, Only)) }
 
     stub.update(asBackStack, registry)
   }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
@@ -59,7 +59,7 @@ open class BackStackContainer @JvmOverloads constructor(
   private var currentRendering: BackStackScreen<Named<*>>? = null
 
   private fun update(newRendering: BackStackScreen<*>) {
-    val named: BackStackScreen<Named<*>> = newRendering.stack.asSequence()
+    val named: BackStackScreen<Named<*>> = newRendering
         // Let interested children know that they're in a stack.
         .mapIndexed { index, frame ->
           val config = if (index == 0) First else Other
@@ -68,8 +68,6 @@ open class BackStackContainer @JvmOverloads constructor(
         // ViewStateCache requires that everything be Named.
         // It's fine if client code is already using Named for its own purposes, recursion works.
         .map { Named(it, "backstack") }
-        .toList()
-        .let { BackStackScreen(it) }
 
     val oldViewMaybe = currentView
 
@@ -77,7 +75,7 @@ open class BackStackContainer @JvmOverloads constructor(
     oldViewMaybe
         ?.takeIf { it.canShowRendering(named.top) }
         ?.let {
-          viewStateCache.prune(named.stack)
+          viewStateCache.prune(named.frames)
           it.showRendering(named.top)
           return
         }

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackAware.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackAware.kt
@@ -50,7 +50,7 @@ interface BackStackAware<T : BackStackAware<T>> {
   /**
    * Creates a copy of the receiver with [backStackConfig] set to the [config].
    * A container view that displays a [BackStackScreen] should use this method
-   * to transform each visible member of a [BackStackScreen.stack] before rendering it.
+   * to transform each visible frame before rendering it.
    */
   fun withBackStackConfig(config: BackStackConfig): T
 

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
@@ -27,10 +27,27 @@ class BackStackScreen<StackedT : Any>(
   bottom: StackedT,
   rest: List<StackedT>
 ) {
+  /**
+   * Creates a screen with elements listed from the [bottom] to the top.
+   */
   constructor(
     bottom: StackedT,
     vararg rest: StackedT
   ) : this(bottom, rest.toList())
+
+  /**
+   * Creates a screen with the frames of the given [backStack], capped with [top].
+   * [backStack] may be empty.
+   */
+  constructor(
+    backStack: List<StackedT>,
+    top: StackedT
+  ) : this(
+      bottom = backStack.firstOrNull() ?: top,
+      rest = backStack.takeIf { it.isNotEmpty() }
+          ?.let { it.subList(1, it.size) + top }
+          ?: emptyList()
+  )
 
   val frames: List<StackedT> = listOf(bottom) + rest
 
@@ -66,6 +83,10 @@ class BackStackScreen<StackedT : Any>(
 
   override fun hashCode(): Int {
     return frames.hashCode()
+  }
+
+  override fun toString(): String {
+    return "${this::class.java.simpleName}($frames)"
   }
 }
 

--- a/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/BackStackScreenTest.kt
+++ b/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/BackStackScreenTest.kt
@@ -47,4 +47,25 @@ class BackStackScreenTest {
   @Test fun `unequal have mismatching hash`() {
     assertThat(BackStackScreen(1, 2).hashCode()).isNotEqualTo(BackStackScreen(1, 2, 3).hashCode())
   }
+
+  @Test fun `empty back and top`() {
+    assertThat(BackStackScreen(
+        backStack = emptyList(),
+        top = 1
+    )).isEqualTo(BackStackScreen(1))
+  }
+
+  @Test fun `one item back and top`() {
+    assertThat(BackStackScreen(
+        backStack = listOf(1),
+        top = 2
+    )).isEqualTo(BackStackScreen(1, 2))
+  }
+
+  @Test fun `multi item back and top`() {
+    assertThat(BackStackScreen(
+        backStack = listOf(1, 2, 3),
+        top = 4
+    )).isEqualTo(BackStackScreen(1, 2, 3, 4))
+  }
 }

--- a/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/BackStackScreenTest.kt
+++ b/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/BackStackScreenTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BackStackScreenTest {
+  @Test fun `top  is last`() {
+    assertThat(BackStackScreen(1, 2, 3, 4).top).isEqualTo(4)
+  }
+
+  @Test fun `backstack is all but top`() {
+    assertThat(BackStackScreen(1, 2, 3, 4).backStack).isEqualTo(listOf(1, 2, 3))
+  }
+
+  @Test fun `get works`() {
+    assertThat(BackStackScreen("able", "baker", "charlie")[1]).isEqualTo("baker")
+  }
+
+  @Test fun `plus another stack`() {
+    assertThat(BackStackScreen(1, 2, 3) + BackStackScreen(8, 9, 0))
+        .isEqualTo(BackStackScreen(1, 2, 3, 8, 9, 0))
+  }
+
+  @Test fun `unequal by order`() {
+    assertThat(BackStackScreen(1, 2, 3)).isNotEqualTo(BackStackScreen(3, 2, 1))
+  }
+
+  @Test fun `equal have matching hash`() {
+    assertThat(BackStackScreen(1, 2, 3).hashCode()).isEqualTo(BackStackScreen(1, 2, 3).hashCode())
+  }
+
+  @Test fun `unequal have mismatching hash`() {
+    assertThat(BackStackScreen(1, 2).hashCode()).isNotEqualTo(BackStackScreen(1, 2, 3).hashCode())
+  }
+}


### PR DESCRIPTION
Previously we only enforced this with a runtime check.
Inspired by #676.