### PR TITLE
Undo making RenderContext a sink, give it a sink property instead.

### DIFF
--- a/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
+++ b/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/PoemWorkflow.kt
@@ -97,7 +97,7 @@ object PoemWorkflow : StatefulWorkflow<Poem, Int, ClosePoem, MasterDetailScreen>
         ?.let { MasterDetailScreen(masterRendering = stanzaIndex, detailRendering = it) }
         ?: MasterDetailScreen(
             masterRendering = stanzaIndex,
-            selectDefault = { context.send(HandleStanzaListOutput(0)) }
+            selectDefault = { context.actionSink.send(HandleStanzaListOutput(0)) }
         )
   }
 

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/DungeonAppWorkflow.kt
@@ -85,7 +85,7 @@ class DungeonAppWorkflow(
             buttons = mapOf(POSITIVE to "Restart"),
             message = "You've been eaten, try again.",
             cancelable = false,
-            onEvent = { context.send(RestartGame) }
+            onEvent = { context.actionSink.send(RestartGame) }
         )
 
         AlertContainerScreen(gameScreen, gameOverDialog)

--- a/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
+++ b/kotlin/samples/dungeon/common/src/main/java/com/squareup/sample/dungeon/PlayerWorkflow.kt
@@ -67,8 +67,8 @@ class PlayerWorkflow(
     context: RenderContext<Movement, Nothing>
   ): Rendering = Rendering(
       actorRendering = ActorRendering(avatar = avatar, movement = state),
-      onStartMoving = { context.send(StartMoving(it)) },
-      onStopMoving = { context.send(StopMoving(it)) }
+      onStartMoving = { context.actionSink.send(StartMoving(it)) },
+      onStopMoving = { context.actionSink.send(StopMoving(it)) }
   )
 
   override fun snapshotState(state: Movement): Snapshot = Snapshot.EMPTY

--- a/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
+++ b/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineWorkflow.kt
@@ -102,7 +102,7 @@ class ShakeableTimeMachineWorkflow<in P, O : Any, out R : Any>(
             { _ -> }
           }
           is PlayingBack -> {
-            { position -> context.send(SeekAction(position)) }
+            { position -> context.actionSink.send(SeekAction(position)) }
           }
         },
         onResumeRecording = when (state) {
@@ -111,7 +111,7 @@ class ShakeableTimeMachineWorkflow<in P, O : Any, out R : Any>(
             {}
           }
           is PlayingBack -> {
-            { context.send(ResumeRecordingAction()) }
+            { context.actionSink.send(ResumeRecordingAction()) }
           }
         }
     )

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflow.kt
@@ -58,7 +58,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   ): Rendering {
     return Rendering(
         message = state.name,
-        onClick = { context.send(helloAction) }
+        onClick = { context.actionSink.send(helloAction) }
     )
   }
 

--- a/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
+++ b/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloWorkflow.kt
@@ -58,7 +58,7 @@ object HelloWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   ): Rendering {
     return Rendering(
         message = state.name,
-        onClick = { context.send(helloAction) }
+        onClick = { context.actionSink.send(helloAction) }
     )
   }
 

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
@@ -99,7 +99,7 @@ object AppWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
     val listRendering = context.renderChild(EditableListWorkflow, Props(state.rows))
     val baseScreen = BaseScreen(
         listRendering = listRendering,
-        onAddRowTapped = { context.send(ShowAddRowAction) }
+        onAddRowTapped = { context.actionSink.send(ShowAddRowAction) }
     )
 
     return when (state) {
@@ -108,7 +108,7 @@ object AppWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
           baseScreen = baseScreen,
           popup = ChooseRowTypeScreen(
               options = allRowTypes.map { it.description },
-              onSelectionTapped = { index -> context.send(CommitNewRowAction(index)) }
+              onSelectionTapped = { index -> context.actionSink.send(CommitNewRowAction(index)) }
           )
       )
     }

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListWorkflow.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListWorkflow.kt
@@ -66,7 +66,7 @@ object EditableListWorkflow : StatefulWorkflow<Props, State, Nothing, Rendering>
     return Rendering(
         rowValues = state.rowValues,
         onValueChanged = { position, newValue ->
-          context.send(valueChangedAction(position, newValue))
+          context.actionSink.send(valueChangedAction(position, newValue))
         }
     )
   }

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/authworkflow/AuthWorkflow.kt
@@ -152,8 +152,8 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
       BackStackScreen(
           LoginScreen(
               state.errorMessage,
-              onLogin = { email, password -> context.send(SubmitLogin(email, password)) },
-              onCancel = { context.send(CancelLogin) }
+              onLogin = { email, password -> context.actionSink.send(SubmitLogin(email, password)) },
+              onCancel = { context.actionSink.send(CancelLogin) }
           )
       )
     }
