### PR TITLE
BREAKING: WorkflowAction.Mutator deprecated by .Updater (#812, #813)

### DIFF
--- a/kotlin/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
+++ b/kotlin/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListWorkflow.kt
@@ -30,7 +30,7 @@ object PoemListWorkflow : StatelessWorkflow<List<Poem>, Int, PoemListRendering>(
     context: RenderContext<Nothing, Int>
   ): PoemListRendering {
     // A sink that emits the given index as the result of this workflow.
-    val sink = context.makeEventSink { index: Int -> index }
+    val sink = context.makeEventSink { index: Int -> setOutput(index) }
 
     return PoemListRendering(
         poems = props,

--- a/kotlin/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemsBrowserWorkflow.kt
+++ b/kotlin/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemsBrowserWorkflow.kt
@@ -21,14 +21,11 @@ import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
-import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.parse
 import com.squareup.workflow.ui.BackStackScreen
-import com.squareup.workflow.workflowAction
 
 typealias SelectedPoem = Int
-
-private typealias Action = WorkflowAction<SelectedPoem, Nothing>
 
 object PoemsBrowserWorkflow :
     StatefulWorkflow<List<Poem>, SelectedPoem, Nothing, MasterDetailScreen>() {
@@ -63,9 +60,8 @@ object PoemsBrowserWorkflow :
     sink.writeInt(state)
   }
 
-  private fun choosePoem(index: SelectedPoem): Action = workflowAction("goToPoem") {
-    state = index
-    null
+  private fun choosePoem(index: SelectedPoem) = action("goToPoem") {
+    nextState = index
   }
 
   private val clearSelection = choosePoem(-1)

--- a/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
+++ b/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION", "OverridingDeprecatedMember")
+
 package com.squareup.sample.poetry
 
 import com.squareup.sample.container.masterdetail.MasterDetailScreen
@@ -112,6 +114,8 @@ object PoemWorkflow : StatefulWorkflow<Poem, Int, ClosePoem, MasterDetailScreen>
     class HandleStanzaListOutput(val selection: Int) : Action()
     object ExitPoem : Action()
 
+    // We continue to use the deprecated method here for one more release, to demonstrate
+    // that the migration mechanism works.
     override fun Mutator<Int>.apply(): ClosePoem? {
       when (this@Action) {
         ClearSelection -> state = -1

--- a/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
+++ b/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListWorkflow.kt
@@ -32,7 +32,7 @@ object StanzaListWorkflow : StatelessWorkflow<Poem, Int, StanzaListRendering>() 
     context: RenderContext<Nothing, Int>
   ): StanzaListRendering {
     // A sink that emits the given index as the result of this workflow.
-    val sink = context.makeEventSink { index: Int -> index }
+    val sink = context.makeEventSink { index: Int -> setOutput(index) }
 
     return StanzaListRendering(
         title = props.title,

--- a/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -44,7 +44,7 @@ object StanzaWorkflow : StatelessWorkflow<Props, Output, StanzaRendering>() {
     context: RenderContext<Nothing, Output>
   ): StanzaRendering {
     with(props) {
-      val sink: Sink<Output> = context.makeEventSink { it }
+      val sink: Sink<Output> = context.makeEventSink { setOutput(it) }
 
       val onGoBack: (() -> Unit)? = when (index) {
         0 -> null

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
@@ -29,7 +29,7 @@ import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowAction.Companion.noAction
-import com.squareup.workflow.WorkflowAction.Mutator
+import com.squareup.workflow.WorkflowAction.Updater
 import com.squareup.workflow.ui.AlertContainerScreen
 import com.squareup.workflow.ui.AlertScreen
 import com.squareup.workflow.ui.AlertScreen.Button.POSITIVE
@@ -97,9 +97,8 @@ class DungeonAppWorkflow(
   override fun snapshotState(state: State): Snapshot = Snapshot.EMPTY
 
   private class StartRunning(val board: Board) : WorkflowAction<State, Nothing> {
-    override fun Mutator<State>.apply(): Nothing? {
-      state = Running(board)
-      return null
+    override fun Updater<State, Nothing>.apply() {
+      nextState = Running(board)
     }
   }
 
@@ -107,11 +106,11 @@ class DungeonAppWorkflow(
     val output: GameWorkflow.Output,
     val board: Board
   ) : WorkflowAction<State, Nothing> {
-    override fun Mutator<State>.apply(): Nothing? {
+    override fun Updater<State, Nothing>.apply() {
       when (output) {
         Vibrate -> vibrate(50)
         PlayerWasEaten -> {
-          state = GameOver(board)
+          nextState = GameOver(board)
           vibrate(20)
           vibrate(20)
           vibrate(20)
@@ -119,14 +118,12 @@ class DungeonAppWorkflow(
           vibrate(1000)
         }
       }
-      return null
     }
   }
 
   private object RestartGame : WorkflowAction<State, Nothing> {
-    override fun Mutator<State>.apply(): Nothing? {
-      state = Loading
-      return null
+    override fun Updater<State, Nothing>.apply() {
+      nextState = Loading
     }
   }
 

--- a/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
+++ b/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/AiWorkflow.kt
@@ -27,8 +27,8 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Worker
+import com.squareup.workflow.action
 import com.squareup.workflow.transform
-import com.squareup.workflow.workflowAction
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.transform
 import kotlin.random.Random
@@ -76,18 +76,16 @@ class AiWorkflow(
 
   override fun snapshotState(state: State): Snapshot = Snapshot.EMPTY
 
-  private val updateDirection = workflowAction("updateDirection") {
+  private val updateDirection = action("updateDirection") {
     // Rotate 90 degrees.
-    val newDirection = when (state.direction) {
+    val newDirection = when (nextState.direction) {
       UP -> RIGHT
       RIGHT -> DOWN
       DOWN -> LEFT
       LEFT -> UP
     }
 
-    state = state.copy(direction = newDirection)
-
-    null
+    nextState = nextState.copy(direction = newDirection)
   }
 }
 

--- a/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
+++ b/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/GameWorkflow.kt
@@ -34,8 +34,8 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Worker
+import com.squareup.workflow.action
 import com.squareup.workflow.renderChild
-import com.squareup.workflow.workflowAction
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -158,7 +158,7 @@ class GameWorkflow(
     playerRendering: Rendering,
     board: Board,
     aiRenderings: List<Pair<Location, ActorRendering>>
-  ) = workflowAction("updateGame") {
+  ) = action("updateGame") {
     // Calculate if this tick should result in movement based on the movement's speed.
     fun Movement.isTimeToMove(): Boolean {
       val ticksPerCell = (ticksPerSecond / cellsPerSecond).roundToLong()
@@ -191,12 +191,12 @@ class GameWorkflow(
     )
 
     // Check if AI captured player.
-    return@workflowAction if (newGame.isPlayerEaten) {
-      state = state.copy(game = newGame)
-      PlayerWasEaten
+    if (newGame.isPlayerEaten) {
+      nextState = nextState.copy(game = newGame)
+      setOutput(PlayerWasEaten)
     } else {
-      state = state.copy(game = newGame)
-      output
+      nextState = nextState.copy(game = newGame)
+      output?.let { setOutput(it) }
     }
   }
 }

--- a/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
+++ b/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
@@ -25,7 +25,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.WorkflowAction.Mutator
+import com.squareup.workflow.WorkflowAction.Updater
 
 /**
  * Workflow that represents the actual player of the game in the [GameWorkflow].
@@ -38,16 +38,14 @@ class PlayerWorkflow(
   sealed class Action : WorkflowAction<Movement, Nothing> {
 
     class StartMoving(private val direction: Direction) : Action() {
-      override fun Mutator<Movement>.apply(): Nothing? {
-        state += direction
-        return null
+      override fun Updater<Movement, Nothing>.apply() {
+        nextState += direction
       }
     }
 
     class StopMoving(private val direction: Direction) : Action() {
-      override fun Mutator<Movement>.apply(): Nothing? {
-        state -= direction
-        return null
+      override fun Updater<Movement, Nothing>.apply() {
+        nextState -= direction
       }
     }
   }

--- a/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
+++ b/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
@@ -26,8 +26,8 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.WorkflowAction.Mutator
-import com.squareup.workflow.workflowAction
+import com.squareup.workflow.WorkflowAction.Updater
+import com.squareup.workflow.action
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -39,7 +39,7 @@ import kotlin.time.ExperimentalTime
  * This workflow takes a [PropsFactory] as its props. See that class for more documentation.
  */
 @ExperimentalTime
-class ShakeableTimeMachineWorkflow<in P, out O : Any, out R : Any>(
+class ShakeableTimeMachineWorkflow<in P, O : Any, out R : Any>(
   private val timeMachineWorkflow: TimeMachineWorkflow<P, O, R>,
   context: Context
 ) : StatefulWorkflow<PropsFactory<P>, State, O, ShakeableTimeMachineRendering>() {
@@ -119,26 +119,23 @@ class ShakeableTimeMachineWorkflow<in P, out O : Any, out R : Any>(
     )
   }
 
-  private val onShake = workflowAction {
-    state = PlayingBack(Duration.INFINITE)
-    return@workflowAction null
+  private val onShake = action {
+    nextState = PlayingBack(Duration.INFINITE)
   }
 
   private inner class SeekAction(
     private val newPosition: Duration
   ) : WorkflowAction<State, O> {
-    override fun Mutator<State>.apply(): O? {
-      state = PlayingBack(newPosition)
-      return null
+    override fun Updater<State, O>.apply() {
+      nextState = PlayingBack(newPosition)
     }
   }
 
   private inner class ResumeRecordingAction : WorkflowAction<State, O> {
-    override fun Mutator<State>.apply(): O? {
-      state = Recording
-      return null
+    override fun Updater<State, O>.apply() {
+      nextState = Recording
     }
   }
 
-  private fun forwardOutput(output: O) = workflowAction { output }
+  private fun forwardOutput(output: O) = action { setOutput(output) }
 }

--- a/kotlin/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
+++ b/kotlin/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/TimeMachineWorkflow.kt
@@ -24,7 +24,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.StatelessWorkflow
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.WorkflowAction.Mutator
+import com.squareup.workflow.WorkflowAction.Updater
 import com.squareup.workflow.renderChild
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -42,7 +42,7 @@ import kotlin.time.ExperimentalTime
  * @param clock The [Clock] to use to assign timestamps to recorded values.
  */
 @ExperimentalTime
-class TimeMachineWorkflow<P, out O : Any, out R>(
+class TimeMachineWorkflow<P, O : Any, out R>(
   private val delegateWorkflow: Workflow<P, O, R>,
   clock: Clock
 ) : StatelessWorkflow<TimeMachineProps<P>, O, TimeMachineRendering<R>>() {
@@ -100,6 +100,8 @@ class TimeMachineWorkflow<P, out O : Any, out R>(
   }
 
   private fun forwardOutput(output: O) = object : WorkflowAction<Nothing, O> {
-    override fun Mutator<Nothing>.apply(): O? = output
+    override fun Updater<Nothing, O>.apply() {
+      setOutput(output)
+    }
   }
 }

--- a/kotlin/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
+++ b/kotlin/samples/dungeon/timemachine/src/test/java/com/squareup/sample/timemachine/TimeMachineWorkflowTest.kt
@@ -42,7 +42,7 @@ class TimeMachineWorkflowTest {
     val delegateWorkflow = Workflow.stateful<String, Nothing, DelegateRendering>(
         initialState = "initial",
         render = { state ->
-          val sink: Sink<String> = makeEventSink { this.state = it; null }
+          val sink: Sink<String> = makeEventSink { nextState = it }
           DelegateRendering(state, setState = { sink.send(it) })
         }
     )

--- a/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
+++ b/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/BlinkingCursorWorkflow.kt
@@ -19,7 +19,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Worker
-import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import kotlinx.coroutines.delay
 
 /**
@@ -58,8 +58,7 @@ class BlinkingCursorWorkflow(
 
   override fun snapshotState(state: Boolean): Snapshot = Snapshot.EMPTY
 
-  private fun setCursorShowing(showing: Boolean) = WorkflowAction<Boolean, Nothing> {
-    state = showing
-    null
+  private fun setCursorShowing(showing: Boolean) = action {
+    nextState = showing
   }
 }

--- a/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
+++ b/kotlin/samples/hello-terminal/hello-terminal-app/src/main/java/com/squareup/sample/helloterminal/HelloTerminalWorkflow.kt
@@ -27,8 +27,8 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.renderChild
-import com.squareup.workflow.runningWorker
 
 private typealias HelloTerminalAction = WorkflowAction<State, ExitCode>
 
@@ -76,13 +76,11 @@ class HelloTerminalWorkflow : TerminalWorkflow,
 
   override fun snapshotState(state: State): Snapshot = Snapshot.EMPTY
 
-  private fun onKeystroke(key: KeyStroke): HelloTerminalAction = WorkflowAction {
+  private fun onKeystroke(key: KeyStroke): HelloTerminalAction = action {
     when {
-      key.character == 'Q' -> return@WorkflowAction 0
-      key.keyType == Backspace -> state = state.backspace()
-      key.character != null -> state = state.append(key.character!!)
+      key.character == 'Q' -> setOutput(0)
+      key.keyType == Backspace -> nextState = nextState.backspace()
+      key.character != null -> nextState = nextState.append(key.character!!)
     }
-
-    null
   }
 }

--- a/kotlin/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
+++ b/kotlin/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/EditTextWorkflow.kt
@@ -11,8 +11,7 @@ import com.squareup.sample.hellotodo.EditTextWorkflow.EditTextState
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
-import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.runningWorker
+import com.squareup.workflow.action
 
 class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, String>() {
 
@@ -61,35 +60,29 @@ class EditTextWorkflow : StatefulWorkflow<EditTextProps, EditTextState, String, 
   }
 
   override fun snapshotState(state: EditTextState): Snapshot = Snapshot.EMPTY
-}
 
-private fun onKeystroke(
-  props: EditTextProps,
-  key: KeyStroke
-) = WorkflowAction<EditTextState, String> {
-  when (key.keyType) {
-    Character -> {
-      state = moveCursor(props, state, 1)
-      props.text.insertCharAt(state.cursorPosition, key.character!!)
-    }
+  private fun onKeystroke(
+    props: EditTextProps,
+    key: KeyStroke
+  ) = action {
+    when (key.keyType) {
+      Character -> {
+        nextState = moveCursor(props, nextState, 1)
+        props.text.insertCharAt(nextState.cursorPosition, key.character!!)
+      }
 
-    Backspace -> {
-      if (props.text.isEmpty()) {
-        null
-      } else {
-        state = moveCursor(props, state, -1)
-        props.text.removeRange(state.cursorPosition - 1, state.cursorPosition)
+      Backspace -> {
+        if (props.text.isNotEmpty()) {
+          nextState = moveCursor(props, nextState, -1)
+          props.text.removeRange(nextState.cursorPosition - 1, nextState.cursorPosition)
+        }
+      }
+      ArrowLeft -> nextState = moveCursor(props, nextState, -1)
+      ArrowRight -> nextState = moveCursor(props, nextState, 1)
+      else -> {
+        // Nothing to do.
       }
     }
-    ArrowLeft -> {
-      state = moveCursor(props, state, -1)
-      null
-    }
-    ArrowRight -> {
-      state = moveCursor(props, state, 1)
-      null
-    }
-    else -> null
   }
 }
 

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
@@ -23,6 +23,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.parse
 
 object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
@@ -41,9 +42,8 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
     val onClick: () -> Unit
   )
 
-  private val helloAction = WorkflowAction<State, Nothing> {
-    state = state.theOtherState()
-    null
+  private val helloAction = action {
+    nextState = nextState.theOtherState()
   }
 
   override fun initialState(

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
@@ -21,10 +21,10 @@ import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowFragment
 import com.squareup.workflow.ui.WorkflowRunner
 
-class HelloWorkflowFragment : WorkflowFragment<Unit, Unit>() {
+class HelloWorkflowFragment : WorkflowFragment<Unit, Nothing>() {
   override val containerHints = ContainerHints(ViewRegistry(HelloFragmentLayoutRunner))
 
-  override fun onCreateWorkflow(): WorkflowRunner.Config<Unit, Unit> {
+  override fun onCreateWorkflow(): WorkflowRunner.Config<Unit, Nothing> {
     return WorkflowRunner.Config(
         HelloWorkflow, diagnosticListener = SimpleLoggingDiagnosticListener()
     )

--- a/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
+++ b/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
@@ -23,6 +23,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.parse
 
 object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
@@ -41,9 +42,8 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
     val onClick: () -> Unit
   )
 
-  private val helloAction = WorkflowAction<State, Nothing> {
-    state = state.theOtherState()
-    null
+  private val helloAction = action {
+    nextState = nextState.theOtherState()
   }
 
   override fun initialState(

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
@@ -32,7 +32,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.WorkflowAction.Mutator
+import com.squareup.workflow.WorkflowAction.Updater
 import com.squareup.workflow.renderChild
 import com.squareup.workflow.ui.HasModals
 
@@ -78,12 +78,11 @@ object AppWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
     object ShowAddRowAction : Action()
     data class CommitNewRowAction(val index: Int) : Action()
 
-    override fun Mutator<State>.apply(): Nothing? {
-      state = when (this@Action) {
-        ShowAddRowAction -> ChooseNewRow(state.rows)
-        is CommitNewRowAction -> ShowList(state.rows + allRowTypes[index])
+    override fun Updater<State, Nothing>.apply() {
+      nextState = when (this@Action) {
+        ShowAddRowAction -> ChooseNewRow(nextState.rows)
+        is CommitNewRowAction -> ShowList(nextState.rows + allRowTypes[index])
       }
-      return null
     }
   }
 

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListWorkflow.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListWorkflow.kt
@@ -23,7 +23,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.workflowAction
+import com.squareup.workflow.action
 
 object EditableListWorkflow : StatefulWorkflow<Props, State, Nothing, Rendering>() {
 
@@ -78,10 +78,9 @@ object EditableListWorkflow : StatefulWorkflow<Props, State, Nothing, Rendering>
   private fun valueChangedAction(
     position: Int,
     newValue: Any?
-  ) = workflowAction {
-    state = state.copy(rowValues = state.rowValues.mapIndexed { index, value ->
+  ) = action {
+    nextState = nextState.copy(rowValues = nextState.rowValues.mapIndexed { index, value ->
       if (index == position) value.withValue(newValue) else value
     })
-    return@workflowAction null
   }
 }

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.squareup.sample.mainworkflow
 
 import com.squareup.sample.authworkflow.AuthResult
@@ -102,9 +104,12 @@ class MainWorkflow(
 
   override fun snapshotState(state: MainState): Snapshot = state.toSnapshot()
 
+  // We continue to use the deprecated method here for one more release, to demonstrate
+  // that the migration mechanism works.
+
   private val startAuth = workflowAction {
     state = Authenticating
-    null
+    return@workflowAction null
   }
 
   private fun handleAuthResult(result: AuthResult) = workflowAction {
@@ -112,6 +117,6 @@ class MainWorkflow(
       is Canceled -> return@workflowAction Unit
       is Authorized -> state = RunningGame
     }
-    null
+    return@workflowAction null
   }
 }

--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
@@ -3,10 +3,10 @@ package com.squareup.sample.mainworkflow
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sample.authworkflow.AuthResult.Authorized
 import com.squareup.sample.authworkflow.AuthWorkflow
+import com.squareup.sample.container.panel.PanelContainerScreen
 import com.squareup.sample.gameworkflow.GamePlayScreen
 import com.squareup.sample.gameworkflow.RunGameScreen
 import com.squareup.sample.gameworkflow.RunGameWorkflow
-import com.squareup.sample.container.panel.PanelContainerScreen
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
@@ -37,7 +37,7 @@ class MainWorkflowTest {
   @Test fun `starts game on auth`() {
     val authWorkflow: AuthWorkflow = Workflow.stateless {
       runningWorker(Worker.from { Unit }) {
-        WorkflowAction<Nothing, Authorized> { Authorized("auth") }
+        WorkflowAction { setOutput(Authorized("auth")) }
       }
       authScreen()
     }

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -26,7 +26,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Sink
 import com.squareup.workflow.StatelessWorkflow
 import com.squareup.workflow.WorkflowAction
-import com.squareup.workflow.WorkflowAction.Mutator
+import com.squareup.workflow.WorkflowAction.Updater
 
 data class TodoList(
   val title: String,
@@ -66,14 +66,14 @@ sealed class TodoAction : WorkflowAction<Nothing, TodoEditorOutput> {
     ) : ListAction()
   }
 
-  override fun Mutator<Nothing>.apply(): TodoEditorOutput {
-    return when (this@TodoAction) {
+  override fun Updater<Nothing, TodoEditorOutput>.apply() {
+    when (this@TodoAction) {
       is GoBackClicked -> Done
       is TitleChanged -> ListUpdated(list.copy(title = newTitle))
       is DoneClicked -> ListUpdated(list.updateRow(index) { copy(done = !done) })
       is TextChanged -> ListUpdated(list.updateRow(index) { copy(text = newText) })
       is DeleteClicked -> ListUpdated(list.removeRow(index))
-    }
+    }.let { setOutput(it) }
   }
 }
 

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -24,6 +24,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.ui.BackStackScreen
 
 private typealias TodoListsAction = WorkflowAction<TodoListsAppState, Nothing>
@@ -59,22 +60,20 @@ object TodoListsAppWorkflow :
   private val listsWorkflow = TodoListsWorkflow()
   private val editorWorkflow = TodoEditorWorkflow()
 
-  private fun onListSelected(index: Int): TodoListsAction = WorkflowAction {
-    state = EditingList(state.lists, index)
-    null
+  private fun onListSelected(index: Int): TodoListsAction = action {
+    nextState = EditingList(nextState.lists, index)
   }
 
   private fun onEditOutput(output: TodoEditorOutput): TodoListsAction = WorkflowAction {
-    state = when (output) {
+    nextState = when (output) {
       is ListUpdated -> {
-        val oldState = state as EditingList
+        val oldState = nextState as EditingList
         oldState.copy(
-            lists = state.lists.updateRow(oldState.editingIndex, output.newList)
+            lists = nextState.lists.updateRow(oldState.editingIndex, output.newList)
         )
       }
-      Done -> ShowingLists(state.lists)
+      Done -> ShowingLists(nextState.lists)
     }
-    null
   }
 
   override fun render(

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsWorkflow.kt
@@ -25,8 +25,8 @@ class TodoListsWorkflow : StatelessWorkflow<List<TodoList>, Int, TodoListsScreen
     props: List<TodoList>,
     context: RenderContext<Nothing, Int>
   ): TodoListsScreen {
-    // A sink that emits the given index as the result of this workflow.
-    val sink: Sink<Int> = context.makeEventSink { index: Int -> index }
+    // A sink that emits the given index as the output of this workflow.
+    val sink: Sink<Int> = context.makeEventSink { index: Int -> setOutput(index) }
 
     return TodoListsScreen(lists = props, onRowClicked = sink::send)
   }

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -18,7 +18,7 @@
 package com.squareup.workflow
 
 import com.squareup.workflow.WorkflowAction.Companion.noAction
-import com.squareup.workflow.WorkflowAction.Mutator
+import com.squareup.workflow.WorkflowAction.Updater
 
 /**
  * Facilities for a [Workflow] to interact with other [Workflow]s and the outside world from inside
@@ -36,7 +36,7 @@ import com.squareup.workflow.WorkflowAction.Mutator
  *
  * See [renderChild].
  */
-interface RenderContext<StateT, in OutputT : Any> {
+interface RenderContext<StateT, OutputT : Any> {
 
   @Deprecated("Use makeActionSink.")
   fun <EventT : Any> onEvent(
@@ -162,12 +162,12 @@ fun <StateT, OutputT : Any> RenderContext<StateT, OutputT>.runningWorker(
  * event types to be mapped to anonymous [WorkflowAction]s.
  */
 fun <EventT, StateT, OutputT : Any> RenderContext<StateT, OutputT>.makeEventSink(
-  block: Mutator<StateT>.(EventT) -> OutputT?
+  update: Updater<StateT, OutputT>.(EventT) -> Unit
 ): Sink<EventT> {
   val actionSink = makeActionSink<WorkflowAction<StateT, OutputT>>()
 
   return actionSink.contraMap { event ->
-    WorkflowAction({ "eventSink($event)" }) { block(event) }
+    WorkflowAction({ "eventSink($event)" }) { update(event) }
   }
 }
 

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -74,7 +74,7 @@ package com.squareup.workflow
  * @see StatefulWorkflow
  * @see StatelessWorkflow
  */
-interface Workflow<in PropsT, out OutputT : Any, out RenderingT> {
+interface Workflow<in PropsT, OutputT : Any, out RenderingT> {
 
   /**
    * Provides a [StatefulWorkflow] view of this workflow. Necessary because [StatefulWorkflow] is

--- a/kotlin/workflow-runtime/src/jmh/java/com/squareup/workflow/WorkflowNodeBenchmark.kt
+++ b/kotlin/workflow-runtime/src/jmh/java/com/squareup/workflow/WorkflowNodeBenchmark.kt
@@ -74,7 +74,7 @@ open class WorkflowNodeBenchmark {
   @JvmField var treeShape = TreeShape.SQUARE
 
   private lateinit var workflow: FractalWorkflow
-  private lateinit var node: WorkflowNode<Props, Unit, *, Unit>
+  private lateinit var node: WorkflowNode<Props, Unit, Nothing, Unit>
 
   @Setup open fun setUp() {
     println("Tree shape: $treeShape")

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Behavior.kt
@@ -26,7 +26,7 @@ import com.squareup.workflow.WorkflowAction
  *
  * @see RealRenderContext
  */
-data class Behavior<StateT, out OutputT : Any> internal constructor(
+data class Behavior<StateT, OutputT : Any> internal constructor(
   val childCases: List<WorkflowOutputCase<*, *, StateT, OutputT>>,
   val workerCases: List<WorkerCase<*, StateT, OutputT>>
 ) {
@@ -36,7 +36,7 @@ data class Behavior<StateT, out OutputT : Any> internal constructor(
       ChildPropsT,
       ChildOutputT : Any,
       ParentStateT,
-      out ParentOutputT : Any
+      ParentOutputT : Any
       > internal constructor(
         val workflow: Workflow<*, ChildOutputT, *>,
         val id: WorkflowId<ChildPropsT, ChildOutputT, *>,
@@ -49,7 +49,7 @@ data class Behavior<StateT, out OutputT : Any> internal constructor(
       }
       // @formatter:on
 
-  data class WorkerCase<T, StateT, out OutputT : Any> internal constructor(
+  data class WorkerCase<T, StateT, OutputT : Any> internal constructor(
     val worker: Worker<T>,
     val key: String,
     val handler: (T) -> WorkflowAction<StateT, OutputT>

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -38,7 +38,7 @@ class RealRenderContext<StateT, OutputT : Any>(
   private val eventActionsChannel: SendChannel<WorkflowAction<StateT, OutputT>>
 ) : RenderContext<StateT, OutputT> {
 
-  interface Renderer<StateT, in OutputT : Any> {
+  interface Renderer<StateT, OutputT : Any> {
     fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> render(
       case: WorkflowOutputCase<ChildPropsT, ChildOutputT, StateT, OutputT>,
       child: Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>,

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowId.kt
@@ -29,7 +29,7 @@ internal typealias AnyId = WorkflowId<*, *, *>
  * Value type that can be used to distinguish between different workflows of different types or
  * the same type (in that case using a [name]).
  */
-data class WorkflowId<in PropsT, out OutputT : Any, out RenderingT>
+data class WorkflowId<in PropsT, OutputT : Any, out RenderingT>
 @PublishedApi
 internal constructor(
   internal val type: KClass<out Workflow<PropsT, OutputT, RenderingT>>,

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -21,6 +21,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Sink
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.applyTo
 import com.squareup.workflow.internal.Behavior.WorkflowOutputCase
@@ -60,7 +61,7 @@ class SubtreeManagerTest {
       state: String,
       context: RenderContext<String, String>
     ): Rendering {
-      val sink: Sink<String> = context.makeEventSink { it }
+      val sink: Sink<String> = context.makeEventSink { setOutput(it) }
       return Rendering(props, state) { sink.send("workflow output:$it") }
     }
 
@@ -140,7 +141,7 @@ class SubtreeManagerTest {
     val id = workflow.id()
     val props = "props"
     val case = WorkflowOutputCase<String, String, String, String>(workflow, id, props) { output ->
-      WorkflowAction { "case output:$output" }
+      WorkflowAction { setOutput("case output:$output") }
     }
 
     // Initialize the child so tickChildren has something to work with, and so that we can send
@@ -169,7 +170,12 @@ class SubtreeManagerTest {
     val manager = SubtreeManager<Unit, Nothing>(Unconfined, parentDiagnosticId = 0)
     val workflow = SnapshotTestWorkflow()
     val id = workflow.id("1")
-    val case = WorkflowOutputCase<Unit, Unit, Unit, Nothing>(workflow, id, Unit) { fail() }
+    @Suppress("UNCHECKED_CAST")
+    val case = WorkflowOutputCase<Unit, Unit, Unit, Nothing>(
+        workflow as Workflow<*, Unit, *>,
+        id as WorkflowId<Unit, Unit, *>,
+        Unit
+    ) { fail() }
     assertEquals(0, workflow.snapshots)
 
     manager.track(listOf(case))
@@ -182,7 +188,11 @@ class SubtreeManagerTest {
     val manager = SubtreeManager<Unit, Nothing>(Unconfined, parentDiagnosticId = 0)
     val workflow = SnapshotTestWorkflow()
     val id = workflow.id("1")
-    val case = WorkflowOutputCase<Unit, Unit, Unit, Nothing>(workflow, id, Unit) { fail() }
+    @Suppress("UNCHECKED_CAST")
+    val case = WorkflowOutputCase<Unit, Unit, Unit, Nothing>(
+        workflow as Workflow<*, Unit, *>,
+        id as WorkflowId<Unit, Unit, *>,
+        Unit) { fail() }
     assertEquals(0, workflow.serializes)
 
     manager.track(listOf(case))

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowDiagnosticListenerIntegrationTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowDiagnosticListenerIntegrationTest.kt
@@ -189,7 +189,7 @@ class WorkflowDiagnosticListenerIntegrationTest {
   @Test fun `workflow updates emit events in order`() {
     val channel = Channel<String>()
     val worker = channel.asWorker()
-    fun action(value: String) = WorkflowAction<Nothing, String> { "output:$value" }
+    fun action(value: String) = WorkflowAction<Nothing, String> { setOutput("output:$value") }
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningWorker(worker, "key", ::action)
     }

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
@@ -21,7 +21,7 @@ class PublisherWorkerTest {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker === this
     }
 
-    fun action(value: String) = WorkflowAction<Nothing, String> { value }
+    fun action(value: String) = WorkflowAction<Nothing, String> { setOutput(value) }
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningWorker(worker) { action(it) }
     }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
@@ -76,8 +76,7 @@ internal class TreeWorkflow(
       it.writeUtf8WithLength(state)
     }
 
-  private fun onEvent(newState: String) = workflowAction {
-    state = newState
-    null
+  private fun onEvent(newState: String) = action {
+    nextState = newState
   }
 }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -131,7 +131,7 @@ class WorkerCompositionIntegrationTest {
   @Test fun `runningWorker gets output`() {
     val worker = WorkerSink<String>("")
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(worker) { WorkflowAction { it } }
+      runningWorker(worker) { WorkflowAction { setOutput(it) } }
     }
 
     workflow.testFromStart {
@@ -146,7 +146,7 @@ class WorkerCompositionIntegrationTest {
   @Test fun `runningWorker gets error`() {
     val channel = Channel<String>()
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(channel.asWorker()) { WorkflowAction { it } }
+      runningWorker(channel.asWorker()) { WorkflowAction { setOutput(it) } }
     }
 
     assertFailsWith<ExpectedException> {
@@ -181,14 +181,13 @@ class WorkerCompositionIntegrationTest {
     val triggerOutput = WorkerSink<Unit>("")
 
     val incrementState = WorkflowAction<Int, Int> {
-      state += 1
-      null
+      nextState += 1
     }
 
     val workflow = Workflow.stateful<Int, Int, () -> Unit>(
         initialState = 0,
         render = { state ->
-          runningWorker(triggerOutput) { WorkflowAction { state } }
+          runningWorker(triggerOutput) { WorkflowAction { setOutput(state) } }
 
           val sink = makeActionSink<WorkflowAction<Int, Int>>()
           return@stateful { sink.send(incrementState) }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerStressTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerStressTest.kt
@@ -25,7 +25,7 @@ class WorkerStressTest {
       channel.asWorker()
           .transform { it.onCompletion { emit(Unit) } }
     }
-    val action = WorkflowAction<Nothing, Unit> { Unit }
+    val action = WorkflowAction<Nothing, Unit> { setOutput(Unit) }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
       // Run lots of workers that will all see the same close event.
       workers.forEachIndexed { i, worker ->
@@ -57,7 +57,7 @@ class WorkerStressTest {
   @Test fun `multiple subscriptions to single channel when emits`() {
     val channel = ConflatedBroadcastChannel(Unit)
     val workers = List(100) { channel.asWorker() }
-    val action = WorkflowAction<Nothing, Int> { 1 }
+    val action = WorkflowAction<Nothing, Int> { setOutput(1) }
     val workflow = Workflow.stateless<Unit, Int, Unit> {
       // Run lots of workers that will all see the same conflated channel value.
       workers.forEachIndexed { i, worker ->

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
@@ -104,16 +104,15 @@ class WorkflowCompositionIntegrationTest {
   @Test fun `renderChild closes over latest state`() {
     val triggerChildOutput = WorkerSink<Unit>("")
     val child = Workflow.stateless<Unit, Unit, Unit> {
-      runningWorker(triggerChildOutput) { WorkflowAction { Unit } }
+      runningWorker(triggerChildOutput) { WorkflowAction { setOutput(Unit) } }
     }
-    val incrementState = WorkflowAction<Int, Nothing> {
-      state += 1
-      null
+    val incrementState = WorkflowAction<Int, Int> {
+      nextState += 1
     }
     val workflow = Workflow.stateful<Int, Int, () -> Unit>(
         initialState = 0,
         render = { state ->
-          renderChild(child) { WorkflowAction { state } }
+          renderChild(child) { WorkflowAction { setOutput(state) } }
           val sink = makeActionSink<WorkflowAction<Int, Int>>()
           return@stateful { sink.send(incrementState) }
         }

--- a/kotlin/workflow-tracing/src/test/java/com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListenerTest.kt
+++ b/kotlin/workflow-tracing/src/test/java/com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListenerTest.kt
@@ -20,7 +20,7 @@ import com.squareup.tracing.TraceEncoder
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
-import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.asWorker
 import com.squareup.workflow.launchWorkflowIn
 import kotlinx.coroutines.CoroutineScope
@@ -131,7 +131,7 @@ class TracingDiagnosticListenerTest {
 
     override fun snapshotState(state: String): Snapshot = Snapshot.EMPTY
 
-    private fun bubbleUp(output: String) = WorkflowAction<String, String>({ "action" }) { output }
+    private fun bubbleUp(output: String) = action { setOutput(output) }
   }
 }
 

--- a/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
+++ b/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
@@ -35,8 +35,6 @@ import org.junit.Test
 class WorkflowRunnerViewModelTest {
 
   private val scope = CoroutineScope(Unconfined)
-  @Suppress("RemoveRedundantSpreadOperator")
-  private val viewRegistry = ViewRegistry(*emptyArray<ViewBinding<*>>())
 
   @Test fun snapshotUpdatedOnHostEmission() {
     val snapshot1 = Snapshot.of("one")
@@ -108,7 +106,7 @@ class WorkflowRunnerViewModelTest {
     val outputs = BroadcastChannel<String>(1)
     val runner = Workflow
         .stateless<Unit, String, Unit> {
-          runningWorker(outputs.asWorker()) { WorkflowAction { it } }
+          runningWorker(outputs.asWorker()) { WorkflowAction { setOutput(it) } }
           Unit
         }
         .run()
@@ -124,7 +122,7 @@ class WorkflowRunnerViewModelTest {
   @Test fun resultEmptyOnCleared() {
     val runner = Workflow
         .stateless<Unit, String, Unit> {
-          runningWorker(flowNever<String>().asWorker()) { WorkflowAction { it } }
+          runningWorker(flowNever<String>().asWorker()) { WorkflowAction { setOutput(it) } }
         }
         .run()
 


### PR DESCRIPTION
First chunk of the work to reduce Kotlin's boilerplate and weirdness around
`WorkflowAction`, tracked by issue #812.

`Updater` has two fields for the action's `apply()` method to work with,
`var nextState`, and a write-only output field set via `setOutput()`.
This has two benefits:

 * You no longer use `return` to provide an output value.
 * Since `nextState` does not conflict with the `state`  argument of
   `render` methods, inline actions should be less painful, and people can
   stop telling us how terrible it was that we deprecated `emitState` and
   `emitOutput`.

Also adds `StatefulWorkflow.action` and `StatelessWorkflow.action` extension
functions. `StatefulWorkflow.workflowAction` is deprecated, as would
`StatelessWorkflow.workflowAction` have been if I had remembered to write it
in the first place.

This is a breaking change because the `OutputT` type on `WorkflowAction` and
`Workflow` now must be invariant instead of `out` (so that we can push output
values into `nextOutput`), and because the `WorkflowAction.companion.invoke`
factory functions couldn't be overloaded to work with both `Mutator` and `Updater`.

But it should not be necessary to rewrite every existing action implementation.
The `fun Mutator.apply(): OutputT?` function on the `WorkflowAction` interface
is still there for now, and the new `fun Updater.apply()` function has a default
implementation that calls the old one. (These will be deleted in a later
release, obv.)

Closes #813.
