### PR TITLE
Upgrade Gradle to 6.0.1.

### DIFF
--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle 6.0 release notes: https://docs.gradle.org/6.0/release-notes.html
Gradle 6.0.1 release notes: https://docs.gradle.org/6.0.1/release-notes.html

This depends on upgrading ktlint first (#780), the version we're currently using doesn't work with Gradle 6.