### PR TITLE
WIP Optimize rendering by caching renderings when possible.

### DIFF
--- a/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/ActorWorkflow.kt
+++ b/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/ActorWorkflow.kt
@@ -32,7 +32,17 @@ interface ActorWorkflow : Workflow<ActorProps, Nothing, ActorRendering> {
     val board: Board,
     val myLocation: Location,
     val ticks: Worker<Long>
-  )
+  ) {
+    override fun equals(other: Any?): Boolean {
+      return when {
+        other === this -> true
+        other !is ActorProps -> false
+        else -> board == other.board &&
+            myLocation == other.myLocation &&
+            ticks.doesSameWorkAs(other.ticks)
+      }
+    }
+  }
 
   data class ActorRendering(
     val avatar: BoardCell,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
@@ -85,12 +85,14 @@ internal class SubtreeManager<StateT, OutputT : Any>(
    */
   fun <T : Any> tickChildren(
     selector: SelectBuilder<T?>,
-    handler: (WorkflowAction<StateT, OutputT>) -> T?
+    handler: (WorkflowAction<StateT, OutputT>?) -> T?
   ) {
     for ((case, node) in nodeLifetimeTracker.lifetimes) {
       node.tick(selector) { output ->
-        val componentUpdate = case.acceptChildOutput(output)
-        return@tick handler(componentUpdate)
+        if (output != null) {
+          val componentUpdate = case.acceptChildOutput(output)
+          return@tick handler(componentUpdate)
+        } else return@tick handler(null)
       }
     }
   }


### PR DESCRIPTION
[Spreadsheet](https://docs.google.com/spreadsheets/d/1e4OBW0RmKscQyQPIYMLHf0Tzj2WbBnOndVLnEcJ5MAg/edit#gid=916243004)

Note below the `renderPassAlternateOneLeaf | SQUARE` case – this is the most similar case to most real-world ones. A tree that is a little deep and a little bushy, where only one path some node up to the root actually updates and needs re-rendering. Here we only render 4 nodes, and all other renderings are simply returned from the cache.


Benchmark | (treeShape) | Mode | Cnt | Score (before) | Error | Score (after) | Error | Units | Speedup
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
WorkflowNodeBenchmark.renderPassAlternateLeaves | DEEP | avgt | 3 | 310.463 | 7.559 | 311.437 | 83.952 | us/op | 1.00
WorkflowNodeBenchmark.renderPassAlternateLeaves | BUSHY | avgt | 3 | 563.374 | 50.840 | 556.091 | 17.334 | us/op | 1.01
WorkflowNodeBenchmark.renderPassAlternateLeaves | SQUARE | avgt | 3 | 504.244 | 8.309 | 538.211 | 230.249 | us/op | 0.94
WorkflowNodeBenchmark.renderPassAlternateOneLeaf | DEEP | avgt | 3 | 315.172 | 18.100 | 312.197 | 11.376 | us/op | 1.01
WorkflowNodeBenchmark.renderPassAlternateOneLeaf | BUSHY | avgt | 3 | 294.026 | 22.039 | 178.340 | 12.926 | us/op | 1.65
WorkflowNodeBenchmark.renderPassAlternateOneLeaf | SQUARE | avgt | 3 | 273.824 | 5.861 | 10.249 | 0.794 | us/op | 26.72
WorkflowNodeBenchmark.renderPassAlternateWorkers | DEEP | avgt | 3 | 323.121 | 20.304 | 327.485 | 10.509 | us/op | 0.99
WorkflowNodeBenchmark.renderPassAlternateWorkers | BUSHY | avgt | 3 | 556.811 | 80.929 | 552.366 | 22.018 | us/op | 1.01
WorkflowNodeBenchmark.renderPassAlternateWorkers | SQUARE | avgt | 3 | 502.989 | 7.628 | 508.815 | 31.266 | us/op | 0.99
WorkflowNodeBenchmark.renderPassAlwaysLeaves | DEEP | avgt | 3 | 312.049 | 93.199 | 0.001 | 0.001 | us/op | 312049.00
WorkflowNodeBenchmark.renderPassAlwaysLeaves | BUSHY | avgt | 3 | 292.758 | 19.453 | 0.001 | 0.001 | us/op | 292758.00
WorkflowNodeBenchmark.renderPassAlwaysLeaves | SQUARE | avgt | 3 | 269.063 | 11.410 | 0.001 | 0.001 | us/op | 269063.00

