### PR TITLE
Workaround Android emulator bug that broke our CI instrumentation tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,69 +93,69 @@ matrix:
           - $HOME/.m2
 
     # Disabled due to https://github.com/square/workflow/issues/759
-    # # AVD config copied from leakcanary and informed by
-    # # https://github.com/mikehardy/Anki-Android/blob/177c63d4eb969548ad7dc5243f0fac33522f3fe7/.travis.yml
-    # - language: android
-    #   name: "Android Instrumentation Tests"
-    #   jdk: oraclejdk8
+    # AVD config copied from leakcanary and informed by
+    # https://github.com/mikehardy/Anki-Android/blob/177c63d4eb969548ad7dc5243f0fac33522f3fe7/.travis.yml
+    - language: android
+      name: "Android Instrumentation Tests"
+      jdk: oraclejdk8
 
-    #   env:
-    #     - secure: "SWQBLsaI5fOfiM+48/oAOcynsnpa1hHADxs8Vsmt7gsqVrtL369znwsX+PkNOXTdAROPKHzfCw1PkMSKiWHwSB+Gc8fMqFoVjxPnpi0NAhm2b4q4pq6GLOed2xF93eLoQZ7x4UwcUie58Qlwif9ZSGyp+7V6fEy7/AexGLPAuD0="
-    #     - secure: "gFmZ18DktyZonExeAYGT4HtCodvAbRcH94AImWG6DrJZFzGkRSN//s1AjrgkAL/jZ4lLuoxyCs1nBoX2U83LmpJ8KxLIhU/45JlJgmD1tnE2zdFim6dHN+J6Yj7MCWqD5KO6E0dJickTJG2XzFu0oN3vBn7sETliQHzlw2lw8ME="
+      env:
+        - secure: "SWQBLsaI5fOfiM+48/oAOcynsnpa1hHADxs8Vsmt7gsqVrtL369znwsX+PkNOXTdAROPKHzfCw1PkMSKiWHwSB+Gc8fMqFoVjxPnpi0NAhm2b4q4pq6GLOed2xF93eLoQZ7x4UwcUie58Qlwif9ZSGyp+7V6fEy7/AexGLPAuD0="
+        - secure: "gFmZ18DktyZonExeAYGT4HtCodvAbRcH94AImWG6DrJZFzGkRSN//s1AjrgkAL/jZ4lLuoxyCs1nBoX2U83LmpJ8KxLIhU/45JlJgmD1tnE2zdFim6dHN+J6Yj7MCWqD5KO6E0dJickTJG2XzFu0oN3vBn7sETliQHzlw2lw8ME="
 
-    #     - ADB_INSTALL_TIMEOUT=8
-    #     - ABI=x86_64
-    #     - API=21
-    #     - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
-    #     # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
-    #     - ANDROID_HOME=/usr/local/android-sdk
-    #     - TOOLS=${ANDROID_HOME}/tools
-    #     - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
+        - ADB_INSTALL_TIMEOUT=8
+        - ABI=x86_64
+        - API=21
+        - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
+        # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
+        - ANDROID_HOME=/usr/local/android-sdk
+        - TOOLS=${ANDROID_HOME}/tools
+        - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
 
-    #   android:
-    #     components:
-    #       # installing tools to start, then use `sdkmanager` below to get the rest
-    #       - tools
+      android:
+        components:
+          # installing tools to start, then use `sdkmanager` below to get the rest
+          - tools
 
-    #   before_install:
-    #     - cd kotlin
-    #     # Install SDK license so Android Gradle plugin can install deps.
-    #     - mkdir "$ANDROID_HOME/licenses" || true
-    #     - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
-    #     - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
+      before_install:
+        - cd kotlin
+        # Install SDK license so Android Gradle plugin can install deps.
+        - mkdir "$ANDROID_HOME/licenses" || true
+        - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+        - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
 
