### PR TITLE
Add WorkflowUI to Package.swift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,19 +169,11 @@ matrix:
         - bundle exec pod install
 
     - language: swift
-      name: "Swift - SPM (Xcode 10.2)"
+      name: "Swift - SPM (Xcode 11.1)"
       os: osx
-      osx_image: xcode10.2
-      cache:
-        directories:
-          - .build
-      before_install:
-        - gem update --system
-        - gem install bundler
-        - swift --version
-        - swift build --verbose
-      script:
-        - swift test
+      osx_image: xcode11.1
+      xcode_scheme: Workflow
+      xcode_destination: platform=iOS Simulator,OS=13.1,name=iPhone 11
 
     - language: swift
       name: "Swift - Tutorial - Cocoapods (Xcode 10.2)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ matrix:
       os: osx
       osx_image: xcode11.1
       script:
-        - xcodebuild -scheme "Workflow" test -destination "name=iPhone 11" 
+        - xcodebuild -scheme "Workflow-Package" test -destination "name=iPhone 11"
 
     - language: swift
       name: "Swift - Tutorial - Cocoapods (Xcode 10.2)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,8 +172,8 @@ matrix:
       name: "Swift - SPM (Xcode 11.1)"
       os: osx
       osx_image: xcode11.1
-      xcode_scheme: Workflow
-      xcode_destination: platform=iOS Simulator,OS=13.1,name=iPhone 11
+      script:
+        - xcodebuild -scheme "Workflow" test -destination "name=iPhone 11" 
 
     - language: swift
       name: "Swift - Tutorial - Cocoapods (Xcode 10.2)"

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,14 @@ let package = Package(
             name: "WorkflowTests",
             dependencies: ["Workflow"],
             path: "swift/Workflow/Tests"),
+        .target(
+            name: "WorkflowUI",
+            dependencies: ["Workflow"],
+            path: "swift/WorkflowUI/Sources"),
+        .testTarget(
+            name: "WorkflowUITests",
+            dependencies: ["WorkflowUI"],
+            path: "swift/WorkflowUI/Tests"),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
         .library(
             name: "Workflow",
             targets: ["Workflow"]),
+        .library(
+            name: "WorkflowUI",
+            targets: ["WorkflowUI"]),
     ],
     dependencies: [
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "6.0.0")

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "Workflow",
+    platforms: [
+        .iOS("9.3"),
+    ],
     products: [
         .library(
             name: "Workflow",

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -338,7 +338,7 @@ extension WorkflowNode.SubtreeManager {
         }
 
         func handle(event: Output) {
-            if #available(iOS 10.0, OSX 10.12, *) {
+            if #available(iOS 10.0, *) {
                 dispatchPrecondition(condition: .onQueue(DispatchQueue.workflowExecution))
             }
 

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreenViewController.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import UIKit
+
+
 internal final class AnyScreenViewController: ScreenViewController<AnyScreen> {
 
     typealias WrappedViewController = UIViewController & UntypedScreenViewController


### PR DESCRIPTION
Now that Xcode 11 supports Swift Package Manager directly, tests can be executed from the command line with `xcodebuild`. This allows us to specify an SDK (including iOS) and simulator device, which unlocks testing of code with system (UIKit/SwiftUI/AppKit) dependencies directly from the Swift package – no CocoaPods required.