### PR TITLE
Add SPM instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ frameborder="0" allowfullscreen></iframe>
 
 [![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-orange.svg)](#swift-package-manager)
 
-If you are developing your own package, be sure that Workflow is included in `dependencies` 
+If you are developing your own package, be sure that Workflow is included in `dependencies`
 in `Package.swift`:
 
 ```swift
@@ -37,7 +37,7 @@ dependencies: [
 ]
 ```
 
-In Xcode 11+, add Workflow directly as a dependency to your project with 
+In Xcode 11+, add Workflow directly as a dependency to your project with
 `File` > `Swift Packages` > `Add Package Dependency...`. Provide the git URL when prompted: `git@github.com:square/workflow.git`.
 
 #### Cocoapods

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ frameborder="0" allowfullscreen></iframe>
 
 [![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-orange.svg)](#swift-package-manager)
 
-If you are developing your own package, be sure that Workflow is included in `dependencies` in `Package.swift`:
+If you are developing your own package, be sure that Workflow is included in `dependencies` 
+in `Package.swift`:
 
 ```swift
 dependencies: [
@@ -36,7 +37,8 @@ dependencies: [
 ]
 ```
 
-In Xcode 11+, add Workflow directly as a dependency to your project with `File` > `Swift Packages` > `Add Package Dependency...`. Provide the git URL when prompted: `git@github.com:square/workflow.git`.
+In Xcode 11+, add Workflow directly as a dependency to your project with 
+`File` > `Swift Packages` > `Add Package Dependency...`. Provide the git URL when prompted: `git@github.com:square/workflow.git`.
 
 #### Cocoapods
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ frameborder="0" allowfullscreen></iframe>
 
 ### Swift
 
+#### Swift Package Manager
+
+[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-orange.svg)](#swift-package-manager)
+
+If you are developing your own package, be sure that Workflow is included in `dependencies` in `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "git@github.com:square/workflow.git", from: "0.21.1")
+]
+```
+
+In Xcode 11+, add Workflow directly as a dependency to your project with `File` > `Swift Packages` > `Add Package Dependency...`. Provide the git URL when prompted: `git@github.com:square/workflow.git`.
+
+#### Cocoapods
+
 [![CocoaPods compatible](https://img.shields.io/cocoapods/v/Workflow.svg)](https://cocoapods.org/pods/Workflow)
 
 If you use CocoaPods to manage your dependencies, simply add Workflow and WorkflowUI to your


### PR DESCRIPTION
Swift Package Manager makes getting started with Workflow dramatically easier for anyone who is not already running Cocoapods, so we should advertise its support in the readme (This should have been in my initial SPM PR).