@@ -175,8 +175,8 @@ class RealAuthWorkflow(private val authService: AuthService) : AuthWorkflow,
           LoginScreen(),
           SecondFactorScreen(
               state.errorMessage,
-              onSubmit = { context.send(SubmitSecondFactor(state.tempToken, it)) },
-              onCancel = { context.send(CancelSecondFactor) }
+              onSubmit = { context.actionSink.send(SubmitSecondFactor(state.tempToken, it)) },
+              onCancel = { context.actionSink.send(CancelSecondFactor) }
           )
       )
     }

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/RunGameWorkflow.kt
@@ -188,8 +188,8 @@ class RealRunGameWorkflow(
           subflow = NewGameScreen(
               state.defaultXName,
               state.defaultOName,
-              onCancel = { context.send(CancelNewGame) },
-              onStartGame = { x, o -> context.send(StartGame(x, o)) }
+              onCancel = { context.actionSink.send(CancelNewGame) },
+              onStartGame = { x, o -> context.actionSink.send(StartGame(x, o)) }
           )
       )
     }
@@ -212,9 +212,9 @@ class RealRunGameWorkflow(
       alertScreen(
           base = GamePlayScreen(state.playerInfo, state.completedGame.lastTurn),
           alert = maybeQuitScreen(
-              confirmQuit = { context.send(ConfirmQuit) },
+              confirmQuit = { context.actionSink.send(ConfirmQuit) },
               continuePlaying = {
-                context.send(ContinuePlaying(state.playerInfo, state.completedGame.lastTurn))
+                context.actionSink.send(ContinuePlaying(state.playerInfo, state.completedGame.lastTurn))
               }
           )
       )
@@ -228,9 +228,9 @@ class RealRunGameWorkflow(
               message = "Really?",
               positive = "Yes!!",
               negative = "Sigh, no",
-              confirmQuit = { context.send(ConfirmQuitAgain) },
+              confirmQuit = { context.actionSink.send(ConfirmQuitAgain) },
               continuePlaying = {
-                context.send(ContinuePlaying(state.playerInfo, state.completedGame.lastTurn))
+                context.actionSink.send(ContinuePlaying(state.playerInfo, state.completedGame.lastTurn))
               }
           )
       )
@@ -245,9 +245,9 @@ class RealRunGameWorkflow(
 
       GameOverScreen(
           state,
-          onTrySaveAgain = { context.send(TrySaveAgain) },
-          onPlayAgain = { context.send(PlayAgain) },
-          onExit = { context.send(Exit) }
+          onTrySaveAgain = { context.actionSink.send(TrySaveAgain) },
+          onPlayAgain = { context.actionSink.send(PlayAgain) },
+          onExit = { context.actionSink.send(Exit) }
       ).let(::simpleScreen)
     }
   }

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/gameworkflow/TakeTurnsWorkflow.kt
@@ -90,8 +90,8 @@ class RealTakeTurnsWorkflow : TakeTurnsWorkflow,
   ): GamePlayScreen = GamePlayScreen(
       playerInfo = props.playerInfo,
       gameState = state,
-      onQuit = { context.send(Quit) },
-      onClick = { row, col -> context.send(TakeSquare(row, col)) }
+      onQuit = { context.actionSink.send(Quit) },
+      onClick = { row, col -> context.actionSink.send(TakeSquare(row, col)) }
   )
 
   override fun snapshotState(state: Turn) = Snapshot.EMPTY

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoEditorWorkflow.kt
@@ -103,7 +103,7 @@ class TodoEditorWorkflow : StatelessWorkflow<TodoList, TodoEditorOutput, TodoRen
       override fun send(value: TodoAction) {
         if (eventFired) return
         eventFired = true
-        context.send(value)
+        context.actionSink.send(value)
       }
     }
 

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -92,7 +92,7 @@ object TodoListsAppWorkflow :
       // the detail panel is never seen to be empty.
       is ShowingLists -> MasterDetailScreen(
           masterRendering = BackStackScreen(listOfLists),
-          selectDefault = { context.send(onListSelected(0)) }
+          selectDefault = { context.actionSink.send(onListSelected(0)) }
       )
 
       // We are editing a list. Notice that we always render the master pane -- the 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/RealRenderContext.kt
