### PR TITLE
Make event sinks queued and reusable instead of throw after going stale.

### DIFF
--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -18,7 +18,6 @@ package com.squareup.workflow.internal
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
-import kotlinx.coroutines.Deferred
 
 /**
  * An immutable description of the things a [Workflow] would like to do as the result of calling its
@@ -29,8 +28,7 @@ import kotlinx.coroutines.Deferred
  */
 data class Behavior<StateT, out OutputT : Any> internal constructor(
   val childCases: List<WorkflowOutputCase<*, *, StateT, OutputT>>,
-  val workerCases: List<WorkerCase<*, StateT, OutputT>>,
-  val nextActionFromEvent: Deferred<WorkflowAction<StateT, OutputT>>
+  val workerCases: List<WorkerCase<*, StateT, OutputT>>
 ) {
 
   // @formatter:off


### PR DESCRIPTION
Fixes #741, based on #743.

This change is actually very simple, it just replaces the per-render-pass `CompletableDeferred` with a per-`WorkflowNode`, unlimited-capacity `Channel`.