### PR TITLE
Give Worker.doesSameWorkAs a default implementation that just compares by concrete type.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -145,7 +145,7 @@ interface Worker<out OutputT> {
    * }
    * ```
    */
-  fun doesSameWorkAs(otherWorker: Worker<*>): Boolean
+  fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker::class == this::class
 
   companion object {
 

--- a/kotlin/workflow-core/src/test/java/com/squareup/workflow/WorkerTest.kt
+++ b/kotlin/workflow-core/src/test/java/com/squareup/workflow/WorkerTest.kt
@@ -1,0 +1,23 @@
+package com.squareup.workflow
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WorkerTest {
+
+  @Test fun `default Worker#doesSameWorkAs implementation compares by concrete type`() {
+    class Worker1 : Worker<Nothing> {
+      override fun run(): Flow<Nothing> = emptyFlow()
+    }
+
+    class Worker2 : Worker<Nothing> {
+      override fun run(): Flow<Nothing> = emptyFlow()
+    }
+
+    assertTrue(Worker1().doesSameWorkAs(Worker1()))
+    assertFalse(Worker1().doesSameWorkAs(Worker2()))
+  }
+}


### PR DESCRIPTION
Closes #745.