### PR TITLE
[DNR] Adds `asWorker` extension method to transform a `SignalProducer` into a `Worker` 

### DIFF
--- a/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -147,7 +147,7 @@ extension AuthenticationWorkflow {
         case .authorizingEmailPassword(email: let email, password: let password):
             let worker = authenticationService
                 .login(email: email, password: password)
-                .asWorker()
+                .asWorker(key: "login-\(email)-\(password)")
             
             context.awaitResult(for: worker) { (output) -> Action in
                 switch output {
@@ -169,7 +169,7 @@ extension AuthenticationWorkflow {
         case .authorizingTwoFactor(twoFactorCode: let twoFactorCode, intermediateSession: let intermediateSession):
             let worker = authenticationService
                 .secondFactor(token: intermediateSession, secondFactor: twoFactorCode)
-                .asWorker()
+                .asWorker(key: "secondFactor-\(intermediateSession)-\(twoFactorCode)")
 
             context.awaitResult(for: worker) { (output) -> Action in
                 switch output {

--- a/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -147,7 +147,7 @@ extension AuthenticationWorkflow {
         case .authorizingEmailPassword(email: let email, password: let password):
             let worker = authenticationService
                 .login(email: email, password: password)
-                .asWorker(key: "login-\(email)-\(password)")
+                .asWorker()
             
             context.awaitResult(for: worker) { (output) -> Action in
                 switch output {
@@ -169,7 +169,7 @@ extension AuthenticationWorkflow {
         case .authorizingTwoFactor(twoFactorCode: let twoFactorCode, intermediateSession: let intermediateSession):
             let worker = authenticationService
                 .secondFactor(token: intermediateSession, secondFactor: twoFactorCode)
-                .asWorker(key: "secondFactor-\(intermediateSession)-\(twoFactorCode)")
+                .asWorker()
 
             context.awaitResult(for: worker) { (output) -> Action in
                 switch output {

--- a/swift/Workflow/Sources/RenderContext.swift
+++ b/swift/Workflow/Sources/RenderContext.swift
@@ -75,7 +75,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         fatalError()
     }
 
-    public func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
+    public func awaitResult<W, Action>(for worker: W, key: String = "", outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
         fatalError()
     }
     
@@ -114,9 +114,9 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         }
 
 
-        override func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
+        override func awaitResult<W, Action>(for worker: W, key: String = "", outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
             assertStillValid()
-            implementation.awaitResult(for: worker, outputMap: outputMap)
+            implementation.awaitResult(for: worker, key: key, outputMap: outputMap)
         }
         
         private func assertStillValid() {
@@ -137,7 +137,7 @@ internal protocol RenderContextType: class {
 
     func subscribe<Action>(signal: Signal<Action, Never>) where Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
-    func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
+    func awaitResult<W, Action>(for worker: W, key: String, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
     
 }
 
@@ -157,12 +157,12 @@ extension RenderContext {
 
 extension RenderContext {
 
-    public func awaitResult<W>(for worker: W) where W : Worker, W.Output : WorkflowAction, WorkflowType == W.Output.WorkflowType {
-        awaitResult(for: worker, outputMap: { $0 })
+    public func awaitResult<W>(for worker: W, key: String = "") where W : Worker, W.Output : WorkflowAction, WorkflowType == W.Output.WorkflowType {
+        awaitResult(for: worker, key: key, outputMap: { $0 })
     }
 
-    public func awaitResult<W>(for worker: W, onOutput: @escaping (W.Output, inout WorkflowType.State) -> WorkflowType.Output?) where W: Worker {
-        awaitResult(for: worker) { output in
+    public func awaitResult<W>(for worker: W, key: String = "", onOutput: @escaping (W.Output, inout WorkflowType.State) -> WorkflowType.Output?) where W: Worker {
+        awaitResult(for: worker, key: key) { output in
             return AnyWorkflowAction<WorkflowType> { state in
                 return onOutput(output, &state)
             }

--- a/swift/Workflow/Sources/SignalProducerWorker.swift
+++ b/swift/Workflow/Sources/SignalProducerWorker.swift
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import ReactiveSwift
+
+/// Workers define a unit of asynchronous work.
+///
+/// During a render pass, a workflow can ask the context to await the result of a worker.
+///
+/// When this occurs, the context checks to see if there is already a running worker of the same type.
+/// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
+///
+/// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
+public struct SignalProducerWorker<Value>: Worker {
+    /// The type of output events returned by this worker.
+    let valueType: Value.Type
+
+    /// The `SignalProducer<Value, Never>` wrapped by this worker.
+    let signalProducer: SignalProducer<Value, Never>
+
+    init(signalProducer: SignalProducer<Value, Never>) {
+        self.signalProducer = signalProducer
+        self.valueType = Value.self
+    }
+
+    /// Returns a signal producer to execute the work represented by this worker.
+    public func run() -> SignalProducer<Value, Never> {
+        return signalProducer
+    }
+
+    /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
+    /// account whatever data is meaninful to the task. For example, a worker that loads a user account from a server
+    /// would not be equivalent to another worker with a different user ID.
+    public func isEquivalent(to otherWorker: SignalProducerWorker<Value>) -> Bool {
+        return valueType == otherWorker.valueType
+    }
+}
+
+public extension SignalProducer {
+    func asWorker(errorTransform: @escaping (Error) -> SignalProducer<Value, Never>) -> SignalProducerWorker<Value> {
+        return self
+            .flatMapError { errorTransform($0) }
+            .asWorker()
+    }
+
+    func asWorker(errorTransform: @escaping (Error) -> Value) -> SignalProducerWorker<Value> {
+        return self
+            .flatMapError({
+                return SignalProducer<Value, Never>(value: errorTransform($0))
+            })
+            .asWorker()
+    }
+}
+
+public extension SignalProducer where Error == Never {
+    func asWorker() -> SignalProducerWorker<Value> {
+        return SignalProducerWorker(signalProducer: self)
+    }
+}

--- a/swift/Workflow/Sources/SignalProducerWorker.swift
+++ b/swift/Workflow/Sources/SignalProducerWorker.swift
@@ -23,16 +23,20 @@ import ReactiveSwift
 /// If there is, and if the workers are 'equivalent', the context leaves the existing worker running.
 ///
 /// If there is not an existing worker of this type, the context will kick off the new worker (via `run`).
-public struct SignalProducerWorker<Value>: Worker {
+public struct SignalProducerWorker<Value, Key>: Worker where Key : Equatable {
     /// The type of output events returned by this worker.
     let valueType: Value.Type
+    
+    /// A unique identifier for this `SignalProducerWorker` instance.
+    let key: Key
 
     /// The `SignalProducer<Value, Never>` wrapped by this worker.
     let signalProducer: SignalProducer<Value, Never>
 
-    internal init(signalProducer: SignalProducer<Value, Never>) {
+    internal init(signalProducer: SignalProducer<Value, Never>, key: Key) {
         self.signalProducer = signalProducer
         self.valueType = Value.self
+        self.key = key
     }
 
     /// Returns a signal producer to execute the work represented by this worker.
@@ -43,8 +47,8 @@ public struct SignalProducerWorker<Value>: Worker {
     /// Returns `true` if the other worker should be considered equivalent to `self`. Equivalence should take into
     /// account whatever data is meaninful to the task. For example, a worker that loads a user account from a server
     /// would not be equivalent to another worker with a different user ID.
-    public func isEquivalent(to otherWorker: SignalProducerWorker<Value>) -> Bool {
-        return valueType == otherWorker.valueType
+    public func isEquivalent(to otherWorker: SignalProducerWorker<Value, Key>) -> Bool {
+        return valueType == otherWorker.valueType && key == otherWorker.key
     }
 }
 
@@ -59,46 +63,50 @@ public extension SignalProducer {
     /// - note: When a Failed event is received, the resulting producer will
     ///         send the `Result.failure` itself and then complete.
     ///
+    /// - Parameter key: A value that uniquely identifies this `Worker`.
     /// - returns: A `SignalProducerWorker` that sends `Results` as its values.
-    func asWorker() -> SignalProducerWorker<Result<Value, Error>> {
-        return SignalProducerWorker(signalProducer: self.materializeResults())
+    func asWorker<Key>(key: Key) -> SignalProducerWorker<Result<Value, Error>, Key> where Key: Equatable {
+        return SignalProducerWorker(signalProducer: self.materializeResults(), key: key)
     }
     
     /// Convenience to transform a `SignalProducer` into a `Worker`.
     ///
     /// - parameters:
+    ///   - key: A value that uniquely identifies this `Worker`.
     ///   - errorTransform: A closure that accepts emitted error and returns a signal
     ///                producer with a different type of error.
     ///
     /// - returns: A `SignalProducerWorker` that catches any failure that may occur on
     /// the input producer, mapping to a new producer that starts in its place.
-    func asWorker(errorTransform: @escaping (Error) -> SignalProducer<Value, Never>) -> SignalProducerWorker<Value> {
+    func asWorker<Key>(key: Key, errorTransform: @escaping (Error) -> SignalProducer<Value, Never>) -> SignalProducerWorker<Value, Key> where Key: Equatable {
         return self
             .flatMapError { errorTransform($0) }
-            .asWorker()
+            .asWorker(key: key)
     }
 
     /// Convenience to transform a `SignalProducer` into a `Worker`.
     ///
     /// - parameters:
+    ///   - key: A value that uniquely identifies this `SignalProdcuerWorker`.
     ///   - errorTransform: A closure that accepts emitted error and returns a value in its place.
     ///
     /// - returns: A `SignalProducerWorker` that catches any failure that may occur on
     /// the input producer, mapping to a new producer that starts in its place.
-    func asWorker(errorTransform: @escaping (Error) -> Value) -> SignalProducerWorker<Value> {
+    func asWorker<Key>(key: Key, errorTransform: @escaping (Error) -> Value) -> SignalProducerWorker<Value, Key> where Key: Equatable {
         return self
             .flatMapError({
                 return SignalProducer<Value, Never>(value: errorTransform($0))
             })
-            .asWorker()
+            .asWorker(key: key)
     }
 }
 
 public extension SignalProducer where Error == Never {
     /// Convenience to transform a `SignalProducer` into a `Worker`.
     ///
+    /// - Parameter key: A value that uniquely identifies this `Worker`.
     /// - returns: A `SignalProducerWorker`
-    func asWorker() -> SignalProducerWorker<Value> {
-        return SignalProducerWorker(signalProducer: self)
+    func asWorker<Key>(key: Key) -> SignalProducerWorker<Value, Key> where Key : Equatable {
+        return SignalProducerWorker(signalProducer: self, key: key)
     }
 }

--- a/swift/Workflow/Tests/SignalProducerWorkerTests.swift
+++ b/swift/Workflow/Tests/SignalProducerWorkerTests.swift
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import ReactiveSwift
+@testable import Workflow
+
+import ReactiveSwift
+
+
+final class SignalProducerWorkerTests: XCTestCase {
+    fileprivate struct MyError: Error {}
+    
+    func test_signalProducersOfSameValueTypeAreEquivalent() {
+        let signalProducer1 = SignalProducer(value: "Hello")
+        let worker1 = signalProducer1.asWorker()
+        
+        let signalProducer2 = SignalProducer(value: "World")
+        let worker2 = signalProducer2.asWorker()
+        
+        XCTAssertTrue(worker1.isEquivalent(to: worker2))
+    }
+    
+    func test_singalProducerAsWorkerNeverError() {
+        let signalProducer = SignalProducer(value: "Hello")
+        let worker = signalProducer.asWorker()
+        
+        XCTAssertNotNil(worker)
+        XCTAssertEqual(worker.run().first()?.value, "Hello")
+    }
+    
+    func test_signalProducerAsWorkerErrorTransformersValueEmission() {
+        let signalProducer1 = SignalProducer<String, Error>(value: "Hello")
+        let worker1 = signalProducer1.asWorker { _ in "Ooops 1" }
+        
+        XCTAssertNotNil(worker1)
+        XCTAssertEqual(worker1.run().first()?.value, "Hello")
+        
+        let signalProducer2 = SignalProducer<String, Error>(value: "World")
+        let worker2 = signalProducer2.asWorker { _ in SignalProducer(value: "Ooops 2") }
+        
+        XCTAssertNotNil(worker2)
+        XCTAssertEqual(worker2.run().first()?.value, "World")
+        
+        let signalProducer3 = SignalProducer<String, Error>(value: "Foo")
+        let worker3 = signalProducer3.asWorker()
+        
+        XCTAssertNotNil(worker3)
+        XCTAssertEqual(worker3.run().first()?.value?.value, "Foo")
+        XCTAssertNil(worker3.run().first()?.value?.error)
+    }
+    
+    func test_signalProducerAsWorkerErrorTransformersErrorEmission() {
+        let signalProducer1 = SignalProducer<String, Error>(error: MyError())
+        let worker1 = signalProducer1.asWorker { _ in "Ooops 1" }
+        
+        XCTAssertNotNil(worker1)
+        XCTAssertEqual(worker1.run().first()?.value, "Ooops 1")
+        
+        let signalProducer2 = SignalProducer<String, Error>(error: MyError())
+        let worker2 = signalProducer2.asWorker { _ in SignalProducer(value: "Ooops 2") }
+
+        XCTAssertNotNil(worker2)
+        XCTAssertEqual(worker2.run().first()?.value, "Ooops 2")
+        
+        let signalProducer3 = SignalProducer<String, Error>(error: MyError())
+        let worker3 = signalProducer3.asWorker()
+        
+        XCTAssertNotNil(worker3)
+        XCTAssertNil(worker3.run().first()?.value?.value)
+        XCTAssertNotNil(worker3.run().first()?.value?.error)
+    }
+}

--- a/swift/Workflow/Tests/SignalProducerWorkerTests.swift
+++ b/swift/Workflow/Tests/SignalProducerWorkerTests.swift
@@ -23,29 +23,19 @@ import ReactiveSwift
 final class SignalProducerWorkerTests: XCTestCase {
     fileprivate struct MyError: Error {}
     
-    func test_signalProducersOfSameValueTypeAndKeyAreEquivalent() {
+    func test_signalProducersOfSameValueTypeAreEquivalent() {
         let signalProducer1 = SignalProducer(value: "Hello")
-        let worker1 = signalProducer1.asWorker(key: "hello-worker")
+        let worker1 = signalProducer1.asWorker()
         
         let signalProducer2 = SignalProducer(value: "World")
-        let worker2 = signalProducer2.asWorker(key: "hello-worker")
+        let worker2 = signalProducer2.asWorker()
         
         XCTAssertTrue(worker1.isEquivalent(to: worker2))
     }
     
-    func test_signalProducersOfSameValueTypeDifferentKeyAreNotEquivalent() {
-        let signalProducer1 = SignalProducer(value: "Hello")
-        let worker1 = signalProducer1.asWorker(key: "hello-worker")
-        
-        let signalProducer2 = SignalProducer(value: "World")
-        let worker2 = signalProducer2.asWorker(key: "world-worker")
-        
-        XCTAssertFalse(worker1.isEquivalent(to: worker2))
-    }
-    
     func test_singalProducerAsWorkerNeverError() {
         let signalProducer = SignalProducer(value: "Hello")
-        let worker = signalProducer.asWorker(key: "hello-worker")
+        let worker = signalProducer.asWorker()
         
         XCTAssertNotNil(worker)
         XCTAssertEqual(worker.run().first()?.value, "Hello")
@@ -53,19 +43,19 @@ final class SignalProducerWorkerTests: XCTestCase {
     
     func test_signalProducerAsWorkerErrorTransformersValueEmission() {
         let signalProducer1 = SignalProducer<String, Error>(value: "Hello")
-        let worker1 = signalProducer1.asWorker(key: "hello-worker") { _ in "Ooops 1" }
+        let worker1 = signalProducer1.asWorker { _ in "Ooops 1" }
         
         XCTAssertNotNil(worker1)
         XCTAssertEqual(worker1.run().first()?.value, "Hello")
         
         let signalProducer2 = SignalProducer<String, Error>(value: "World")
-        let worker2 = signalProducer2.asWorker(key: "world-worker") { _ in SignalProducer(value: "Ooops 2") }
+        let worker2 = signalProducer2.asWorker { _ in SignalProducer(value: "Ooops 2") }
         
         XCTAssertNotNil(worker2)
         XCTAssertEqual(worker2.run().first()?.value, "World")
         
         let signalProducer3 = SignalProducer<String, Error>(value: "Foo")
-        let worker3 = signalProducer3.asWorker(key: "foo-worker")
+        let worker3 = signalProducer3.asWorker()
         
         XCTAssertNotNil(worker3)
         XCTAssertEqual(worker3.run().first()?.value?.value, "Foo")
@@ -74,19 +64,19 @@ final class SignalProducerWorkerTests: XCTestCase {
     
     func test_signalProducerAsWorkerErrorTransformersErrorEmission() {
         let signalProducer1 = SignalProducer<String, Error>(error: MyError())
-        let worker1 = signalProducer1.asWorker(key: "error-worker-1") { _ in "Ooops 1" }
+        let worker1 = signalProducer1.asWorker { _ in "Ooops 1" }
         
         XCTAssertNotNil(worker1)
         XCTAssertEqual(worker1.run().first()?.value, "Ooops 1")
         
         let signalProducer2 = SignalProducer<String, Error>(error: MyError())
-        let worker2 = signalProducer2.asWorker(key: "error-worker-2") { _ in SignalProducer(value: "Ooops 2") }
+        let worker2 = signalProducer2.asWorker { _ in SignalProducer(value: "Ooops 2") }
 
         XCTAssertNotNil(worker2)
         XCTAssertEqual(worker2.run().first()?.value, "Ooops 2")
         
         let signalProducer3 = SignalProducer<String, Error>(error: MyError())
-        let worker3 = signalProducer3.asWorker(key: "error-worker-3")
+        let worker3 = signalProducer3.asWorker()
         
         XCTAssertNotNil(worker3)
         XCTAssertNil(worker3.run().first()?.value?.value)

--- a/swift/Workflow/Tests/SignalProducerWorkerTests.swift
+++ b/swift/Workflow/Tests/SignalProducerWorkerTests.swift
@@ -23,19 +23,29 @@ import ReactiveSwift
 final class SignalProducerWorkerTests: XCTestCase {
     fileprivate struct MyError: Error {}
     
-    func test_signalProducersOfSameValueTypeAreEquivalent() {
+    func test_signalProducersOfSameValueTypeAndKeyAreEquivalent() {
         let signalProducer1 = SignalProducer(value: "Hello")
-        let worker1 = signalProducer1.asWorker()
+        let worker1 = signalProducer1.asWorker(key: "hello-worker")
         
         let signalProducer2 = SignalProducer(value: "World")
-        let worker2 = signalProducer2.asWorker()
+        let worker2 = signalProducer2.asWorker(key: "hello-worker")
         
         XCTAssertTrue(worker1.isEquivalent(to: worker2))
     }
     
+    func test_signalProducersOfSameValueTypeDifferentKeyAreNotEquivalent() {
+        let signalProducer1 = SignalProducer(value: "Hello")
+        let worker1 = signalProducer1.asWorker(key: "hello-worker")
+        
+        let signalProducer2 = SignalProducer(value: "World")
+        let worker2 = signalProducer2.asWorker(key: "world-worker")
+        
+        XCTAssertFalse(worker1.isEquivalent(to: worker2))
+    }
+    
     func test_singalProducerAsWorkerNeverError() {
         let signalProducer = SignalProducer(value: "Hello")
-        let worker = signalProducer.asWorker()
+        let worker = signalProducer.asWorker(key: "hello-worker")
         
         XCTAssertNotNil(worker)
         XCTAssertEqual(worker.run().first()?.value, "Hello")
@@ -43,19 +53,19 @@ final class SignalProducerWorkerTests: XCTestCase {
     
     func test_signalProducerAsWorkerErrorTransformersValueEmission() {
         let signalProducer1 = SignalProducer<String, Error>(value: "Hello")
-        let worker1 = signalProducer1.asWorker { _ in "Ooops 1" }
+        let worker1 = signalProducer1.asWorker(key: "hello-worker") { _ in "Ooops 1" }
         
         XCTAssertNotNil(worker1)
         XCTAssertEqual(worker1.run().first()?.value, "Hello")
         
         let signalProducer2 = SignalProducer<String, Error>(value: "World")
-        let worker2 = signalProducer2.asWorker { _ in SignalProducer(value: "Ooops 2") }
+        let worker2 = signalProducer2.asWorker(key: "world-worker") { _ in SignalProducer(value: "Ooops 2") }
         
         XCTAssertNotNil(worker2)
         XCTAssertEqual(worker2.run().first()?.value, "World")
         
         let signalProducer3 = SignalProducer<String, Error>(value: "Foo")
-        let worker3 = signalProducer3.asWorker()
+        let worker3 = signalProducer3.asWorker(key: "foo-worker")
         
         XCTAssertNotNil(worker3)
         XCTAssertEqual(worker3.run().first()?.value?.value, "Foo")
@@ -64,19 +74,19 @@ final class SignalProducerWorkerTests: XCTestCase {
     
     func test_signalProducerAsWorkerErrorTransformersErrorEmission() {
         let signalProducer1 = SignalProducer<String, Error>(error: MyError())
-        let worker1 = signalProducer1.asWorker { _ in "Ooops 1" }
+        let worker1 = signalProducer1.asWorker(key: "error-worker-1") { _ in "Ooops 1" }
         
         XCTAssertNotNil(worker1)
         XCTAssertEqual(worker1.run().first()?.value, "Ooops 1")
         
         let signalProducer2 = SignalProducer<String, Error>(error: MyError())
-        let worker2 = signalProducer2.asWorker { _ in SignalProducer(value: "Ooops 2") }
+        let worker2 = signalProducer2.asWorker(key: "error-worker-2") { _ in SignalProducer(value: "Ooops 2") }
 
         XCTAssertNotNil(worker2)
         XCTAssertEqual(worker2.run().first()?.value, "Ooops 2")
         
         let signalProducer3 = SignalProducer<String, Error>(error: MyError())
-        let worker3 = signalProducer3.asWorker()
+        let worker3 = signalProducer3.asWorker(key: "error-worker-3")
         
         XCTAssertNotNil(worker3)
         XCTAssertNil(worker3.run().first()?.value?.value)

--- a/swift/WorkflowTesting/Sources/RenderExpectations.swift
+++ b/swift/WorkflowTesting/Sources/RenderExpectations.swift
@@ -75,13 +75,15 @@ public struct ExpectedState<WorkflowType: Workflow> {
 
 
 public struct ExpectedWorker {
+    let key: String
     let worker: Any
     private let output: Any?
 
     /// Create a new expected worker with an optional output. If `output` is not nil, it will be emitted
     /// when this worker is declared in the render pass.
-    public init<WorkerType: Worker>(worker: WorkerType, output: WorkerType.Output? = nil) {
+    public init<WorkerType: Worker>(worker: WorkerType, key: String = "", output: WorkerType.Output? = nil) {
         self.worker = worker
+        self.key = key
         self.output = output
     }
 

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -282,10 +282,9 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
             }
     }
 
-    func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
-
+    func awaitResult<W, Action>(for worker: W, key: String = "", outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
         guard let workerIndex = expectations.expectedWorkers.firstIndex(where: { (expectedWorker) -> Bool in
-            return expectedWorker.isEquivalent(to: worker)
+            return expectedWorker.isEquivalent(to: worker) && expectedWorker.key == key
         }) else {
             XCTFail("Unexpected worker during render \(worker)", file: file, line: line)
             return


### PR DESCRIPTION
Resolves #581, issue originally created from https://github.com/square/workflow/pull/571#discussion_r318785702.

Change summary:
* Adds `asWorker` extensions to `SignalProducer` with doc comments.
* Adds optional `key` parameter to `awaitResult` as @zach-klippenstein  points out is the Workflow-Kotlin method