### PR TITLE
Publish internal testing artifact, required by other published artifacts.

### DIFF
--- a/kotlin/internal-testing-utils/build.gradle
+++ b/kotlin/internal-testing-utils/build.gradle
@@ -15,6 +15,8 @@
  */
 apply plugin: 'kotlin'
 
+apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
+
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 

--- a/kotlin/internal-testing-utils/gradle.properties
+++ b/kotlin/internal-testing-utils/gradle.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2019 Square Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+POM_ARTIFACT_ID=workflow-internal-testing-utils
+POM_NAME=Workflow internal testing utilities
+POM_PACKAGING=jar


### PR DESCRIPTION
Because the `internal-testing-utils` module wasn't configured to publish to maven, the modules that depend on it were using version `unspecified` in their POMs. This was invalid, but also the shared artifact just wasn't being published, so everything breaks consumers.