### PR TITLE
Optimize re-rendering child workflows.

### DIFF
--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -27,27 +27,8 @@ import com.squareup.workflow.WorkflowAction
  * @see RealRenderContext
  */
 data class Behavior<StateT, OutputT : Any> internal constructor(
-  val childCases: List<WorkflowOutputCase<*, *, StateT, OutputT>>,
   val workerCases: List<WorkerCase<*, StateT, OutputT>>
 ) {
-
-  /* ktlint-disable parameter-list-wrapping */
-  data class WorkflowOutputCase<
-      ChildPropsT,
-      ChildOutputT : Any,
-      ParentStateT,
-      ParentOutputT : Any
-      > internal constructor(
-    val workflow: Workflow<*, ChildOutputT, *>,
-    val id: WorkflowId<ChildPropsT, ChildOutputT, *>,
-    val props: ChildPropsT,
-    val handler: (ChildOutputT) -> WorkflowAction<ParentStateT, ParentOutputT>
-  ) {
-    @Suppress("UNCHECKED_CAST")
-    fun acceptChildOutput(output: Any): WorkflowAction<ParentStateT, ParentOutputT> =
-      handler(output as ChildOutputT)
-  }
-  /* ktlint-enable parameter-list-wrapping */
 
   data class WorkerCase<T, StateT, OutputT : Any> internal constructor(
     val worker: Worker<T>,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/InlineLinkedList.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/InlineLinkedList.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.internal.InlineLinkedList.InlineListNode
+
+/**
+ * A simple singly-linked list that uses the list elements themselves to store the links.
+ *
+ * List elements must implement [InlineListNode].
+ *
+ * It supports a limited number of operations:
+ *  - [forEach]: Iterate over the list. This is an inline function, so has no lambda allocation
+ *    overhead.
+ *  - [removeFirst]: Find the first element that matches a predicate, remove it, and return it.
+ *    This function is also inline and so has no lambda allocation overhead.
+ *  - [plusAssign]
+ *  - [clear]
+ */
+internal class InlineLinkedList<T : InlineListNode<T>> {
+
+  /**
+   * Interface to be implemented by something that can be stored in an [InlineLinkedList].
+   *
+   * @property nextListNode For use by [InlineLinkedList] only – implementors should never mutate
+   * this property. It's default value should be null.
+   */
+  interface InlineListNode<T : InlineListNode<T>> {
+    var nextListNode: T?
+  }
+
+  var head: T? = null
+  var tail: T? = null
+
+  /**
+   * Append an element to the end of the list.
+   *
+   * @throws IllegalArgumentException If node is already linked in another list.
+   */
+  operator fun plusAssign(node: T) {
+    require(node.nextListNode == null) { "Expected node to not be linked." }
+
+    tail?.let { oldTail ->
+      tail = node
+      oldTail.nextListNode = node
+      return
+    }
+
+    // List is currently empty.
+    check(head == null)
+    head = node
+    tail = node
+  }
+
+  /**
+   * Finds the first node matching [predicate], removes it, and returns it.
+   *
+   * This function is inline and has no lambda allocation overhead.
+   *
+   * @return The matching element, or null if not found.
+   */
+  inline fun removeFirst(predicate: (T) -> Boolean): T? {
+    var currentNode: T? = head
+    var previousNode: T? = null
+
+    while (currentNode != null) {
+      if (predicate(currentNode)) {
+        // Unlink the node from the list.
+        if (previousNode == null) {
+          // First element matched.
+          head = currentNode.nextListNode
+        } else {
+          previousNode.nextListNode = currentNode.nextListNode
+        }
+        if (tail == currentNode) {
+          tail = previousNode
+        }
+        currentNode.nextListNode = null
+        return currentNode
+      }
+
+      previousNode = currentNode
+      currentNode = currentNode.nextListNode
+    }
+
+    return null
+  }
+
+  /**
+   * Iterates over the list.
+   */
+  inline fun forEach(block: (T) -> Unit) {
+    var currentNode = head
+    while (currentNode != null) {
+      block(currentNode)
+      currentNode = currentNode.nextListNode
+    }
+  }
+
+  /**
+   * Removes all elements from the list.
+   */
+  fun clear() {
+    head = null
+    tail = null
+  }
+}

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowChildNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowChildNode.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.Workflow
+import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.internal.InlineLinkedList.InlineListNode
+
+/**
+ * Representation of a child workflow that has been rendered by another workflow.
+ *
+ * Associates the child's [WorkflowNode] (which includes the key passed to `renderChild`) with the
+ * output handler function that was passed to `renderChild`.
+ */
+internal class WorkflowChildNode<
+    ChildPropsT,
+    ChildOutputT : Any,
+    ParentStateT,
+    ParentOutputT : Any
+    >
+internal constructor(
+  val workflow: Workflow<*, ChildOutputT, *>,
+  private var handler: (ChildOutputT) -> WorkflowAction<ParentStateT, ParentOutputT>,
+  val workflowNode: WorkflowNode<ChildPropsT, *, ChildOutputT, *>
+) : InlineListNode<WorkflowChildNode<*, *, *, *>> {
+
+  override var nextListNode: WorkflowChildNode<*, *, *, *>? = null
+
+  /** The [WorkflowNode]'s [WorkflowId]. */
+  val id get() = workflowNode.id
+
+  /**
+   * Returns true if this child has the same type as [otherWorkflow] and key as [key].
+   */
+  fun matches(
+    otherWorkflow: Workflow<*, *, *>,
+    key: String
+  ): Boolean = id.let { (myClass, myKey) -> myClass == otherWorkflow::class && myKey == key }
+
+  /**
+   * Updates the handler function that will be invoked by [acceptChildOutput].
+   */
+  fun <CO, S, O : Any> setHandler(handler: (CO) -> WorkflowAction<S, O>) {
+    @Suppress("UNCHECKED_CAST")
+    this.handler = handler as (ChildOutputT) -> WorkflowAction<ParentStateT, ParentOutputT>
+  }
+
+  /**
+   * Wrapper around [WorkflowNode.render] that allows calling it with erased types.
+   */
+  fun <R> render(
+    workflow: StatefulWorkflow<*, *, *, *>,
+    props: Any?
+  ): R {
+    @Suppress("UNCHECKED_CAST")
+    return workflowNode.render(
+        workflow as StatefulWorkflow<ChildPropsT, out Any?, ChildOutputT, Nothing>,
+        props as ChildPropsT
+    ) as R
+  }
+
+  /**
+   * Wrapper around [handler] that allows calling it with erased types.
+   */
+  @Suppress("UNCHECKED_CAST")
+  fun acceptChildOutput(output: Any): WorkflowAction<ParentStateT, ParentOutputT> =
+    handler(output as ChildOutputT)
+}

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -237,10 +237,10 @@ internal class WorkflowNode<PropsT, StateT, OutputT : Any, RenderingT>(
     val rendering = workflow.render(props, state, context)
     diagnosticListener?.onAfterWorkflowRendered(diagnosticId, rendering)
 
+    subtreeManager.commitRenderedChildren()
     behavior = context.buildBehavior()
         .apply {
-          // Start new children/workers, and drop old ones.
-          subtreeManager.track(childCases)
+          // Start new workers and drop old ones.
           workerTracker.track(workerCases)
         }
 

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/InlineLinkedListTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/InlineLinkedListTest.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.internal
+
+import com.squareup.workflow.internal.InlineLinkedList.InlineListNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class InlineLinkedListTest {
+
+  @Test fun `forEach empty list`() {
+    val list = InlineLinkedList<StringElement>()
+    var count = 0
+    list.forEach { count++ }
+    assertEquals(0, count)
+  }
+
+  @Test fun `plusAssign on empty list`() {
+    val list = InlineLinkedList<StringElement>()
+
+    list += StringElement("foo")
+
+    assertEquals(listOf("foo"), list.toList())
+  }
+
+  @Test fun `removeFirst on empty list`() {
+    val list = InlineLinkedList<StringElement>()
+
+    list.removeFirst { true }
+
+    assertEquals(emptyList(), list.toList())
+  }
+
+  @Test fun `removeFirst on single-item list`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+
+    assertEquals("foo", list.removeFirst { it.value == "foo" }?.value)
+
+    assertEquals(emptyList(), list.toList())
+  }
+
+  @Test fun `removeFirst head on list with 2 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+
+    assertEquals("foo", list.removeFirst { it.value == "foo" }?.value)
+
+    assertEquals(listOf("bar"), list.toList())
+  }
+
+  @Test fun `removeFirst tail on list with 2 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+
+    assertEquals("bar", list.removeFirst { it.value == "bar" }?.value)
+
+    assertEquals(listOf("foo"), list.toList())
+  }
+
+  @Test fun `removeFirst head on list with 3 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list += StringElement("baz")
+
+    assertEquals("foo", list.removeFirst { it.value == "foo" }?.value)
+
+    assertEquals(listOf("bar", "baz"), list.toList())
+  }
+
+  @Test fun `removeFirst middle on list with 3 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list += StringElement("baz")
+
+    assertEquals("bar", list.removeFirst { it.value == "bar" }?.value)
+
+    assertEquals(listOf("foo", "baz"), list.toList())
+  }
+
+  @Test fun `removeFirst tail on list with 3 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list += StringElement("baz")
+
+    assertEquals("baz", list.removeFirst { it.value == "baz" }?.value)
+
+    assertEquals(listOf("foo", "bar"), list.toList())
+  }
+
+  @Test fun `removeFirst when multiple matches`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("foo")
+    list += StringElement("bar")
+
+    assertEquals("foo", list.removeFirst { it.value == "foo" }?.value)
+
+    assertEquals(listOf("foo", "bar"), list.toList())
+  }
+
+  @Test fun `removeFirst when no matches`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+
+    assertNull(list.removeFirst { it.value == "baz" })
+
+    assertEquals(listOf("foo", "bar"), list.toList())
+  }
+
+  @Test fun `plusAssign on non-empty list`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+
+    list += StringElement("bar")
+
+    assertEquals(listOf("foo", "bar"), list.toList())
+  }
+
+  @Test fun `plusAssign after remove head with 2 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list.removeFirst { it.value == "foo" }
+
+    list += StringElement("buzz")
+
+    assertEquals(listOf("bar", "buzz"), list.toList())
+  }
+
+  @Test fun `plusAssign after remove tail with 2 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list.removeFirst { it.value == "bar" }
+
+    list += StringElement("buzz")
+
+    assertEquals(listOf("foo", "buzz"), list.toList())
+  }
+
+  @Test fun `plusAssign after remove head with 3 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list += StringElement("baz")
+    list.removeFirst { it.value == "foo" }
+
+    list += StringElement("buzz")
+
+    assertEquals(listOf("bar", "baz", "buzz"), list.toList())
+  }
+
+  @Test fun `plusAssign after remove middle with 3 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list += StringElement("baz")
+    list.removeFirst { it.value == "bar" }
+
+    list += StringElement("buzz")
+
+    assertEquals(listOf("foo", "baz", "buzz"), list.toList())
+  }
+
+  @Test fun `plusAssign after remove tail with 3 items`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list += StringElement("baz")
+    list.removeFirst { it.value == "baz" }
+
+    list += StringElement("buzz")
+
+    assertEquals(listOf("foo", "bar", "buzz"), list.toList())
+  }
+
+  @Test fun `clear empty list`() {
+    val list = InlineLinkedList<StringElement>()
+    list.clear()
+    assertEquals(emptyList(), list.toList())
+  }
+
+  @Test fun `clear single-item list`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list.clear()
+    assertEquals(emptyList(), list.toList())
+  }
+
+  @Test fun `clear multi-item list`() {
+    val list = InlineLinkedList<StringElement>()
+    list += StringElement("foo")
+    list += StringElement("bar")
+    list.clear()
+    assertEquals(emptyList(), list.toList())
+  }
+
+  private fun InlineLinkedList<StringElement>.toList(): List<String> {
+    val items = mutableListOf<String>()
+    forEach { items += it.value }
+    return items
+  }
+}
+
+private class StringElement(
+  val value: String
+) : InlineListNode<StringElement> {
+  override var nextListNode: StringElement? = null
+}

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -21,10 +21,8 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Sink
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
-import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.applyTo
-import com.squareup.workflow.internal.Behavior.WorkflowOutputCase
 import com.squareup.workflow.internal.SubtreeManagerTest.TestWorkflow.Rendering
 import com.squareup.workflow.makeEventSink
 import kotlinx.coroutines.Dispatchers.Unconfined
@@ -33,8 +31,11 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.selects.select
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.fail
+
+private typealias StringHandler = (String) -> WorkflowAction<String, String>
 
 class SubtreeManagerTest {
 
@@ -100,11 +101,8 @@ class SubtreeManagerTest {
     val manager =
       SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
     val workflow = TestWorkflow()
-    val id = workflow.id()
-    val props = "props"
-    val case = WorkflowOutputCase<String, String, String, String>(workflow, id, props) { fail() }
 
-    manager.render(case, workflow, id, props)
+    manager.render(workflow, "props", key = "", handler = { fail() })
     assertEquals(1, workflow.started)
   }
 
@@ -112,24 +110,55 @@ class SubtreeManagerTest {
     val manager =
       SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
     val workflow = TestWorkflow()
-    val id = workflow.id()
-    val props = "props"
-    val case = WorkflowOutputCase<String, String, String, String>(workflow, id, props) { fail() }
+    fun render() = manager.render(workflow, "props", key = "", handler = { fail() })
+        .also { manager.commitRenderedChildren() }
 
-    manager.render(case, workflow, id, props)
-    manager.render(case, workflow, id, props)
+    render()
+    render()
+
     assertEquals(1, workflow.started)
+  }
+
+  @Test fun `render restarts child after tearing down`() {
+    val manager =
+      SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
+    val workflow = TestWorkflow()
+    fun render() = manager.render(workflow, "props", key = "", handler = { fail() })
+        .also { manager.commitRenderedChildren() }
+    render()
+    assertEquals(1, workflow.started)
+
+    // Render without rendering child.
+    manager.commitRenderedChildren()
+    assertEquals(1, workflow.started)
+
+    render()
+    assertEquals(2, workflow.started)
+  }
+
+  @Test fun `render throws on duplicate key`() {
+    val manager =
+      SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
+    val workflow = TestWorkflow()
+    manager.render(workflow, "props", "foo", handler = { fail() })
+
+    val error = assertFailsWith<IllegalArgumentException> {
+      manager.render(workflow, "props", "foo", handler = { fail() })
+    }
+    assertEquals(
+        "Expected keys to be unique for ${TestWorkflow::class.java.name}: key=foo",
+        error.message
+    )
   }
 
   @Test fun `render returns child rendering`() {
     val manager =
       SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
     val workflow = TestWorkflow()
-    val id = workflow.id()
-    val props = "props"
-    val case = WorkflowOutputCase<String, String, String, String>(workflow, id, props) { fail() }
 
-    val (composeProps, composeState) = manager.render(case, workflow, id, props)
+    val (composeProps, composeState) = manager.render(
+        workflow, "props", key = "", handler = { fail() }
+    )
     assertEquals("props", composeProps)
     assertEquals("initialState:props", composeState)
   }
@@ -138,15 +167,14 @@ class SubtreeManagerTest {
     val manager =
       SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
     val workflow = TestWorkflow()
-    val id = workflow.id()
-    val props = "props"
-    val case = WorkflowOutputCase<String, String, String, String>(workflow, id, props) { output ->
+    val handler: StringHandler = { output ->
       WorkflowAction { setOutput("case output:$output") }
     }
 
     // Initialize the child so tickChildren has something to work with, and so that we can send
     // an event to trigger an output.
-    val (_, _, eventHandler) = manager.render(case, workflow, id, "props")
+    val (_, _, eventHandler) = manager.render(workflow, "props", key = "", handler = handler)
+    manager.commitRenderedChildren()
 
     runBlocking {
       val tickOutput = async { manager.tickAction() }
@@ -163,15 +191,13 @@ class SubtreeManagerTest {
     val manager =
       SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
     val workflow = TestWorkflow()
-    val id = workflow.id()
-    val props = "props"
-    val case = WorkflowOutputCase<String, String, String, String>(workflow, id, props) { output ->
-      WorkflowAction { setOutput("initial handler: $output") }
-    }
+    fun render(handler: StringHandler) =
+      manager.render(workflow, "props", key = "", handler = handler)
+          .also { manager.commitRenderedChildren() }
 
     runBlocking {
       // First render + tick pass – uninteresting.
-      manager.render(case, workflow, id, props)
+      render { WorkflowAction { setOutput("initial handler: $it") } }
           .let { rendering ->
             rendering.eventHandler("initial output")
             val initialAction = manager.tickAction()!!
@@ -180,10 +206,7 @@ class SubtreeManagerTest {
           }
 
       // Do a second render + tick, but with a different handler function.
-      val case2 = case.copy(handler = { output ->
-        WorkflowAction { setOutput("second handler: $output") }
-      })
-      manager.render(case2, workflow, id, props)
+      render { WorkflowAction { setOutput("second handler: $it") } }
           .let { rendering ->
             rendering.eventHandler("second output")
             val secondAction = manager.tickAction()!!
@@ -197,17 +220,12 @@ class SubtreeManagerTest {
   @Test fun `createChildSnapshot snapshots eagerly`() {
     val manager = SubtreeManager<Unit, Nothing>(Unconfined, parentDiagnosticId = 0)
     val workflow = SnapshotTestWorkflow()
-    val id = workflow.id("1")
-    @Suppress("UNCHECKED_CAST")
-    val case = WorkflowOutputCase<Unit, Unit, Unit, Nothing>(
-        workflow as Workflow<*, Unit, *>,
-        id as WorkflowId<Unit, Unit, *>,
-        Unit
-    ) { fail() }
     assertEquals(0, workflow.snapshots)
 
-    manager.track(listOf(case))
+    manager.render(workflow, props = Unit, key = "1", handler = { fail() })
+    manager.commitRenderedChildren()
     manager.createChildSnapshots()
+
     assertEquals(1, workflow.snapshots)
   }
 
@@ -215,17 +233,12 @@ class SubtreeManagerTest {
   @Test fun `createChildSnapshot serializes lazily`() {
     val manager = SubtreeManager<Unit, Nothing>(Unconfined, parentDiagnosticId = 0)
     val workflow = SnapshotTestWorkflow()
-    val id = workflow.id("1")
-    @Suppress("UNCHECKED_CAST")
-    val case = WorkflowOutputCase<Unit, Unit, Unit, Nothing>(
-        workflow as Workflow<*, Unit, *>,
-        id as WorkflowId<Unit, Unit, *>,
-        Unit
-    ) { fail() }
     assertEquals(0, workflow.serializes)
 
-    manager.track(listOf(case))
+    manager.render(workflow, props = Unit, key = "1", handler = { fail() })
+    manager.commitRenderedChildren()
     val snapshots = manager.createChildSnapshots()
+
     assertEquals(0, workflow.serializes)
 
     snapshots.forEach { (_, snapshot) -> snapshot.bytes }


### PR DESCRIPTION
This optimization moves the management of child workflows out
of `Behavior` and `LifetimeTracker` and directly into `SubtreeManager`.
It uses roughly the same algorithm as the Swift implementation (I believe),
and during a render pass just effectively tags nodes as still in-use or not,
by moving them between two linked lists. After the render pass, everything that
is in the old list is torn down and the lists are swapped for the next render pass.

This reduces the number of allocations required by each `WorkflowNode`'s `render`,
and in the optimal case of a workflow just re-rendering all its children, has
almost no overhead.


[Spreadsheet](https://docs.google.com/spreadsheets/d/1e4OBW0RmKscQyQPIYMLHf0Tzj2WbBnOndVLnEcJ5MAg/edit?usp=sharing)

Benchmark | (treeShape) | Mode | Cnt | Score (before) | Error | Score (after) | Error | Units | Speedup
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
WorkflowNodeBenchmark.renderPassAlternateLeaves | DEEP | avgt | 3 | 310.463 | 7.559 | 72.753 | 4.480 | us/op | 4.27
WorkflowNodeBenchmark.renderPassAlternateLeaves | BUSHY | avgt | 3 | 563.374 | 50.840 | 445.627 | 119.474 | us/op | 1.26
WorkflowNodeBenchmark.renderPassAlternateLeaves | SQUARE | avgt | 3 | 504.244 | 8.309 | 343.108 | 124.959 | us/op | 1.47
WorkflowNodeBenchmark.renderPassAlternateOneLeaf | DEEP | avgt | 3 | 315.172 | 18.100 | 71.529 | 8.432 | us/op | 4.41
WorkflowNodeBenchmark.renderPassAlternateOneLeaf | BUSHY | avgt | 3 | 294.026 | 22.039 | 67.544 | 0.996 | us/op | 4.35
WorkflowNodeBenchmark.renderPassAlternateOneLeaf | SQUARE | avgt | 3 | 273.824 | 5.861 | 54.579 | 1.845 | us/op | 5.02
WorkflowNodeBenchmark.renderPassAlternateWorkers | DEEP | avgt | 3 | 323.121 | 20.304 | 69.888 | 6.516 | us/op | 4.62
WorkflowNodeBenchmark.renderPassAlternateWorkers | BUSHY | avgt | 3 | 556.811 | 80.929 | 444.579 | 100.674 | us/op | 1.25
WorkflowNodeBenchmark.renderPassAlternateWorkers | SQUARE | avgt | 3 | 502.989 | 7.628 | 344.899 | 46.005 | us/op | 1.46
WorkflowNodeBenchmark.renderPassAlwaysLeaves | DEEP | avgt | 3 | 312.049 | 93.199 | 65.652 | 3.975 | us/op | 4.75
WorkflowNodeBenchmark.renderPassAlwaysLeaves | BUSHY | avgt | 3 | 292.758 | 19.453 | 61.276 | 0.459 | us/op | 4.78
WorkflowNodeBenchmark.renderPassAlwaysLeaves | SQUARE | avgt | 3 | 269.063 | 11.410 | 53.762 | 7.107 | us/op | 5.00

