### PR TITLE
WorkflowAction.invoke is now action

### DIFF
--- a/kotlin/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
+++ b/kotlin/samples/hello-terminal/todo-terminal-app/src/main/java/com/squareup/sample/hellotodo/TodoWorkflow.kt
@@ -102,14 +102,14 @@ class TodoWorkflow : TerminalWorkflow,
   }
 }
 
-private fun updateTitle(newTitle: String): TodoAction = WorkflowAction {
+private fun updateTitle(newTitle: String): TodoAction = action {
   nextState = nextState.copy(title = newTitle)
 }
 
 private fun setLabel(
   index: Int,
   text: String
-): TodoAction = WorkflowAction {
+): TodoAction = action {
   nextState = nextState.copy(items = nextState.items.mapIndexed { i, item ->
     if (index == i) item.copy(label = text) else item
   })

--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
@@ -9,7 +9,7 @@ import com.squareup.sample.gameworkflow.RunGameScreen
 import com.squareup.sample.gameworkflow.RunGameWorkflow
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.rendering
 import com.squareup.workflow.stateless
 import com.squareup.workflow.testing.testFromStart
@@ -37,7 +37,7 @@ class MainWorkflowTest {
   @Test fun `starts game on auth`() {
     val authWorkflow: AuthWorkflow = Workflow.stateless {
       runningWorker(Worker.from { Unit }) {
-        WorkflowAction { setOutput(Authorized("auth")) }
+        action { setOutput(Authorized("auth")) }
       }
       authScreen()
     }

--- a/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
+++ b/kotlin/samples/todo-android/common/src/main/java/com/squareup/sample/todo/TodoListsAppWorkflow.kt
@@ -64,7 +64,7 @@ object TodoListsAppWorkflow :
     nextState = EditingList(nextState.lists, index)
   }
 
-  private fun onEditOutput(output: TodoEditorOutput): TodoListsAction = WorkflowAction {
+  private fun onEditOutput(output: TodoEditorOutput): TodoListsAction = action {
     nextState = when (output) {
       is ListUpdated -> {
         val oldState = nextState as EditingList

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/RenderContext.kt
@@ -40,7 +40,8 @@ import com.squareup.workflow.WorkflowAction.Updater
  *
  * To create populate such functions from your `render` method, you first need to define a
  * [WorkflowAction] to handle the event by changing state, emitting an output, or both. Then, just
- * pass a lambda to your rendering that instantiates the action and passes it to [send].
+ * pass a lambda to your rendering that instantiates the action and passes it to
+ * [actionSink.send][Sink.send].
  *
  * ## Performing asynchronous work
  *
@@ -179,7 +180,7 @@ fun <StateT, OutputT : Any> RenderContext<StateT, OutputT>.runningWorker(
 fun <EventT, StateT, OutputT : Any> RenderContext<StateT, OutputT>.makeEventSink(
   update: Updater<StateT, OutputT>.(EventT) -> Unit
 ): Sink<EventT> = actionSink.contraMap { event ->
-  WorkflowAction({ "eventSink($event)" }) { update(event) }
+  action({ "eventSink($event)" }) { update(event) }
 }
 
 /**

--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/StatelessWorkflow.kt
@@ -109,7 +109,7 @@ fun <PropsT, OutputT : Any, FromRenderingT, ToRenderingT>
 ): Workflow<PropsT, OutputT, ToRenderingT> = Workflow.stateless { props ->
   /* ktlint-disable parameter-list-wrapping */
   renderChild(this@mapRendering, props) { output ->
-    WorkflowAction({ "mapRendering" }) { setOutput(output) }
+    action({ "mapRendering" }) { setOutput(output) }
   }.let(transform)
 }
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/WorkflowDiagnosticListener.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/diagnostic/WorkflowDiagnosticListener.kt
@@ -283,7 +283,7 @@ interface WorkflowDiagnosticListener {
    *
    * Either [onWorkerOutput] or [onSinkReceived] will have been called before this.
    *
-   * @param workflowId The ID of the workflow that created this [action].
+   * @param workflowId The ID of the workflow that created [action].
    * @param action The [WorkflowAction] that was executed.
    * @param oldState The state of the workflow before executing [action].
    * @param newState The state of the workflow after executing [action]. If the action doesn't set

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/RealRenderContextTest.kt
@@ -26,6 +26,7 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowAction.Companion.noAction
 import com.squareup.workflow.WorkflowAction.Updater
+import com.squareup.workflow.action
 import com.squareup.workflow.applyTo
 import com.squareup.workflow.internal.RealRenderContext.Renderer
 import com.squareup.workflow.internal.RealRenderContextTest.TestRenderer.Rendering
@@ -127,7 +128,7 @@ class RealRenderContextTest {
 
   @Test fun `send completes update`() {
     val context = RealRenderContext(PoisonRenderer(), eventActionsChannel)
-    val stringAction = WorkflowAction<String, String>({ "stringAction" }) { }
+    val stringAction = action<String, String>({ "stringAction" }) { }
     // Enable sink sends.
     context.buildBehavior()
 
@@ -213,7 +214,7 @@ class RealRenderContextTest {
     val workflow = TestWorkflow()
 
     val (child, props, key, handler) = context.renderChild(workflow, "props", "key") { output ->
-      WorkflowAction { setOutput("output:$output") }
+      action { setOutput("output:$output") }
     }
 
     assertSame(workflow, child)

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/SubtreeManagerTest.kt
@@ -22,6 +22,7 @@ import com.squareup.workflow.Sink
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.applyTo
 import com.squareup.workflow.internal.SubtreeManagerTest.TestWorkflow.Rendering
 import com.squareup.workflow.makeEventSink
@@ -168,7 +169,7 @@ class SubtreeManagerTest {
       SubtreeManager<String, String>(context, parentDiagnosticId = 0, diagnosticListener = null)
     val workflow = TestWorkflow()
     val handler: StringHandler = { output ->
-      WorkflowAction { setOutput("case output:$output") }
+      action { setOutput("case output:$output") }
     }
 
     // Initialize the child so tickChildren has something to work with, and so that we can send
@@ -197,7 +198,7 @@ class SubtreeManagerTest {
 
     runBlocking {
       // First render + tick pass – uninteresting.
-      render { WorkflowAction { setOutput("initial handler: $it") } }
+      render { action { setOutput("initial handler: $it") } }
           .let { rendering ->
             rendering.eventHandler("initial output")
             val initialAction = manager.tickAction()!!
@@ -206,7 +207,7 @@ class SubtreeManagerTest {
           }
 
       // Do a second render + tick, but with a different handler function.
-      render { WorkflowAction { setOutput("second handler: $it") } }
+      render { action { setOutput("second handler: $it") } }
           .let { rendering ->
             rendering.eventHandler("second output")
             val secondAction = manager.tickAction()!!

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowDiagnosticListenerIntegrationTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowDiagnosticListenerIntegrationTest.kt
@@ -19,7 +19,7 @@ import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.asWorker
 import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
 import com.squareup.workflow.diagnostic.andThen
@@ -189,7 +189,7 @@ class WorkflowDiagnosticListenerIntegrationTest {
   @Test fun `workflow updates emit events in order`() {
     val channel = Channel<String>()
     val worker = channel.asWorker()
-    fun action(value: String) = WorkflowAction<Nothing, String> { setOutput("output:$value") }
+    fun action(value: String) = action<Nothing, String> { setOutput("output:$value") }
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningWorker(worker, "key", ::action)
     }

--- a/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
+++ b/kotlin/workflow-runtime/src/test/java/com/squareup/workflow/internal/WorkflowNodeTest.kt
@@ -25,6 +25,7 @@ import com.squareup.workflow.Workflow
 import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowAction.Companion.emitOutput
 import com.squareup.workflow.WorkflowAction.Updater
+import com.squareup.workflow.action
 import com.squareup.workflow.asWorker
 import com.squareup.workflow.makeEventSink
 import com.squareup.workflow.parse
@@ -282,7 +283,7 @@ class WorkflowNodeTest {
         context.runningWorker(channel.asWorker()) {
           check(update == null)
           update = it
-          WorkflowAction { setOutput("update:$it") }
+          action { setOutput("update:$it") }
         }
         return ""
       }
@@ -331,11 +332,11 @@ class WorkflowNodeTest {
         return props
       }
 
-      fun update(value: String) = WorkflowAction<String, String> {
+      fun update(value: String) = action<String, String> {
         setOutput("update:$value")
       }
 
-      val finish = WorkflowAction<String, String> {
+      val finish = action<String, String> {
         nextState = "finished"
       }
 

--- a/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
+++ b/kotlin/workflow-rx2/src/test/java/com/squareup/workflow/rx2/PublisherWorkerTest.kt
@@ -17,7 +17,7 @@ package com.squareup.workflow.rx2
 
 import com.squareup.workflow.Worker
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowAction
+import com.squareup.workflow.action
 import com.squareup.workflow.stateless
 import com.squareup.workflow.testing.testFromStart
 import io.reactivex.BackpressureStrategy.BUFFER
@@ -36,7 +36,7 @@ class PublisherWorkerTest {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = otherWorker === this
     }
 
-    fun action(value: String) = WorkflowAction<Nothing, String> { setOutput(value) }
+    fun action(value: String) = action<Nothing, String> { setOutput(value) }
     val workflow = Workflow.stateless<Unit, String, Unit> {
       runningWorker(worker) { action(it) }
     }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerCompositionIntegrationTest.kt
@@ -131,7 +131,7 @@ class WorkerCompositionIntegrationTest {
   @Test fun `runningWorker gets output`() {
     val worker = WorkerSink<String>("")
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(worker) { WorkflowAction { setOutput(it) } }
+      runningWorker(worker) { action { setOutput(it) } }
     }
 
     workflow.testFromStart {
@@ -146,7 +146,7 @@ class WorkerCompositionIntegrationTest {
   @Test fun `runningWorker gets error`() {
     val channel = Channel<String>()
     val workflow = Workflow.stateless<Unit, String, Unit> {
-      runningWorker(channel.asWorker()) { WorkflowAction { setOutput(it) } }
+      runningWorker(channel.asWorker()) { action { setOutput(it) } }
     }
 
     assertFailsWith<ExpectedException> {
@@ -180,14 +180,14 @@ class WorkerCompositionIntegrationTest {
   @Test fun `onWorkerOutput closes over latest state`() {
     val triggerOutput = WorkerSink<Unit>("")
 
-    val incrementState = WorkflowAction<Int, Int> {
+    val incrementState = action<Int, Int> {
       nextState += 1
     }
 
     val workflow = Workflow.stateful<Int, Int, () -> Unit>(
         initialState = 0,
         render = { state ->
-          runningWorker(triggerOutput) { WorkflowAction { setOutput(state) } }
+          runningWorker(triggerOutput) { action { setOutput(state) } }
 
           return@stateful { actionSink.send(incrementState) }
         }

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerStressTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerStressTest.kt
@@ -25,7 +25,7 @@ class WorkerStressTest {
       channel.asWorker()
           .transform { it.onCompletion { emit(Unit) } }
     }
-    val action = WorkflowAction<Nothing, Unit> { setOutput(Unit) }
+    val action = action<Nothing, Unit> { setOutput(Unit) }
     val workflow = Workflow.stateless<Unit, Unit, Unit> {
       // Run lots of workers that will all see the same close event.
       workers.forEachIndexed { i, worker ->
@@ -57,7 +57,7 @@ class WorkerStressTest {
   @Test fun `multiple subscriptions to single channel when emits`() {
     val channel = ConflatedBroadcastChannel(Unit)
     val workers = List(100) { channel.asWorker() }
-    val action = WorkflowAction<Nothing, Int> { setOutput(1) }
+    val action = action<Nothing, Int> { setOutput(1) }
     val workflow = Workflow.stateless<Unit, Int, Unit> {
       // Run lots of workers that will all see the same conflated channel value.
       workers.forEachIndexed { i, worker ->

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkflowCompositionIntegrationTest.kt
@@ -104,15 +104,15 @@ class WorkflowCompositionIntegrationTest {
   @Test fun `renderChild closes over latest state`() {
     val triggerChildOutput = WorkerSink<Unit>("")
     val child = Workflow.stateless<Unit, Unit, Unit> {
-      runningWorker(triggerChildOutput) { WorkflowAction { setOutput(Unit) } }
+      runningWorker(triggerChildOutput) { action { setOutput(Unit) } }
     }
-    val incrementState = WorkflowAction<Int, Int> {
+    val incrementState = action<Int, Int> {
       nextState += 1
     }
     val workflow = Workflow.stateful<Int, Int, () -> Unit>(
         initialState = 0,
         render = { state ->
-          renderChild(child) { WorkflowAction { setOutput(state) } }
+          renderChild(child) { action { setOutput(state) } }
           return@stateful { actionSink.send(incrementState) }
         }
     )

--- a/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
+++ b/kotlin/workflow-ui-android/src/test/java/com/squareup/workflow/ui/WorkflowRunnerViewModelTest.kt
@@ -9,8 +9,8 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.workflow.RenderingAndSnapshot
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.Workflow
-import com.squareup.workflow.WorkflowAction
 import com.squareup.workflow.WorkflowSession
+import com.squareup.workflow.action
 import com.squareup.workflow.asWorker
 import com.squareup.workflow.stateless
 import com.squareup.workflow.ui.WorkflowRunner.Config
@@ -106,7 +106,7 @@ class WorkflowRunnerViewModelTest {
     val outputs = BroadcastChannel<String>(1)
     val runner = Workflow
         .stateless<Unit, String, Unit> {
-          runningWorker(outputs.asWorker()) { WorkflowAction { setOutput(it) } }
+          runningWorker(outputs.asWorker()) { action { setOutput(it) } }
           Unit
         }
         .run()
@@ -122,7 +122,7 @@ class WorkflowRunnerViewModelTest {
   @Test fun resultEmptyOnCleared() {
     val runner = Workflow
         .stateless<Unit, String, Unit> {
-          runningWorker(flowNever<String>().asWorker()) { WorkflowAction { setOutput(it) } }
+          runningWorker(flowNever<String>().asWorker()) { action { setOutput(it) } }
         }
         .run()
 


### PR DESCRIPTION
`v0.22.0` changed `Workflow.invoke()` to use `Updater` instead of `Mutator`.
That's a breaking change, but it compiles just fine  -- updating to `v0.22.0`
or later is a fraught process.

Motivated by that, this change eliminates `WorkflowAction.invoke` entirely,
replacing it with an `action` function that parallels `StatefulWorkflow.action`
and `StatelessWorkflow.action`.

However we got here, I'm pretty happy with the final shape!