### PR TITLE
BREAKING CHANGE: ViewRegistry is now a ContainerHint.

### DIFF
--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/masterdetail/MasterDetailContainer.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/masterdetail/MasterDetailContainer.kt
@@ -26,7 +26,6 @@ import com.squareup.workflow.ui.BackStackScreen
 import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.ViewBinding
-import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowViewStub
 
 /**
@@ -38,10 +37,7 @@ import com.squareup.workflow.ui.WorkflowViewStub
  * For single pane layouts, [MasterDetailScreen] is repackaged as a [BackStackScreen]
  * with [MasterDetailScreen.masterRendering] as the base of the stack.
  */
-class MasterDetailContainer(
-  view: View,
-  private val registry: ViewRegistry
-) : LayoutRunner<MasterDetailScreen> {
+class MasterDetailContainer(view: View) : LayoutRunner<MasterDetailScreen> {
 
   private val masterStub: WorkflowViewStub? = view.findViewById(R.id.master_stub)
   private val detailStub: WorkflowViewStub? = view.findViewById(R.id.detail_stub)
@@ -71,16 +67,14 @@ class MasterDetailContainer(
     } else {
       masterStub!!.update(
           rendering.masterRendering,
-          containerHints + (MasterDetailConfig to Master),
-          registry
+          containerHints + (MasterDetailConfig to Master)
       )
       rendering.detailRendering
           ?.let { detail ->
             detailStub!!.actual.visibility = VISIBLE
             detailStub.update(
                 detail,
-                containerHints + (MasterDetailConfig to Detail),
-                registry
+                containerHints + (MasterDetailConfig to Detail)
             )
           }
           ?: run {
@@ -98,7 +92,7 @@ class MasterDetailContainer(
         ?.let { rendering.masterRendering + it }
         ?: rendering.masterRendering
 
-    stub.update(combined, containerHints + (MasterDetailConfig to Single), registry)
+    stub.update(combined, containerHints + (MasterDetailConfig to Single))
   }
 
   companion object : ViewBinding<MasterDetailScreen> by LayoutRunner.Binding(

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardView.kt
@@ -99,7 +99,7 @@ class BoardView(context: Context) : View(context) {
 
   companion object : ViewBinding<Board> by BuilderBinding(
       type = Board::class,
-      viewConstructor = { _, initialRendering, initialHints, contextForNewView, _ ->
+      viewConstructor = { initialRendering, initialHints, contextForNewView, _ ->
         BoardView(contextForNewView)
             .apply { bindShowRendering(initialRendering, initialHints) { r, _ -> update(r) } }
       })

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameLayoutRunner.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameLayoutRunner.kt
@@ -29,13 +29,9 @@ import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
-import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowViewStub
 
-class GameLayoutRunner(
-  view: View,
-  private val viewRegistry: ViewRegistry
-) : LayoutRunner<GameRendering> {
+class GameLayoutRunner(view: View) : LayoutRunner<GameRendering> {
 
   private val boardView: WorkflowViewStub = view.findViewById(R.id.board_stub)
   private val moveLeft: View = view.findViewById(R.id.move_left)
@@ -56,7 +52,7 @@ class GameLayoutRunner(
     rendering: GameRendering,
     containerHints: ContainerHints
   ) {
-    boardView.update(rendering.board, containerHints, viewRegistry)
+    boardView.update(rendering.board, containerHints)
     this.rendering = rendering
 
     // Disable the views if we don't have an event handler, e.g. when the game has finished.

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/BaseScreenLayoutRunner.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/BaseScreenLayoutRunner.kt
@@ -25,7 +25,6 @@ import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
-import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowViewStub
 
 /**
@@ -34,10 +33,7 @@ import com.squareup.workflow.ui.WorkflowViewStub
  *
  * Each of the `RecyclerView`s uses a different [ListDiffMode] for updating its adapter.
  */
-class BaseScreenLayoutRunner(
-  view: View,
-  private val viewRegistry: ViewRegistry
-) : LayoutRunner<BaseScreen> {
+class BaseScreenLayoutRunner(view: View) : LayoutRunner<BaseScreen> {
 
   private val noDiffListStub = view.findViewById<WorkflowViewStub>(R.id.list_stub)
   private val syncListStub = view.findViewById<WorkflowViewStub>(R.id.sync_list_stub)
@@ -50,9 +46,9 @@ class BaseScreenLayoutRunner(
   ) {
     val syncHints = containerHints + (ListDiffMode to Synchronous)
     val asyncHints = containerHints + (ListDiffMode to Asynchronous)
-    noDiffListStub.update(rendering.listRendering, containerHints, viewRegistry)
-    syncListStub.update(rendering.listRendering, syncHints, viewRegistry)
-    asyncListStub.update(rendering.listRendering, asyncHints, viewRegistry)
+    noDiffListStub.update(rendering.listRendering, containerHints)
+    syncListStub.update(rendering.listRendering, syncHints)
+    asyncListStub.update(rendering.listRendering, asyncHints)
     addRowButton.setOnClickListener { rendering.onAddRowTapped() }
   }
 

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/ChooseRowTypeViewBinding.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/ChooseRowTypeViewBinding.kt
@@ -27,7 +27,6 @@ import android.widget.LinearLayout
 import com.squareup.sample.recyclerview.AppWorkflow.ChooseRowTypeScreen
 import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.ViewBinding
-import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.bindShowRendering
 import kotlin.reflect.KClass
 
@@ -38,7 +37,6 @@ object ChooseRowTypeViewBinding : ViewBinding<ChooseRowTypeScreen> {
   override val type: KClass<ChooseRowTypeScreen> get() = ChooseRowTypeScreen::class
 
   override fun buildView(
-    registry: ViewRegistry,
     initialRendering: ChooseRowTypeScreen,
     initialContainerHints: ContainerHints,
     contextForNewView: Context,
@@ -48,12 +46,12 @@ object ChooseRowTypeViewBinding : ViewBinding<ChooseRowTypeScreen> {
     list.orientation = LinearLayout.VERTICAL
     list.setBackgroundColor(Color.WHITE)
 
-    val inflator = LayoutInflater.from(contextForNewView)
+    val inflater = LayoutInflater.from(contextForNewView)
 
     list.bindShowRendering(initialRendering, initialContainerHints) { rendering, _ ->
       list.removeAllViews()
       rendering.options.forEachIndexed { index, option ->
-        val row = inflator.inflate(R.layout.new_row_type_item, list, false) as Button
+        val row = inflater.inflate(R.layout.new_row_type_item, list, false) as Button
         row.text = option
         row.setOnClickListener { rendering.onSelectionTapped(index) }
         list.addView(row, LayoutParams(WRAP_CONTENT, WRAP_CONTENT))

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/AlertContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/AlertContainer.kt
@@ -43,8 +43,7 @@ internal class AlertContainer @JvmOverloads constructor(
 
   override fun buildDialog(
     initialModalRendering: AlertScreen,
-    initialContainerHints: ContainerHints,
-    viewRegistry: ViewRegistry
+    initialContainerHints: ContainerHints
   ): DialogRef<AlertScreen> {
     val dialog = AlertDialog.Builder(context, dialogThemeResId)
         .create()
@@ -92,12 +91,11 @@ internal class AlertContainer @JvmOverloads constructor(
   ) : ViewBinding<AlertContainerScreen<*>>
   by BuilderBinding(
       type = AlertContainerScreen::class,
-      viewConstructor = { viewRegistry, initialRendering, initialHints, context, _ ->
+      viewConstructor = { initialRendering, initialHints, context, _ ->
         AlertContainer(context, dialogThemeResId = dialogThemeResId)
             .apply {
               id = R.id.workflow_alert_container
               layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-              registry = viewRegistry
               bindShowRendering(initialRendering, initialHints, ::update)
             }
       }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/BuilderBinding.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/BuilderBinding.kt
@@ -50,18 +50,10 @@ import kotlin.reflect.KClass
  *    val TicTacToeViewBuilders = ViewRegistry(
  *        MyView, GamePlayLayoutRunner, GameOverLayoutRunner
  *    )
- *
- * Note in particular the [ViewRegistry] argument to the [viewConstructor] lambda. This allows
- * nested renderings to be displayed.
- *
- * It's simplest, and most typical, to pass the [ViewRegistry] to [WorkflowViewStub.update] to
- * show nested renderings. When that's too constraining, more complex containers can
- * call [ViewRegistry.buildView], [View.canShowRendering] and [View.showRendering] directly.
  */
 class BuilderBinding<RenderingT : Any>(
   override val type: KClass<RenderingT>,
   private val viewConstructor: (
-    viewRegistry: ViewRegistry,
     initialRendering: RenderingT,
     initialContainerHints: ContainerHints,
     contextForNewView: Context,
@@ -69,10 +61,9 @@ class BuilderBinding<RenderingT : Any>(
   ) -> View
 ) : ViewBinding<RenderingT> {
   override fun buildView(
-    registry: ViewRegistry,
     initialRendering: RenderingT,
     initialContainerHints: ContainerHints,
     contextForNewView: Context,
     container: ViewGroup?
-  ): View = viewConstructor(registry, initialRendering, initialContainerHints, contextForNewView, container)
+  ): View = viewConstructor(initialRendering, initialContainerHints, contextForNewView, container)
 }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ContainerHints.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ContainerHints.kt
@@ -19,13 +19,20 @@ import kotlin.reflect.KClass
 
 /**
  * Immutable, append-only map of values that a parent view can pass down to
- * its children via [android.view.View.showRendering] et al. Allows container views
- * to give descendants information about the context in which they're drawing.
+ * its children via [View.showRendering][android.view.View.showRendering] et al.
+ * Allows container views to give descendants information about the context in which
+ * they're drawing.
+ *
+ * Every [View.showRendering][android.view.View.showRendering] call initiated via
+ * [ViewRegistry.buildView] or [WorkflowLayout.start] includes an appropriate [ViewRegistry]
+ * hint. This allows container views to make recursive [ViewRegistry.buildView]
+ * calls to build child views to show nested renderings.
  */
 class ContainerHints private constructor(
   private val map: Map<ContainerHintKey<*>, Any>
 ) {
-  constructor() : this(emptyMap())
+  constructor(registry: ViewRegistry) :
+      this(mapOf<ContainerHintKey<*>, Any>(ViewRegistry to registry))
 
   @Suppress("UNCHECKED_CAST")
   operator fun <T : Any> get(key: ContainerHintKey<T>): T = map[key] as? T ?: key.default

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
@@ -57,13 +57,11 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
 
   private var dialogs: List<DialogRef<ModalRenderingT>> = emptyList()
 
-  protected lateinit var registry: ViewRegistry
-
   protected fun update(
     newScreen: HasModals<*, ModalRenderingT>,
     containerHints: ContainerHints
   ) {
-    baseView.update(newScreen.baseScreen, containerHints, registry)
+    baseView.update(newScreen.baseScreen, containerHints)
 
     val newDialogs = mutableListOf<DialogRef<ModalRenderingT>>()
     for ((i, modal) in newScreen.modals.withIndex()) {
@@ -71,7 +69,7 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
         dialogs[i].copy(modalRendering = modal, containerHints = containerHints)
             .also { updateDialog(it) }
       } else {
-        buildDialog(modal, containerHints, registry).apply {
+        buildDialog(modal, containerHints).apply {
           dialog.show()
           // Android makes a lot of logcat noise if it has to close the window for us. :/
           // https://github.com/square/workflow/issues/51
@@ -90,8 +88,7 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
    */
   protected abstract fun buildDialog(
     initialModalRendering: ModalRenderingT,
-    initialContainerHints: ContainerHints,
-    viewRegistry: ViewRegistry
+    initialContainerHints: ContainerHints
   ): DialogRef<ModalRenderingT>
 
   protected abstract fun updateDialog(dialogRef: DialogRef<ModalRenderingT>)

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalViewContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalViewContainer.kt
@@ -42,10 +42,11 @@ internal class ModalViewContainer @JvmOverloads constructor(
 ) : ModalContainer<Any>(context, attributeSet, defStyle, defStyleRes) {
   override fun buildDialog(
     initialModalRendering: Any,
-    initialContainerHints: ContainerHints,
-    viewRegistry: ViewRegistry
+    initialContainerHints: ContainerHints
   ): DialogRef<Any> {
-    val view = viewRegistry.buildView(initialModalRendering, initialContainerHints, this)
+    val view = initialContainerHints[ViewRegistry].buildView(
+        initialModalRendering, initialContainerHints, this
+    )
 
     return Dialog(context, dialogThemeResId)
         .apply {
@@ -103,18 +104,16 @@ internal class ModalViewContainer @JvmOverloads constructor(
   ) : ViewBinding<H>
   by BuilderBinding(
       type = type,
-      viewConstructor = { viewRegistry, initialRendering, initialHints, context, _ ->
+      viewConstructor = { initialRendering, initialHints, context, _ ->
         ModalViewContainer(
             context,
             modalDecorator = modalDecorator,
             dialogThemeResId = dialogThemeResId
-        )
-            .apply {
-              this.id = id
-              layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
-              registry = viewRegistry
-              bindShowRendering(initialRendering, initialHints, ::update)
-            }
+        ).apply {
+          this.id = id
+          layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+          bindShowRendering(initialRendering, initialHints, ::update)
+        }
       }
   )
 }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewBinding.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewBinding.kt
@@ -35,7 +35,6 @@ interface ViewBinding<RenderingT : Any> {
    * via [View.showRendering].
    */
   fun buildView(
-    registry: ViewRegistry,
     initialRendering: RenderingT,
     initialContainerHints: ContainerHints,
     contextForNewView: Context,

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
@@ -55,14 +55,15 @@ class WorkflowLayout(
     renderings: Observable<out Any>,
     registry: ViewRegistry
   ) {
-    takeWhileAttached(renderings) { show(it, registry) }
+    val hints = ContainerHints(registry)
+    takeWhileAttached(renderings) { show(it, hints) }
   }
 
   private fun show(
     newRendering: Any,
-    registry: ViewRegistry
+    hints: ContainerHints
   ) {
-    showing.update(newRendering, ContainerHints(), registry)
+    showing.update(newRendering, hints)
     restoredChildState?.let { restoredState ->
       restoredChildState = null
       showing.actual.restoreHierarchyState(restoredState)

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
@@ -11,7 +11,7 @@ import android.view.ViewGroup
  *
  * ## Usage
  *
- * In the XML layout for your container view, place a [WorkflowViewStub] where
+ * In the XML layout for a container view, place a [WorkflowViewStub] where
  * you want child renderings to be displayed. E.g.:
  *
  *    <LinearLayout…>
@@ -22,19 +22,18 @@ import android.view.ViewGroup
  *       …
  *
  * Then in your [LayoutRunner],
- *   - get the `ViewRegistry` in your constructor
  *   - pull the view out with `findViewById` like any other view
  *   - and update it in your `showRendering` method:
  *
  * ```
- *     class YourLayoutRunner(
- *       view: View, private
- *       val viewRegistry: ViewRegistry
- *     ) {
+ *     class YourLayoutRunner(view: View) {
  *       private val child = view.findViewById<WorkflowViewStub>(R.id.child_stub)
  *
- *       override fun showRendering(rendering: YourRendering) {
- *         child.update(rendering.childRendering, viewRegistry)
+ *       override fun showRendering(
+ *          rendering: YourRendering,
+ *          containerHints: ContainerHints
+ *       ) {
+ *         child.update(rendering.childRendering, containerHints)
  *       }
  *     }
  * ```
@@ -69,8 +68,7 @@ class WorkflowViewStub @JvmOverloads constructor(
    */
   fun update(
     rendering: Any,
-    containerHints: ContainerHints,
-    registry: ViewRegistry
+    containerHints: ContainerHints
   ): View {
     actual.takeIf { it.canShowRendering(rendering) }
         ?.let {
@@ -79,9 +77,9 @@ class WorkflowViewStub @JvmOverloads constructor(
         }
 
     return when (val parent = actual.parent) {
-      is ViewGroup -> registry.buildView(rendering, containerHints, parent)
+      is ViewGroup -> containerHints[ViewRegistry].buildView(rendering, containerHints, parent)
           .also { buildNewViewAndReplaceOldView(parent, it) }
-      else -> registry.buildView(rendering, containerHints, actual.context)
+      else -> containerHints[ViewRegistry].buildView(rendering, containerHints, actual.context)
     }.also { actual = it }
   }
 

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
@@ -52,7 +52,6 @@ open class BackStackContainer @JvmOverloads constructor(
 ) : FrameLayout(context, attributeSet, defStyle, defStyleRes) {
 
   private val viewStateCache = ViewStateCache()
-  private lateinit var registry: ViewRegistry
 
   private val currentView: View? get() = if (childCount > 0) getChildAt(0) else null
   private var currentRendering: BackStackScreen<Named<*>>? = null
@@ -80,7 +79,7 @@ open class BackStackContainer @JvmOverloads constructor(
           return
         }
 
-    val newView = registry.buildView(named.top, hints, this)
+    val newView = hints[ViewRegistry].buildView(named.top, hints, this)
     viewStateCache.update(named.backStack, oldViewMaybe, newView)
 
     val popped = currentRendering?.backStack?.any { compatible(it, named.top) } == true
@@ -154,12 +153,11 @@ open class BackStackContainer @JvmOverloads constructor(
   companion object : ViewBinding<BackStackScreen<*>>
   by BuilderBinding(
       type = BackStackScreen::class,
-      viewConstructor = { viewRegistry, initialRendering, initialHints, context, _ ->
+      viewConstructor = { initialRendering, initialHints, context, _ ->
         BackStackContainer(context)
             .apply {
               id = R.id.workflow_back_stack_container
               layoutParams = (ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT))
-              registry = viewRegistry
               bindShowRendering(initialRendering, initialHints, ::update)
             }
       }

--- a/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/ContainerHintsTest.kt
+++ b/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/ContainerHintsTest.kt
@@ -16,6 +16,7 @@
 package com.squareup.workflow.ui
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow.ui.backstack.BackStackContainer
 import org.junit.Test
 
 class ContainerHintsTest {
@@ -36,12 +37,14 @@ class ContainerHintsTest {
     }
   }
 
+  private val emptyHints = ContainerHints(ViewRegistry(BackStackContainer))
+
   @Test fun defaults() {
-    assertThat(ContainerHints()[DataHint]).isEqualTo(DataHint())
+    assertThat(emptyHints[DataHint]).isEqualTo(DataHint())
   }
 
   @Test fun put() {
-    val hints = ContainerHints() +
+    val hints = emptyHints +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
@@ -50,11 +53,11 @@ class ContainerHintsTest {
   }
 
   @Test fun `map equality`() {
-    val hints1 = ContainerHints() +
+    val hints1 = emptyHints +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
-    val hints2 = ContainerHints() +
+    val hints2 = emptyHints +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
@@ -62,11 +65,11 @@ class ContainerHintsTest {
   }
 
   @Test fun `map inequality`() {
-    val hints1 = ContainerHints() +
+    val hints1 = emptyHints +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
-    val hints2 = ContainerHints() +
+    val hints2 = emptyHints +
         (StringHint to "fnord") +
         (DataHint to DataHint(43, "foo"))
 
@@ -82,7 +85,7 @@ class ContainerHintsTest {
   }
 
   @Test fun override() {
-    val hints = ContainerHints() +
+    val hints = emptyHints +
         (StringHint to "able") +
         (StringHint to "baker")
 
@@ -90,7 +93,7 @@ class ContainerHintsTest {
   }
 
   @Test fun `keys of the same type`() {
-    val hints = ContainerHints() +
+    val hints = emptyHints +
         (StringHint to "able") +
         (OtherStringHint to "baker")
 


### PR DESCRIPTION
`LayoutRunner` constructors and `bindView` factory methods no longer have the
option to include a `ViewRegistry` parameter. Instead, every `ContainerHint`
map includes a hint pointing to the related `ViewRegistry`.

This further simplifies the chore of creating custom container views.
They no longer have to build a mechanism for getting their hands
on a `ViewRegistry` reference. In this PR you'll see various
`registry = viewRegistry` lines deleted from various factory functions
in various `BuilderBinding` calls, e.g. in `AlertContainer`,
`ModalViewContainer` and `BackStackContainer`.

Closes #737.