### PR TITLE
Soft-deprecate ViewRegistry

### DIFF
--- a/swift/Samples/SampleApp/Sources/AppDelegate.swift
+++ b/swift/Samples/SampleApp/Sources/AppDelegate.swift
@@ -28,7 +28,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         var viewRegistry = ViewRegistry()
         viewRegistry.registerDemoScreen()
-        viewRegistry.registerWelcomeScreen()
         viewRegistry.registerCrossFadeContainer()
         window?.rootViewController = ContainerViewController(
             workflow: RootWorkflow(),

--- a/swift/Samples/SampleApp/Sources/WelcomeScreen.swift
+++ b/swift/Samples/SampleApp/Sources/WelcomeScreen.swift
@@ -23,15 +23,11 @@ struct WelcomeScreen: Screen {
     var onLoginTapped: () -> Void
 }
 
-
-extension ViewRegistry {
-
-    public mutating func registerWelcomeScreen() {
-        self.register(screenViewControllerType: WelcomeViewController.self)
+extension WelcomeScreen {
+    var viewControllerDescription: ViewControllerDescription {
+        screenViewControllerDescription(for: WelcomeViewController.self)
     }
-
 }
-
 
 fileprivate final class WelcomeViewController: ScreenViewController<WelcomeScreen> {
     let welcomeLabel: UILabel

--- a/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
+++ b/swift/WorkflowUI/Sources/Container/ContainerViewController.swift
@@ -35,7 +35,7 @@ public final class ContainerViewController<Output, ScreenType>: UIViewController
 
     private let (lifetime, token) = Lifetime.make()
 
-    private init(workflowHost: Any, rendering: Property<ScreenType>, output: Signal<Output, Never>, viewRegistry: ViewRegistry) {
+    private init(workflowHost: Any, rendering: Property<ScreenType>, output: Signal<Output, Never>, viewRegistry: ViewRegistry = ViewRegistry()) {
         self.workflowHost = workflowHost
         self.rootViewController = viewRegistry.provideView(for: rendering.value)
         self.rendering = rendering

--- a/swift/WorkflowUI/Sources/Screen/Screen.swift
+++ b/swift/WorkflowUI/Sources/Screen/Screen.swift
@@ -19,4 +19,14 @@
 ///
 /// Conforming types contain any information needed to populate a screen: data,
 /// styling, event handlers, etc.
-public protocol Screen {}
+public protocol Screen {
+    /// Use `screenViewControllerDescription` to return the `ViewControllerDescription`
+    var viewControllerDescription: ViewControllerDescription { get }
+}
+
+/// Temporary extension to enable soft-migration from `ViewRegistry`.
+public extension Screen {
+    var viewControllerDescription: ViewControllerDescription {
+        fatalError("Return appropriate `ViewControllerDescription` from \(self)")
+    }
+}

--- a/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -23,7 +23,7 @@ import UIKit
 /// given screen type.
 open class ScreenViewController<ScreenType: Screen>: UIViewController {
 
-    public final let viewRegistry: ViewRegistry
+    public final var viewRegistry: ViewRegistry
 
     private var currentScreen: ScreenType
 
@@ -35,7 +35,7 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
         return ScreenType.self
     }
 
-    public required init(screen: ScreenType, viewRegistry: ViewRegistry) {
+    public required init(screen: ScreenType, viewRegistry: ViewRegistry = ViewRegistry()) {
         self.currentScreen = screen
         self.viewRegistry = viewRegistry
         super.init(nibName: nil, bundle: nil)
@@ -57,6 +57,15 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
 
     }
 
+}
+
+public extension Screen {
+    func screenViewControllerDescription<VC: ScreenViewController<Self>>(for type: VC.Type) -> ViewControllerDescription {
+        ViewControllerDescription(
+            builder: { VC(screen: self) },
+            updater: { $0.update(screen: self) }
+        )
+    }
 }
 
 #endif

--- a/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -61,7 +61,7 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
 
 public extension Screen {
     func screenViewControllerDescription<VC: ScreenViewController<Self>>(for type: VC.Type) -> ViewControllerDescription {
-        ViewControllerDescription(
+        return ViewControllerDescription(
             builder: { VC(screen: self) },
             updater: { $0.update(screen: self) }
         )

--- a/swift/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/swift/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -14,6 +14,12 @@
 * limitations under the License.
 */
 
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
 public struct ViewControllerDescription {
     #if canImport(UIKit)
     public typealias ViewController = UIViewController

--- a/swift/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/swift/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -24,7 +24,7 @@ public struct ViewControllerDescription {
     private let _build: () -> ViewController
     private let _update: (ViewController) -> Void
 
-    public init<VC: ViewController>(builder: @escaping () -> VC = { VC() }, updater: @escaping (VC) -> Void) {
+    public init<VC: ViewController>(builder: @escaping () -> VC = { VC.init() }, updater: @escaping (VC) -> Void) {
         _build = {
             builder()
         }

--- a/swift/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
+++ b/swift/WorkflowUI/Sources/ViewControllerDescription/ViewControllerDescription.swift
@@ -1,0 +1,54 @@
+/*
+* Copyright 2019 Square Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+public struct ViewControllerDescription {
+    #if canImport(UIKit)
+    public typealias ViewController = UIViewController
+    #elseif canImport(AppKit)
+    public typealias ViewController = NSViewController
+    #endif
+
+    private let _build: () -> ViewController
+    private let _update: (ViewController) -> Void
+
+    public init<VC: ViewController>(builder: @escaping () -> VC = { VC() }, updater: @escaping (VC) -> Void) {
+        _build = {
+            builder()
+        }
+        _update = { vc in
+            guard let vc = vc as? VC else {
+                fatalError("Unexpected type while updating screen for \(VC.self)")
+            }
+            updater(vc)
+        }
+        viewControllerType = VC.self
+    }
+
+    internal let viewControllerType: ViewController.Type
+
+    internal func canUpdate(viewController: ViewController) -> Bool {
+        return type(of: viewController) == viewControllerType
+    }
+
+    internal func build() -> ViewController {
+        return _build()
+    }
+
+    internal func update(viewController: ViewController) {
+        assert(type(of: viewController) == viewControllerType)
+        _update(viewController)
+    }
+}


### PR DESCRIPTION
Provides a path for `ViewRegistry` migration without any breaking API changes.

Individual `Screen`s can move from using `register(screenViewControllerType:)` to providing a `viewControllerDescription`.

Initializers for both `ScreenViewController` and `ContainerViewController` have default values for `ViewRegistry`.

This is an awkward intermediate step since we're not gaining any compile-time safety here and are introducing some dangerous side-effects like:
* a `ViewControllerDescription` described `ViewController` cannot build a new `ViewController` using the `ViewRegistry`, since it will not have the correct `ViewRegistry` on init.
* `ViewControllerDescription` can only return implementations of `ScreenViewController`, if not, we'll see a run-time error.

This is the Migration strategy 1 as described in #815 