### PR TITLE
Make WorkflowAction covariant on OutputT again.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -50,7 +50,7 @@ import com.squareup.workflow.WorkflowAction.Updater
  *
  * See [renderChild].
  */
-interface RenderContext<StateT, OutputT : Any> : Sink<WorkflowAction<StateT, OutputT>> {
+interface RenderContext<StateT, in OutputT : Any> : Sink<WorkflowAction<StateT, OutputT>> {
 
   @Deprecated("Use RenderContext.send.")
   fun <EventT : Any> onEvent(
@@ -73,7 +73,7 @@ interface RenderContext<StateT, OutputT : Any> : Sink<WorkflowAction<StateT, Out
    */
   @Suppress("UNCHECKED_CAST", "DeprecatedCallableAddReplaceWith")
   @Deprecated("Use the RenderContext's send method directly.")
-  fun <A : WorkflowAction<StateT, OutputT>> makeActionSink(): Sink<A> = this as Sink<A>
+  fun <A : WorkflowAction<StateT, OutputT>> makeActionSink(): Sink<A> = this
 
   /**
    * Ensures [child] is running as a child of this workflow, and returns the result of its

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Sink.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Sink.kt
@@ -19,7 +19,7 @@ package com.squareup.workflow
  * An object that receives values (commonly events or [WorkflowAction]).
  * [RenderContext] implements this interface directly, see [RenderContext.send].
  */
-interface Sink<T> {
+interface Sink<in T> {
   fun send(value: T)
 }
 

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatefulWorkflow.kt
@@ -69,7 +69,7 @@ import com.squareup.workflow.WorkflowAction.Updater
 abstract class StatefulWorkflow<
     in PropsT,
     StateT,
-    OutputT : Any,
+    out OutputT : Any,
     out RenderingT
     > : Workflow<PropsT, OutputT, RenderingT> {
 

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -34,7 +34,7 @@ import com.squareup.workflow.WorkflowAction.Updater
  *
  * @see StatefulWorkflow
  */
-abstract class StatelessWorkflow<in PropsT, OutputT : Any, out RenderingT> :
+abstract class StatelessWorkflow<in PropsT, out OutputT : Any, out RenderingT> :
     Workflow<PropsT, OutputT, RenderingT> {
 
   @Suppress("UNCHECKED_CAST")

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Workflow.kt
@@ -74,7 +74,7 @@ package com.squareup.workflow
  * @see StatefulWorkflow
  * @see StatelessWorkflow
  */
-interface Workflow<in PropsT, OutputT : Any, out RenderingT> {
+interface Workflow<in PropsT, out OutputT : Any, out RenderingT> {
 
   /**
    * Provides a [StatefulWorkflow] view of this workflow. Necessary because [StatefulWorkflow] is

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -21,7 +21,7 @@ import com.squareup.workflow.WorkflowAction.Updater
 /**
  * An atomic operation that updates the state of a [Workflow], and also optionally emits an output.
  */
-interface WorkflowAction<StateT, OutputT : Any> {
+interface WorkflowAction<StateT, out OutputT : Any> {
   @Deprecated("Use Updater")
   class Mutator<S>(var state: S)
 
@@ -31,8 +31,8 @@ interface WorkflowAction<StateT, OutputT : Any> {
    *
    * @param nextState the state that the workflow should move to. Default is the current state.
    */
-  class Updater<S, O : Any>(var nextState: S) {
-    internal var output: O? = null
+  class Updater<S, in O : Any>(var nextState: S) {
+    internal var output: @UnsafeVariance O? = null
 
     /**
      * Sets the value the workflow will emit as output when this action is applied.


### PR DESCRIPTION
`WorkflowAction`'s output type is, as the name suggests, an output value,
and so it is natural that it have `out` variance (i.e. be covariant). This was changed because
the new `Updater` API stores the pending output value in a var, which is readable
as well as writeable and therefore an invariant (`in`) position, and therefore `Updater`'s `O`
must be neither `in` nor `out` (i.e. be invariant), and `WorkflowAction`'s `OutputT` must, in turn, also be invariant.
However, the only _API_ in which `Updater` exposes this type is as a method parameter,
which is an `in` position. It is only _read_ in the same context as the `WorkflowAction` for which
it was created, which means its type will never actually be out of bounds. Therefore, we can
just mark the output use of `Updater.O` as `@UnsafeVariance`, mark the type parameter itself
as contravariant (`in`), and revert `WorkflowAction`'s `OutputT` back to `out`.