### PR TITLE
Bump moshi and moshi-kotlin from 1.9.1 to 1.9.2 in /kotlin

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -57,7 +57,7 @@ buildscript {
           'transition': "androidx.transition:transition:1.2.0",
       ],
 
-      'moshi': "com.squareup.moshi:moshi:1.9.1",
+      'moshi': "com.squareup.moshi:moshi:1.9.2",
       'rxandroid2': "io.reactivex.rxjava2:rxandroid:2.1.1",
       'timber': "com.jakewharton.timber:timber:4.7.1",
 
@@ -75,7 +75,7 @@ buildscript {
               'rx2': "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.2",
               'test': "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
           ],
-          'moshi': "com.squareup.moshi:moshi-kotlin:1.9.1",
+          'moshi': "com.squareup.moshi:moshi-kotlin:1.9.2",
           'reflect': "org.jetbrains.kotlin:kotlin-reflect:1.3.60",
           'test': [
               'common': "org.jetbrains.kotlin:kotlin-test-common",


### PR DESCRIPTION
Closes #765 and closes #766.

Bumps [moshi](https://github.com/square/moshi) from 1.9.1 to 1.9.2.
- [Release notes](https://github.com/square/moshi/releases)
- [Changelog](https://github.com/square/moshi/blob/master/CHANGELOG.md)
- [Commits](https://github.com/square/moshi/compare/moshi-parent-1.9.1...moshi-parent-1.9.2)

Bumps [moshi-kotlin](https://github.com/square/moshi) from 1.9.1 to 1.9.2.
- [Release notes](https://github.com/square/moshi/releases)
- [Changelog](https://github.com/square/moshi/blob/master/CHANGELOG.md)
- [Commits](https://github.com/square/moshi/compare/moshi-parent-1.9.1...moshi-parent-1.9.2)

Verified UI tests pass locally.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>