@@ -19,6 +19,7 @@ package com.squareup.workflow.internal
 
 import com.squareup.workflow.EventHandler
 import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Sink
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
@@ -33,7 +34,7 @@ import kotlinx.coroutines.channels.SendChannel
 class RealRenderContext<StateT, OutputT : Any>(
   private val renderer: Renderer<StateT, OutputT>,
   private val eventActionsChannel: SendChannel<WorkflowAction<StateT, OutputT>>
-) : RenderContext<StateT, OutputT> {
+) : RenderContext<StateT, OutputT>, Sink<WorkflowAction<StateT, OutputT>> {
 
   interface Renderer<StateT, OutputT : Any> {
     fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> render(
@@ -54,6 +55,8 @@ class RealRenderContext<StateT, OutputT : Any>(
    *  - prevent sending to sinks before render returns.
    */
   private var frozen = false
+
+  override val actionSink: Sink<WorkflowAction<StateT, OutputT>> get() = this
 
   @Suppress("OverridingDeprecatedMember")
   override fun <EventT : Any> onEvent(handler: (EventT) -> WorkflowAction<StateT, OutputT>):

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -133,7 +133,7 @@ class RealRenderContextTest {
 
     assertTrue(eventActionsChannel.isEmpty)
 
-    context.send(stringAction)
+    context.actionSink.send(stringAction)
 
     assertFalse(eventActionsChannel.isEmpty)
     val actualAction = eventActionsChannel.poll()
@@ -153,10 +153,10 @@ class RealRenderContextTest {
     // Enable sink sends.
     context.buildBehavior()
 
-    context.send(firstAction)
+    context.actionSink.send(firstAction)
 
     // Shouldn't throw.
-    context.send(secondAction)
+    context.actionSink.send(secondAction)
   }
 
   @Test fun `send throws before render returns`() {
@@ -167,7 +167,7 @@ class RealRenderContextTest {
     }
 
     val error = assertFailsWith<UnsupportedOperationException> {
-      context.send(action)
+      context.actionSink.send(action)
     }
     assertEquals(
         "Expected sink to not be sent to until after the render pass. Received action: action",

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
@@ -220,7 +220,7 @@ class WorkflowNodeTest {
         state: String,
         context: RenderContext<String, String>
       ): String {
-        sink = context
+        sink = context.actionSink
         return ""
       }
     }
@@ -349,7 +349,7 @@ class WorkflowNodeTest {
             context.runningWorker(channel.asWorker(closeOnCancel = true)) {
               update(it)
             }
-            doClose = { context.send(finish) }
+            doClose = { context.actionSink.send(finish) }
           }
         }
         return ""
@@ -769,7 +769,7 @@ class WorkflowNodeTest {
     val workflow = Workflow.stateful<String, String, String, (String) -> Unit>(
         initialState = { props, _ -> "($props:)" },
         render = { _, _ ->
-          return@stateful { send(action(it)) }
+          return@stateful { actionSink.send(action(it)) }
         },
         onPropsChanged = { old, new, state -> "($old:$new:$state)" },
         snapshot = { Snapshot.EMPTY }
@@ -840,7 +840,7 @@ class WorkflowNodeTest {
     }
 
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
-      send(TestAction())
+      actionSink.send(TestAction())
     }
     val node = WorkflowNode(
         workflow.id(),

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
@@ -16,6 +16,7 @@
 package com.squareup.workflow.testing
 
 import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Sink
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
@@ -35,7 +36,8 @@ internal class RealRenderTester<PropsT, StateT, OutputT : Any, RenderingT>(
   private var processedAction: WorkflowAction<StateT, OutputT>? = null
 ) : RenderTester<PropsT, StateT, OutputT, RenderingT>,
     RenderContext<StateT, OutputT>,
-    RenderTestResult<StateT, OutputT> {
+    RenderTestResult<StateT, OutputT>,
+    Sink<WorkflowAction<StateT, OutputT>> {
 
   internal sealed class Expectation<out OutputT> {
     abstract val output: EmittedOutput<OutputT>?
@@ -54,6 +56,8 @@ internal class RealRenderTester<PropsT, StateT, OutputT : Any, RenderingT>(
       override val output: EmittedOutput<OutputT>?
     ) : Expectation<OutputT>()
   }
+
+  override val actionSink: Sink<WorkflowAction<StateT, OutputT>> get() = this
 
   override fun <ChildPropsT, ChildOutputT : Any, ChildRenderingT> expectWorkflow(
     workflowType: KClass<out Workflow<ChildPropsT, ChildOutputT, ChildRenderingT>>,

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/TreeWorkflow.kt
@@ -64,7 +64,7 @@ internal class TreeWorkflow(
 
     return Rendering(
         data = "$name:$state",
-        setData = { context.send(onEvent(it)) },
+        setData = { context.actionSink.send(onEvent(it)) },
         children = childRenderings
     )
   }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -189,7 +189,7 @@ class WorkerCompositionIntegrationTest {
         render = { state ->
           runningWorker(triggerOutput) { WorkflowAction { setOutput(state) } }
 
-          return@stateful { send(incrementState) }
+          return@stateful { actionSink.send(incrementState) }
         }
     )
 

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
@@ -113,7 +113,7 @@ class WorkflowCompositionIntegrationTest {
         initialState = 0,
         render = { state ->
           renderChild(child) { WorkflowAction { setOutput(state) } }
-          return@stateful { send(incrementState) }
+          return@stateful { actionSink.send(incrementState) }
         }
     )
 

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
@@ -159,7 +159,7 @@ class RealRenderTesterTest {
 
     val workflow = Workflow.stateful<Unit, Nothing, Sink<TestAction>>(
         initialState = Unit,
-        render = { contraMap { it } }
+        render = { actionSink.contraMap { it } }
     )
     val action1 = TestAction("1")
     val action2 = TestAction("2")
@@ -190,7 +190,7 @@ class RealRenderTesterTest {
         render = {
           // Need to satisfy the expectation.
           runningWorker(Worker.finished() as Worker<Unit>) { noAction() }
-          return@stateful contraMap { it }
+          return@stateful actionSink.contraMap { it }
         }
     )
 
@@ -529,7 +529,7 @@ class RealRenderTesterTest {
 
   @Test fun `verifyAction failure fails test`() {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
-      contraMap { it }
+      actionSink.contraMap { it }
     }
     val testResult = workflow.renderTester(Unit)
         .render { it.send(TestAction("noop")) }
@@ -590,7 +590,7 @@ class RealRenderTesterTest {
 
   @Test fun `verifyAction verifies sink send`() {
     val workflow = Workflow.stateless<Unit, Nothing, Sink<TestAction>> {
-      contraMap { it }
+      actionSink.contraMap { it }
     }
     val testResult = workflow.renderTester(Unit)
         .render { sink ->
@@ -613,7 +613,7 @@ class RealRenderTesterTest {
 
     val workflow = Workflow.stateful<Unit, String, String, Sink<TestAction>>(
         initialState = { "initial" },
-        render = { _, _ -> contraMap { it } }
+        render = { _, _ -> actionSink.contraMap { it } }
     )
     val testResult = workflow.renderTester(Unit)
         .render { sink ->


### PR DESCRIPTION
It looks weird to say `context.send`, and weirder to say `context.contraMap` –
what does it mean to "contra map" a `RenderContext`? It makes more sense to say
a context _has_ a sink than it _is_ a sink. Only slightly more typing but much
more clear.