### PR TITLE
Improve renderTester API

### DIFF
--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -248,6 +248,33 @@ interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
 }
 
 /**
+ * Specifies that this render pass is expected to run a particular worker.
+ *
+ * @param doesSameWorkAs Worker passed to the actual worker's
+ * [doesSameWorkAs][Worker.doesSameWorkAs] method to identify the worker. Note that the actual
+ * method is called on the worker instance given by the workflow-under-test, and the value of this
+ * argument is passed to that method – if you need custom comparison logic for some reason, use
+ * the overload of this method that takes a `matchesWhen` parameter.
+ * @param key The key passed to [runningWorker][com.squareup.workflow.RenderContext.runningWorker]
+ * when rendering this workflow.
+ * @param output If non-null, [EmittedOutput.output] will be emitted when this worker is ran.
+ * The [WorkflowAction] used to handle this output can be verified using methods on
+ * [RenderTestResult].
+ */
+/* ktlint-disable parameter-list-wrapping */
+fun <PropsT, StateT, OutputT : Any, RenderingT>
+    RenderTester<PropsT, StateT, OutputT, RenderingT>.expectWorker(
+  doesSameWorkAs: Worker<OutputT>,
+  key: String = "",
+  output: EmittedOutput<OutputT>? = null
+): RenderTester<PropsT, StateT, OutputT, RenderingT> = expectWorker(
+/* ktlint-enable parameter-list-wrapping */
+    matchesWhen = { it.doesSameWorkAs(doesSameWorkAs) },
+    key = key,
+    output = output
+)
+
+/**
  * Wrapper around a potentially-nullable [OutputT] value.
  */
 data class EmittedOutput<out OutputT>(val output: OutputT)

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -22,7 +22,8 @@ import com.squareup.workflow.WorkflowAction
 import kotlin.reflect.KClass
 
 /**
- * Create a [RenderTester] to unit test an individual render pass of this workflow.
+ * Create a [RenderTester] to unit test an individual render pass of this workflow, using the
+ * workflow's [initial state][StatefulWorkflow.initialState].
  *
  * See [RenderTester] for usage documentation.
  */

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -244,7 +244,7 @@ interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
    * @return A [RenderTestResult] that can be used to verify the [WorkflowAction] that was used to
    * handle a workflow or worker output or a rendering event.
    */
-  fun render(block: (RenderingT) -> Unit): RenderTestResult<StateT, OutputT>
+  fun render(block: (rendering: RenderingT) -> Unit = {}): RenderTestResult<StateT, OutputT>
 }
 
 /**

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
@@ -223,7 +223,7 @@ class RealRenderTesterTest {
     val tester = workflow.renderTester(Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected child workflow ${child::class.java.name}.",
@@ -240,7 +240,7 @@ class RealRenderTesterTest {
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected child workflow ${child::class.java.name}.",
@@ -256,7 +256,7 @@ class RealRenderTesterTest {
     val tester = workflow.renderTester(Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected child workflow ${child::class.java.name} " +
@@ -274,7 +274,7 @@ class RealRenderTesterTest {
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected child workflow ${child::class.java.name} " +
@@ -292,7 +292,7 @@ class RealRenderTesterTest {
         .expectWorkflow(OutputNothingChild::class, rendering = Unit, key = "wrong key")
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected child workflow ${child::class.java.name} " +
@@ -319,7 +319,7 @@ class RealRenderTesterTest {
         .expectWorkflow(Child::class, rendering = Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertTrue(
         error.message!!.startsWith(
@@ -342,7 +342,7 @@ class RealRenderTesterTest {
     val tester = workflow.renderTester(Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected worker TestWorker.",
@@ -364,7 +364,7 @@ class RealRenderTesterTest {
         .expectWorker(matchesWhen = { false })
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected worker TestWorker.",
@@ -385,7 +385,7 @@ class RealRenderTesterTest {
     val tester = workflow.renderTester(Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected worker TestWorker with key \"key\".",
@@ -407,7 +407,7 @@ class RealRenderTesterTest {
         .expectWorker(matchesWhen = { true })
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected worker TestWorker with key \"key\".",
@@ -432,7 +432,7 @@ class RealRenderTesterTest {
         )
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertEquals(
         "Tried to render unexpected worker TestWorker with key \"key\".",
@@ -454,7 +454,7 @@ class RealRenderTesterTest {
         .expectWorker(matchesWhen = { true })
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertTrue(error.message!!.startsWith("Multiple expectations matched worker TestWorker:"))
   }
@@ -467,7 +467,7 @@ class RealRenderTesterTest {
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertTrue(error.message!!.startsWith("Expected 1 more workflows or workers to be ran:"))
   }
@@ -480,7 +480,7 @@ class RealRenderTesterTest {
         .expectWorker(matchesWhen = { true })
 
     val error = assertFailsWith<AssertionError> {
-      tester.render {}
+      tester.render()
     }
     assertTrue(error.message!!.startsWith("Expected 1 more workflows or workers to be ran:"))
   }
@@ -500,7 +500,7 @@ class RealRenderTesterTest {
     val tester = workflow.renderTester(Unit)
         .expectWorkflow(OutputNothingChild::class, rendering = Unit)
 
-    tester.render {}
+    tester.render()
   }
 
   @Test fun `assertProps failure fails test`() {
@@ -516,7 +516,7 @@ class RealRenderTesterTest {
         )
 
     val error = assertFailsWith<AssertionError> {
-      tester.render { }
+      tester.render()
     }
     assertEquals("bad props: wrong props", error.message)
   }
@@ -542,7 +542,7 @@ class RealRenderTesterTest {
   @Test fun `verifyAction fails when no actions processed`() {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {}
     val testResult = workflow.renderTester(Unit)
-        .render {}
+        .render()
 
     val error = assertFailsWith<AssertionError> {
       testResult.verifyAction {}
@@ -561,7 +561,7 @@ class RealRenderTesterTest {
             rendering = Unit,
             output = EmittedOutput("output")
         )
-        .render {}
+        .render()
 
     testResult.verifyAction {
       assertTrue(it is TestAction)
@@ -579,7 +579,7 @@ class RealRenderTesterTest {
             matchesWhen = { true },
             output = EmittedOutput("output")
         )
-        .render {}
+        .render()
 
     testResult.verifyAction {
       assertTrue(it is TestAction)
@@ -630,7 +630,7 @@ class RealRenderTesterTest {
     val workflow = Workflow.stateless<Unit, Nothing, Unit> { renderCount++ }
 
     workflow.renderTester(Unit)
-        .render {}
+        .render()
 
     assertEquals(2, renderCount)
   }


### PR DESCRIPTION
- Give RenderTester.render function argument a default no-op value. Fixes #814.
- Add overload to RenderTester.expectWorker for simple worker comparisons.
- Improve documentation on state-less renderTester.