### PR TITLE
Give worker coroutines descriptive names for debugging.

### DIFF
--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -93,7 +93,8 @@ internal class WorkflowNode<PropsT, StateT, OutputT : Any, RenderingT>(
             diagnosticListener
                 .onWorkerStarted(workerId, diagnosticId, case.key, case.worker.toString())
           }
-          val workerChannel = launchWorker(case.worker, workerId, diagnosticId, diagnosticListener)
+          val workerChannel =
+            launchWorker(case.worker, case.key, workerId, diagnosticId, diagnosticListener)
           WorkerSession(workerChannel)
         },
         dispose = { _, session -> session.channel.cancel() }


### PR DESCRIPTION
Also fills out the worker docs some more.

Closes #848.