### PR TITLE
#842: Detect possible Worker mock setup issues.

### DIFF
--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/NullFlowWorker.java
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/NullFlowWorker.java
@@ -1,0 +1,30 @@
+package com.squareup.workflow.internal;
+
+import com.squareup.workflow.Worker;
+import kotlinx.coroutines.flow.Flow;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Worker that incorrectly returns null from {@link #run}, to simulate the default behavior of some
+ * mocking libraries.
+ *
+ * See <a href="https://github.com/square/workflow/issues/842">#842</a>.
+ */
+class NullFlowWorker implements Worker {
+  @NotNull @Override public Flow run() {
+    //noinspection ConstantConditions
+    return null;
+  }
+
+  @Override public boolean doesSameWorkAs(@NotNull Worker otherWorker) {
+    //noinspection unchecked
+    return Worker.DefaultImpls.doesSameWorkAs(this, otherWorker);
+  }
+
+  /**
+   * Override this to make writing assertions on exception messages easier.
+   */
+  @Override public String toString() {
+    return "NullFlowWorker.toString";
+  }
+}


### PR DESCRIPTION
Per #842:
> In unit tests, if you use Mockito to create a Worker, the `run` method will return `null` even though the return type is non-nullable in Kotlin. Kotlin helps out with this by throwing an NPE before control is returned to any kotlin code, but the NPE that it throws includes an almost completely useless stacktrace and no other details.
>
> We can do better: When calling `worker.run()`, we can catch the NPE and throw a wrapper exception that asks if you're using mocks and reminds you to do the right thing.

Closes #842 