### PR TITLE
Drops BackStackScreen var-args constructor.

### DIFF
--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/panel/PanelContainerScreen.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/panel/PanelContainerScreen.kt
@@ -47,5 +47,5 @@ fun <B : Any, T : Any> BackStackScreen<T>.inPanelOver(baseScreen: B): PanelConta
  * Shows the receiver as the only panel over [baseScreen], with no back stack.
  */
 fun <B : Any, T : Any> T.firstInPanelOver(baseScreen: B): PanelContainerScreen<B, T> {
-  return BackStackScreen(this).inPanelOver(baseScreen)
+  return BackStackScreen(this, emptyList()).inPanelOver(baseScreen)
 }

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/BackStackScreen.kt
@@ -28,12 +28,11 @@ class BackStackScreen<StackedT : Any>(
   rest: List<StackedT>
 ) {
   /**
-   * Creates a screen with elements listed from the [bottom] to the top.
+   * Creates a screen with elements listed from the bottom to the top.
    */
   constructor(
-    bottom: StackedT,
-    vararg rest: StackedT
-  ) : this(bottom, rest.toList())
+    frames: List<StackedT>
+  ) : this(frames.first(), frames.subList(1, frames.size))
 
   /**
    * Creates a screen with the frames of the given [backStack], capped with [top].

--- a/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/BackStackScreenTest.kt
+++ b/kotlin/workflow-ui-core/src/test/java/com/squareup/workflow/ui/BackStackScreenTest.kt
@@ -20,52 +20,71 @@ import org.junit.Test
 
 class BackStackScreenTest {
   @Test fun `top  is last`() {
-    assertThat(BackStackScreen(1, 2, 3, 4).top).isEqualTo(4)
+    assertThat(BackStackScreen(listOf(1, 2, 3, 4)).top).isEqualTo(4)
   }
 
   @Test fun `backstack is all but top`() {
-    assertThat(BackStackScreen(1, 2, 3, 4).backStack).isEqualTo(listOf(1, 2, 3))
+    assertThat(BackStackScreen(listOf(1, 2, 3, 4)).backStack).isEqualTo(listOf(1, 2, 3))
   }
 
   @Test fun `get works`() {
-    assertThat(BackStackScreen("able", "baker", "charlie")[1]).isEqualTo("baker")
+    assertThat(BackStackScreen(listOf("able", "baker", "charlie"))[1]).isEqualTo("baker")
   }
 
   @Test fun `plus another stack`() {
-    assertThat(BackStackScreen(1, 2, 3) + BackStackScreen(8, 9, 0))
-        .isEqualTo(BackStackScreen(1, 2, 3, 8, 9, 0))
+    assertThat(BackStackScreen(listOf(1, 2, 3)) + BackStackScreen(listOf(8, 9, 0)))
+        .isEqualTo(BackStackScreen(listOf(1, 2, 3, 8, 9, 0)))
   }
 
   @Test fun `unequal by order`() {
-    assertThat(BackStackScreen(1, 2, 3)).isNotEqualTo(BackStackScreen(3, 2, 1))
+    assertThat(BackStackScreen(listOf(1, 2, 3))).isNotEqualTo(BackStackScreen(listOf(3, 2, 1)))
   }
 
   @Test fun `equal have matching hash`() {
-    assertThat(BackStackScreen(1, 2, 3).hashCode()).isEqualTo(BackStackScreen(1, 2, 3).hashCode())
+    assertThat(BackStackScreen(listOf(1, 2, 3)).hashCode()).isEqualTo(
+        BackStackScreen(listOf(1, 2, 3)).hashCode()
+    )
   }
 
   @Test fun `unequal have mismatching hash`() {
-    assertThat(BackStackScreen(1, 2).hashCode()).isNotEqualTo(BackStackScreen(1, 2, 3).hashCode())
+    assertThat(BackStackScreen(listOf(1, 2)).hashCode()).isNotEqualTo(
+        BackStackScreen(listOf(1, 2, 3)).hashCode()
+    )
   }
 
   @Test fun `empty back and top`() {
-    assertThat(BackStackScreen(
-        backStack = emptyList(),
-        top = 1
-    )).isEqualTo(BackStackScreen(1))
+    assertThat(
+        BackStackScreen(
+            backStack = emptyList(),
+            top = 1
+        )
+    ).isEqualTo(BackStackScreen(1, emptyList()))
   }
 
   @Test fun `one item back and top`() {
-    assertThat(BackStackScreen(
-        backStack = listOf(1),
-        top = 2
-    )).isEqualTo(BackStackScreen(1, 2))
+    assertThat(
+        BackStackScreen(
+            backStack = listOf(1),
+            top = 2
+        )
+    ).isEqualTo(BackStackScreen(listOf(1, 2)))
   }
 
   @Test fun `multi item back and top`() {
-    assertThat(BackStackScreen(
-        backStack = listOf(1, 2, 3),
-        top = 4
-    )).isEqualTo(BackStackScreen(1, 2, 3, 4))
+    assertThat(
+        BackStackScreen(
+            backStack = listOf(1, 2, 3),
+            top = 4
+        )
+    ).isEqualTo(BackStackScreen(listOf(1, 2, 3, 4)))
+  }
+
+  @Test fun `bottom and rest`() {
+    assertThat(
+        BackStackScreen(
+            bottom = 1,
+            rest = listOf(2, 3, 4)
+        )
+    ).isEqualTo(BackStackScreen(listOf(1, 2, 3, 4)))
   }
 }


### PR DESCRIPTION
Too easy to shoot yourself in the foot otherwise. I keep creating
`BackStackScreen<List<Foo>>` instead of `BackStackScreen<Foo>`. Yes, it's
annoying to have to call `listOf`, but it's not the end of the world.