-    #     # Emulator Management: Create, Start and Wait
-    #     # Do it in before_install to race with install.
-    #     - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid harmless sdkmanager warning
-    #     - echo y | sdkmanager "platform-tools" >/dev/null
-    #     - echo y | sdkmanager "tools" >/dev/null # A second time per Travis docs, gets latest versions
-    #     - echo y | sdkmanager "build-tools;28.0.3" >/dev/null # Implicit gradle dependency - gradle drives changes
-    #     - echo y | sdkmanager "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
-    #     - echo y | sdkmanager "platforms;android-28" >/dev/null # We need the API of the current compileSdkVersion from gradle.properties
-    #     - echo y | sdkmanager --channel=4 "emulator" # Experiment with canary, specifying 28.0.3 (prior version) did not work
-    #     - echo y | sdkmanager "extras;android;m2repository" >/dev/null
-    #     - echo y | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" #>/dev/null # install our emulator
-    #     - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
-    #     - emulator -verbose -avd test -no-accel -no-snapshot -no-window -no-audio -camera-back none -camera-front none -selinux permissive -qemu -m 2048 &
+        # Emulator Management: Create, Start and Wait
+        # Do it in before_install to race with install.
+        - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid harmless sdkmanager warning
+        - echo y | sdkmanager "platform-tools" >/dev/null
+        - echo y | sdkmanager "tools" >/dev/null # A second time per Travis docs, gets latest versions
+        - echo y | sdkmanager "build-tools;28.0.3" >/dev/null # Implicit gradle dependency - gradle drives changes
+        - echo y | sdkmanager "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
+        - echo y | sdkmanager "platforms;android-28" >/dev/null # We need the API of the current compileSdkVersion from gradle.properties
+        - echo y | sdkmanager --channel=4 "emulator" # Experiment with canary, specifying 28.0.3 (prior version) did not work
+        - echo y | sdkmanager "extras;android;m2repository" >/dev/null
+        - echo y | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" #>/dev/null # install our emulator
+        - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
+        - emulator -verbose -avd test -no-accel -no-snapshot -no-window -no-audio -camera-back none -camera-front none -selinux permissive -qemu -m 2048
 
-    #   install:
-    #     - ./gradlew clean
-    #     - ./gradlew assembleAndroidTest --stacktrace
+      install:
+        - ./gradlew clean
+        - ./gradlew assembleAndroidTest --stacktrace
 
-    #   before_script:
-    #     - android-wait-for-emulator
-    #     # 82 is KEYCODE_MENU. Everyone seems to send this. Does anyone know why?
-    #     - adb shell input keyevent 82
+      before_script:
+        - android-wait-for-emulator
+        # 82 is KEYCODE_MENU. Everyone seems to send this. Does anyone know why?
+        - adb shell input keyevent 82
 
-    #   script:
-    #     # Don't run build task again, since we don't want to do linting.
-    #     - ./gradlew connectedCheck
+      script:
+        # Don't run build task again, since we don't want to do linting.
+        - ./gradlew connectedCheck
 
-    #   cache:
-    #     directories:
-    #       - $HOME/.gradle/caches/
-    #       - $HOME/.gradle/wrapper/
-    #       - $HOME/.m2
+      cache:
+        directories:
+          - $HOME/.gradle/caches/
+          - $HOME/.gradle/wrapper/
+          - $HOME/.m2
 
     # Disabled due to https://github.com/square/workflow/issues/223
     # - language: swift

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,14 +129,22 @@ matrix:
         - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid harmless sdkmanager warning
         - echo y | sdkmanager "platform-tools" >/dev/null
         - echo y | sdkmanager "tools" >/dev/null # A second time per Travis docs, gets latest versions
-        - echo y | sdkmanager "build-tools;28.0.3" >/dev/null # Implicit gradle dependency - gradle drives changes
+        - echo y | sdkmanager "build-tools;29.0.2" >/dev/null # Implicit gradle dependency - gradle drives changes
         - echo y | sdkmanager "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
         - echo y | sdkmanager "platforms;android-28" >/dev/null # We need the API of the current compileSdkVersion from gradle.properties
-        - echo y | sdkmanager --channel=4 "emulator" # Experiment with canary, specifying 28.0.3 (prior version) did not work
         - echo y | sdkmanager "extras;android;m2repository" >/dev/null
         - echo y | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" #>/dev/null # install our emulator
-        - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
-        - emulator -verbose -avd test -no-accel -no-snapshot -no-window -no-audio -camera-back none -camera-front none -selinux permissive -qemu -m 2048
+
+        # Pin the emulator to 29.2.1.0 to work around https://issuetracker.google.com/issues/145622251.
+        # These commands replace this command:
+        # echo y | sdkmanager --channel=4 "emulator" # Experiment with canary, specifying 28.0.3 (prior version) did not work
+        - curl -fo emulator.zip "https://dl.google.com/android/repository/emulator-linux-5889189.zip"
+        - rm -rf "${ANDROID_HOME}/emulator"
+        - unzip -q emulator.zip -d "${ANDROID_HOME}"
+        - rm -f emulator.zip
+
+        - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI"
+        - emulator -verbose -avd test -no-window -no-audio
 
       install:
         - ./gradlew clean


### PR DESCRIPTION
Copied from https://github.com/square/leakcanary/pull/1665, which was
itself copied from https://github.com/coil-kt/coil/pull/195.

Fixes #759.