### PR TITLE
Add macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -219,16 +219,16 @@ matrix:
         - bundle exec pod install
 
     - language: swift
-      name: "Swift - SPM - iOS (Xcode 11.2)"
+      name: "Swift - SPM - iOS (Xcode 11.1)"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.1
       script:
         - xcodebuild -scheme "Workflow-Package" test -destination "name=iPhone 11"
 
     - language: swift
-      name: "Swift - SPM - macOS (Xcode 11.2)"
+      name: "Swift - SPM - macOS (Xcode 11.1)"
       os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.1
       script:
         - xcodebuild -scheme "Workflow-Package" test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,11 +219,18 @@ matrix:
         - bundle exec pod install
 
     - language: swift
-      name: "Swift - SPM (Xcode 11.1)"
+      name: "Swift - SPM - iOS (Xcode 11.2)"
       os: osx
-      osx_image: xcode11.1
+      osx_image: xcode11.2
       script:
         - xcodebuild -scheme "Workflow-Package" test -destination "name=iPhone 11"
+
+    - language: swift
+      name: "Swift - SPM - macOS (Xcode 11.2)"
+      os: osx
+      osx_image: xcode11.2
+      script:
+        - xcodebuild -scheme "Workflow-Package" test
 
     - language: swift
       name: "Swift - Tutorial - Cocoapods (Xcode 10.2)"

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "Workflow",
     platforms: [
         .iOS("9.3"),
+        .macOS("10.12")
     ],
     products: [
         .library(

--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
 
   s.swift_versions = ['5.0']
   s.ios.deployment_target = '9.3'
+  s.osx.deployment_target = '10.12'
 
   s.source_files = 'swift/Workflow/Sources/*.swift'
 

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
 
   s.swift_versions = ['5.0']
   s.ios.deployment_target = '9.3'
+  s.osx.deployment_target = '10.12'
 
   s.source_files = 'swift/WorkflowTesting/Sources/*.swift'
 

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
 
   s.swift_versions = ['5.0']
   s.ios.deployment_target = '9.3'
+  s.osx.deployment_target = '10.12'
 
   s.source_files = 'swift/WorkflowUI/Sources/**/*.swift'
 

--- a/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
+++ b/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import UIKit
 import ReactiveSwift
 import Workflow
@@ -101,3 +104,5 @@ public final class ContainerViewController<Output, ScreenType>: UIViewController
     }
 
 }
+
+#endif

--- a/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
+++ b/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import UIKit
 import ReactiveSwift

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import UIKit
 

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import UIKit
 
 public struct AnyScreen: Screen {
@@ -35,3 +38,5 @@ public struct AnyScreen: Screen {
         return viewControllerBuilder(viewRegistry)
     }
 }
+
+#endif

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreenViewController.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import UIKit
 

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreenViewController.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import UIKit
 
 
@@ -86,4 +89,4 @@ internal final class AnyScreenViewController: ScreenViewController<AnyScreen> {
 }
 
 
-
+#endif

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/UntypedScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/UntypedScreenViewController.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 // Internal API for working with a screen view controller when the specific screen type is unknown.
 protocol UntypedScreenViewController {

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/UntypedScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/UntypedScreenViewController.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#if os(iOS)
 
 // Internal API for working with a screen view controller when the specific screen type is unknown.
 protocol UntypedScreenViewController {
@@ -33,3 +34,5 @@ extension ScreenViewController: UntypedScreenViewController {
     }
 
 }
+
+#endif

--- a/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import UIKit
 

--- a/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import UIKit
 
 
@@ -55,3 +58,5 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
     }
 
 }
+
+#endif

--- a/swift/WorkflowUI/Sources/ViewRegistry/ViewRegistry.swift
+++ b/swift/WorkflowUI/Sources/ViewRegistry/ViewRegistry.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import UIKit
 import ReactiveSwift

--- a/swift/WorkflowUI/Sources/ViewRegistry/ViewRegistry.swift
+++ b/swift/WorkflowUI/Sources/ViewRegistry/ViewRegistry.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import UIKit
 import ReactiveSwift
 
@@ -78,3 +81,5 @@ public struct ViewRegistry {
     }
 
 }
+
+#endif

--- a/swift/WorkflowUI/Tests/AnyScreenViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/AnyScreenViewControllerTests.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import XCTest
 @testable import WorkflowUI
 
@@ -59,3 +62,5 @@ class AnyScreenViewControllerTests: XCTestCase {
         XCTAssert(expected !== actual)
     }
 }
+
+#endif

--- a/swift/WorkflowUI/Tests/AnyScreenViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/AnyScreenViewControllerTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import XCTest
 @testable import WorkflowUI

--- a/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import XCTest
 

--- a/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import XCTest
 
 import ReactiveSwift
@@ -126,3 +129,5 @@ fileprivate struct MockWorkflow: Workflow {
     }
 
 }
+
+#endif

--- a/swift/WorkflowUI/Tests/ViewRegistryTests.swift
+++ b/swift/WorkflowUI/Tests/ViewRegistryTests.swift
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if os(iOS)
+
 import XCTest
 
 @testable import WorkflowUI
@@ -73,3 +76,5 @@ class ViewRegistryTests: XCTestCase {
         XCTAssertTrue(type(of: actual) == ViewC.self)
     }
 }
+
+#endif

--- a/swift/WorkflowUI/Tests/ViewRegistryTests.swift
+++ b/swift/WorkflowUI/Tests/ViewRegistryTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if os(iOS)
+#if canImport(UIKit)
 
 import XCTest
 


### PR DESCRIPTION
For now this primarily marks `UIKit` code as unavailable when not compiling for iOS. The benefit today is that we can run unit tests directly on macOS.

As we add SwiftUI support in the future, a common API across Apple platforms becomes more interesting (which was the real motivation behind this PR).