### PR TITLE
Prevent sending to sinks before the workflow's own render method returns.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -167,7 +167,7 @@ fun <EventT, StateT, OutputT : Any> RenderContext<StateT, OutputT>.makeEventSink
   val actionSink = makeActionSink<WorkflowAction<StateT, OutputT>>()
 
   return actionSink.contraMap { event ->
-    WorkflowAction("eventSink") { block(event) }
+    WorkflowAction({ "eventSink($event)" }) { block(event) }
   }
 }
 

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -125,6 +125,9 @@ class RealRenderContextTest {
     val context = RealRenderContext(PoisonRenderer(), eventActionsChannel)
     val stringAction = WorkflowAction<String, String>({ "stringAction" }) { null }
     val sink = context.makeActionSink<WorkflowAction<String, String>>()
+    // Enable sink sends.
+    context.buildBehavior()
+
     assertTrue(eventActionsChannel.isEmpty)
 
     sink.send(stringAction)
@@ -145,6 +148,9 @@ class RealRenderContextTest {
       override fun toString(): String = "secondAction"
     }
     val sink = context.makeActionSink<WorkflowAction<String, String>>()
+    // Enable sink sends.
+    context.buildBehavior()
+
     sink.send(firstAction)
 
     // Shouldn't throw.
@@ -154,6 +160,9 @@ class RealRenderContextTest {
   @Test fun `makeEventSink gets event`() {
     val context = RealRenderContext(PoisonRenderer(), eventActionsChannel)
     val sink: Sink<String> = context.makeEventSink { it }
+    // Enable sink sends.
+    context.buildBehavior()
+
     sink.send("foo")
 
     val update = eventActionsChannel.poll()!!
@@ -165,6 +174,9 @@ class RealRenderContextTest {
   @Test fun `makeEventSink works with OutputT of Nothing`() {
     val context = RealRenderContext<String, Nothing>(PoisonRenderer(), eventActionsChannel)
     val sink: Sink<String> = context.makeEventSink { null }
+    // Enable sink sends.
+    context.buildBehavior()
+
     sink.send("foo")
 
     val update = eventActionsChannel.poll()!!


### PR DESCRIPTION
This fix will prevent sends from the workflow's _own_ render method is called,
but not the more general case of the entire tree's render pass being complete.
The reason for this is that this is just a safety check to provide a more useful
error message than a raw stack overflow, and uses the existing `frozen` flag
private to the current node, so doesn't add any machinery to the overall tree.

Fixes #764.