### PR TITLE
Make all workers run on the Unconfined dispatcher.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -123,11 +123,17 @@ interface Worker<out OutputT> {
    *
    * ## Coroutine Context
    *
-   * When a worker is started, a coroutine is launched to [collect][Flow.collect] the flow. This
-   * coroutine is launched in the same scope as the workflow runtime, with the addition a
-   * [CoroutineName][kotlinx.coroutines.CoroutineName] that describes the `Worker` instance
-   * (via `toString`) and the key specified by the workflow running the worker. When the worker is
-   * torn down, the coroutine is cancelled.
+   * When a worker is started, a coroutine is launched to [collect][Flow.collect] the flow.
+   * When the worker is torn down, the coroutine is cancelled.
+   * This coroutine is launched in the same scope as the workflow runtime, with a few changes:
+   *
+   * - The dispatcher is always set to [Unconfined][kotlinx.coroutines.Dispatchers.Unconfined] to
+   *   minimize overhead for workers that don't care which thread they're executed on (e.g. logging
+   *   side effects, workers that wrap third-party reactive libraries, etc.). If your work cares
+   *   which thread it runs on, use [withContext][kotlinx.coroutines.withContext] or
+   *   [flowOn][kotlinx.coroutines.flow.flowOn] to specify a dispatcher.
+   * - A [CoroutineName][kotlinx.coroutines.CoroutineName] that describes the `Worker` instance
+   *   (via `toString`) and the key specified by the workflow running the worker.
    *
    * ## Exceptions
    *

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/Workers.kt
@@ -20,6 +20,7 @@ import com.squareup.workflow.Worker
 import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
@@ -131,7 +132,7 @@ private fun <T> Flow<T>.transformToValueOrDone(): Flow<ValueOrDone<T>> = flow {
 private fun CoroutineScope.createWorkerScope(
   worker: Worker<*>,
   key: String
-): CoroutineScope = this + CoroutineName(worker.debugName(key))
+): CoroutineScope = this + CoroutineName(worker.debugName(key)) + Unconfined
 
 private fun Worker<*>.debugName(key: String) =
   toString().let { if (key.isBlank()) it else "$it:$key" }


### PR DESCRIPTION
From the kdoc:

> The dispatcher is always set to `Unconfined` to
>    *   minimize overhead for workers that don't care which thread they're executed on (e.g. logging
>    *   side effects, workers that wrap third-party reactive libraries, etc.). If your work cares
>    *   which thread it runs on, use `withContext` or
>    *   `flowOn` to specify a dispatcher.

Previously, the workers would run on the same dispatcher as the workflow runtime (`Main.immediate`), which meant that if the worker was wrapping, e.g., an `Observable` that was emitting on a background thread, the coroutine would dispatch back onto the main thread before sending to the channel, which is completely unnecessary, since channels are already thread-safe.

This doesn't change the threading behavior for simple side-effect-only workers – since they're started from the workflow runtime, they will be dispatched onto the nested event loop that `Main.immediate` creates for "immediate" dispatches.