### PR TITLE
Adds ContainerHints to ShowRenderingTag.

### DIFF
--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Workflow'
-  s.version      = '0.22.2'
+  s.version      = '0.22.3'
   s.summary      = 'Reactive application architecture'
   s.homepage     = 'https://www.github.com/square/workflow'
   s.license      = 'Apache License, Version 2.0'

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'WorkflowTesting'
-  s.version      = '0.22.2'
+  s.version      = '0.22.3'
   s.summary      = 'Reactive application architecture'
   s.homepage     = 'https://www.github.com/square/workflow'
   s.license      = 'Apache License, Version 2.0'

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'WorkflowUI'
-  s.version      = '0.22.2'
+  s.version      = '0.22.3'
   s.summary      = 'Infrastructure for Workflow-powered UI'
   s.homepage     = 'https://www.github.com/square/workflow'
   s.license      = 'Apache License, Version 2.0'

--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -21,7 +21,7 @@ android.useAndroidX=true
 #android.debug.obsoleteApi=true
 
 GROUP=com.squareup.workflow
-VERSION_NAME=0.22.2
+VERSION_NAME=0.22.3-SNAPSHOT
 
 POM_DESCRIPTION=Reactive workflows
 

--- a/kotlin/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/kotlin/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -24,16 +24,19 @@ import com.squareup.sample.gameworkflow.Player
 import com.squareup.sample.gameworkflow.symbol
 import com.squareup.sample.mainactivity.MainActivity
 import com.squareup.sample.tictactoe.R
+import com.squareup.workflow.ui.ContainerHints
+import com.squareup.workflow.ui.hints
 import com.squareup.workflow.ui.getRendering
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
 class TicTacToeEspressoTest {
 
-  lateinit var scenario: ActivityScenario<MainActivity>
+  private lateinit var scenario: ActivityScenario<MainActivity>
 
   @Before
   fun setUp() {
@@ -65,12 +68,18 @@ class TicTacToeEspressoTest {
 
     onView(withId(R.id.start_game)).perform(click())
 
+    val hints = AtomicReference<ContainerHints>()
+
     // Why should I learn how to write a matcher when I can just grab the activity
     // and work with it directly?
     scenario.onActivity { activity ->
       val button = activity.findViewById<View>(R.id.game_play_board)
-      val rendering = (button.parent as View).getRendering<GamePlayScreen>()!!
+      val parent = button.parent as View
+      val rendering = parent.getRendering<GamePlayScreen>()!!
       assertThat(rendering.gameState.playing).isSameInstanceAs(Player.X)
+      val firstHints = parent.hints
+      assertThat(firstHints).isNotNull()
+      hints.set(firstHints)
 
       // Make a move.
       rendering.onClick(0, 0)
@@ -88,8 +97,10 @@ class TicTacToeEspressoTest {
     // to mess with what should be the updated rendering.
     scenario.onActivity { activity ->
       val button = activity.findViewById<View>(R.id.game_play_board)
-      val rendering = (button.parent as View).getRendering<GamePlayScreen>()!!
+      val parent = button.parent as View
+      val rendering = parent.getRendering<GamePlayScreen>()!!
       assertThat(rendering.gameState.playing).isSameInstanceAs(Player.O)
+      assertThat(parent.hints).isEqualTo(hints.get())
     }
   }
 

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewShowRendering.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewShowRendering.kt
@@ -32,6 +32,7 @@ typealias ViewShowRendering<RenderingT> = (@UnsafeVariance RenderingT, Container
  */
 data class ShowRenderingTag<out RenderingT : Any>(
   val showing: RenderingT,
+  val hints: ContainerHints,
   val showRendering: ViewShowRendering<RenderingT>
 )
 
@@ -49,7 +50,10 @@ fun <RenderingT : Any> View.bindShowRendering(
   initialContainerHints: ContainerHints,
   showRendering: ViewShowRendering<RenderingT>
 ) {
-  setTag(R.id.view_show_rendering_function, ShowRenderingTag(initialRendering, showRendering))
+  setTag(
+      R.id.view_show_rendering_function,
+      ShowRenderingTag(initialRendering, initialContainerHints, showRendering)
+  )
   showRendering.invoke(initialRendering, initialContainerHints)
 }
 
@@ -101,6 +105,7 @@ fun <RenderingT : Any> View.showRendering(
  * has never been called.
  */
 fun <RenderingT : Any> View.getRendering(): RenderingT? {
+  // Can't use a val because of the parameter type.
   @Suppress("UNCHECKED_CAST")
   return when (val showing = showRenderingTag?.showing) {
     null -> null
@@ -109,12 +114,16 @@ fun <RenderingT : Any> View.getRendering(): RenderingT? {
 }
 
 /**
+ * Returns the most recent [ContainerHints] that apply to this view, or null if [bindShowRendering]
+ * has never been called.
+ */
+val View.hints: ContainerHints? get() = showRenderingTag?.hints
+
+/**
  * Returns the function set by the most recent call to [bindShowRendering], or null
  * if that method has never been called.
  */
 fun <RenderingT : Any> View.getShowRendering(): ViewShowRendering<RenderingT>? {
-  // IDE is lying, casting here is unnecessary and causes a compiler warning.
-  // https://youtrack.jetbrains.com/issue/KT-34433
   return showRenderingTag?.showRendering
 }
 


### PR DESCRIPTION
We're already storing the most recent rendering in view tags. It's weird that we don't do so for the ContainerHints that are always provided at render time, and the lack is actually getting in my way as I build custom containers.

(Note additional commit to bump the version number.)