### PR TITLE
Upgrade coroutines to 1.3.3

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -70,10 +70,10 @@ buildscript {
               'jdk6': "org.jetbrains.kotlin:kotlin-stdlib"
           ],
           'coroutines': [
-              'android': "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.2",
-              'core': "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2",
-              'rx2': "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.2",
-              'test': "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2"
+              'android': "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3",
+              'core': "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3",
+              'rx2': "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:1.3.3",
+              'test': "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3"
           ],
           'moshi': "com.squareup.moshi:moshi-kotlin:1.9.2",
           'reflect': "org.jetbrains.kotlin:kotlin-reflect:1.3.60",

--- a/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/CoroutineEventChannelTest.kt
+++ b/kotlin/legacy/legacy-workflow-rx2/src/test/java/com/squareup/workflow/legacy/rx2/CoroutineEventChannelTest.kt
@@ -217,7 +217,9 @@ class CoroutineEventChannelTest {
     deferred.completeExceptionally(e)
 
     resultSub.assertNoValues()
-    resultSub.assertError(e)
+    // Can't use assertError since the exception is cloned by the coroutine runtime for stacktrace
+    // recovery.
+    resultSub.assertError { it is RuntimeException && it.message == "oops" }
   }
 
   @Test fun `onSuspending with onEvent when Single wins`() {

--- a/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeWorker.kt
+++ b/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeWorker.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.flowOf
  *
  *     adb shell am broadcast -a com.squareup.sample.timemachine.SHAKE
  */
-@UseExperimental(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@UseExperimental(ExperimentalCoroutinesApi::class)
 class ShakeWorker(private val context: Context) : Worker<Unit> {
 
   private val sensorManager = context.getSystemService(SENSOR_SERVICE) as SensorManager
@@ -63,6 +63,7 @@ class ShakeWorker(private val context: Context) : Worker<Unit> {
     awaitClose { context.unregisterReceiver(receiver) }
   }
 
+  @UseExperimental(FlowPreview::class)
   override fun run(): Flow<Unit> = flowOf(realShakes, fakeShakes).flattenMerge()
 
   override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker is ShakeWorker

--- a/kotlin/trace-encoder/src/main/java/com/squareup/tracing/TraceEncoder.kt
+++ b/kotlin/trace-encoder/src/main/java/com/squareup/tracing/TraceEncoder.kt
@@ -19,8 +19,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.channels.SendChannel
@@ -45,11 +43,7 @@ import kotlin.time.MonoClock
  * @param sinkProvider Returns the [BufferedSink] to use to write trace events to. Called on a
  * background thread.
  */
-@UseExperimental(
-    ExperimentalTime::class,
-    ExperimentalCoroutinesApi::class,
-    ObsoleteCoroutinesApi::class
-)
+@UseExperimental(ExperimentalTime::class)
 class TraceEncoder(
   scope: CoroutineScope,
   private val start: ClockMark = MonoClock.markNow(),
@@ -60,12 +54,14 @@ class TraceEncoder(
   private val processIdCounter = AtomicInteger(0)
   private val threadIdCounter = AtomicInteger(0)
 
+  @Suppress("EXPERIMENTAL_API_USAGE")
   private val events: SendChannel<List<ChromeTraceEvent>> =
     scope.actor(ioDispatcher, capacity = UNLIMITED) {
       sinkProvider().use { sink ->
         // Start the JSON array. Doesn't need to be closed.
         sink.writeUtf8("[\n")
 
+        @Suppress("EXPERIMENTAL_API_USAGE")
         consumeEach { eventBatch ->
           eventBatch.forEach { event ->
             event.writeTo(sink)

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -247,8 +247,10 @@ inline fun <reified OutputT> Deferred<OutputT>.asWorker(): Worker<OutputT> =
 /**
  * Shorthand for `.asFlow().asWorker(key)`.
  */
-@ExperimentalCoroutinesApi
-@UseExperimental(FlowPreview::class)
+@UseExperimental(
+    FlowPreview::class,
+    ExperimentalCoroutinesApi::class
+)
 inline fun <reified OutputT> BroadcastChannel<OutputT>.asWorker(): Worker<OutputT> =
   asFlow().asWorker()
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -25,7 +25,6 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.internal.Behavior.WorkerCase
 import com.squareup.workflow.internal.Behavior.WorkflowOutputCase
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.SendChannel
 
 /**
@@ -60,7 +59,6 @@ class RealRenderContext<StateT, OutputT : Any>(
   private var frozen = false
 
   @Suppress("OverridingDeprecatedMember")
-  @UseExperimental(ExperimentalCoroutinesApi::class)
   override fun <EventT : Any> onEvent(handler: (EventT) -> WorkflowAction<StateT, OutputT>):
       EventHandler<EventT> {
     checkNotFrozen()
@@ -72,7 +70,6 @@ class RealRenderContext<StateT, OutputT : Any>(
     }
   }
 
-  @UseExperimental(ExperimentalCoroutinesApi::class)
   override fun <A : WorkflowAction<StateT, OutputT>> makeActionSink(): Sink<A> {
     checkNotFrozen()
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
@@ -21,8 +21,6 @@ import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.VeryExperimentalWorkflow
 import com.squareup.workflow.diagnostic.IdCounter
 import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.consume
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
@@ -55,7 +53,6 @@ internal interface WorkflowLoop {
 @UseExperimental(VeryExperimentalWorkflow::class)
 internal open class RealWorkflowLoop : WorkflowLoop {
 
-  @UseExperimental(FlowPreview::class, ExperimentalCoroutinesApi::class)
   @Suppress("LongMethod")
   override suspend fun <PropsT, StateT, OutputT : Any, RenderingT> runWorkflowLoop(
     workflow: StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>,
@@ -67,7 +64,9 @@ internal open class RealWorkflowLoop : WorkflowLoop {
     diagnosticListener: WorkflowDiagnosticListener?
   ): Nothing = coroutineScope {
 
+    @Suppress("EXPERIMENTAL_API_USAGE")
     val inputsChannel = props.produceIn(this)
+    @Suppress("EXPERIMENTAL_API_USAGE")
     inputsChannel.consume {
       var output: OutputT? = null
       var input: PropsT = inputsChannel.receive()

--- a/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/PublisherWorker.kt
+++ b/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/PublisherWorker.kt
@@ -3,7 +3,6 @@ package com.squareup.workflow.rx2
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
 import io.reactivex.Flowable
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
 import org.reactivestreams.Publisher
@@ -15,8 +14,7 @@ import org.reactivestreams.Publisher
  * If you're using RxJava, [Flowable] is a [Publisher].
  *
  * Subclassing this is equivalent to just implementing [Worker.run] directly and calling [asFlow]
- * on your [Publisher], but doesn't require you to add
- * `@UseExperimental(ExperimentalCoroutinesApi::class)` to your code.
+ * on your [Publisher].
  */
 abstract class PublisherWorker<out OutputT : Any> : Worker<OutputT> {
 
@@ -32,6 +30,5 @@ abstract class PublisherWorker<out OutputT : Any> : Worker<OutputT> {
    */
   abstract fun runPublisher(): Publisher<out OutputT>
 
-  @UseExperimental(ExperimentalCoroutinesApi::class)
   final override fun run(): Flow<OutputT> = runPublisher().asFlow()
 }

--- a/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorkers.kt
+++ b/kotlin/workflow-rx2/src/main/java/com/squareup/workflow/rx2/RxWorkers.kt
@@ -23,7 +23,6 @@ import io.reactivex.Flowable
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.rx2.await
 import org.reactivestreams.Publisher
@@ -51,7 +50,6 @@ inline fun <reified T : Any> Observable<out T?>.asWorker(): Worker<T> =
  * is nullable so that the resulting [Worker] is non-nullable instead of having
  * platform nullability.
  */
-@UseExperimental(ExperimentalCoroutinesApi::class)
 inline fun <reified T : Any> Publisher<out T?>.asWorker(): Worker<T> =
 // This cast works because RxJava types don't actually allow nulls, it's just that they can't
   // express that in their types because Java.

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.workflow.rx2
 
 import com.squareup.workflow.Worker

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/WorkflowRunnerViewModel.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.rx2.asObservable
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.CancellationException
 
-@UseExperimental(ExperimentalCoroutinesApi::class)
 internal class WorkflowRunnerViewModel<OutputT : Any>(
   private val scope: CoroutineScope,
   session: WorkflowSession<OutputT, Any>
@@ -65,6 +64,7 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
     }
   }
 
+  @Suppress("EXPERIMENTAL_API_USAGE")
   override val result: Maybe<out OutputT> = session.outputs.asObservable()
       .firstElement()
       .doAfterTerminate {
@@ -73,6 +73,7 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
       .cache()
 
   init {
+    @Suppress("EXPERIMENTAL_API_USAGE")
     session.renderingsAndSnapshots
         .map { it.snapshot }
         .onEach { lastSnapshot = it }
@@ -81,6 +82,7 @@ internal class WorkflowRunnerViewModel<OutputT : Any>(
 
   private var lastSnapshot: Snapshot = Snapshot.EMPTY
 
+  @UseExperimental(ExperimentalCoroutinesApi::class)
   override val renderings: Observable<out Any> = session.renderingsAndSnapshots
       .map { it.rendering }
       .asObservable()


### PR DESCRIPTION
Also removes some experimental annotations that are no longer necessary, and makes others more targeted so it's more obvious when they can be removed in the future.