### PR TITLE
Flag out WorkflowTesting APIs when in Release mode

### DIFF
--- a/swift/WorkflowTesting/Sources/WorkflowActionTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowActionTester.swift
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// WorkflowTesting only available in Debug mode.
+//
+// `@testable import Workflow` will fail compilation in Release mode.
+#if DEBUG
+
 @testable import Workflow
 
 
@@ -82,3 +88,5 @@ public struct WorkflowActionTester<WorkflowType, Action> where Action: WorkflowA
     }
 
 }
+
+#endif

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -13,9 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if DEBUG
+
+// WorkflowTesting only available in Debug mode.
+//
+// `@testable import Workflow` will fail compilation in Release mode.
+@testable import Workflow
+
 import XCTest
 import ReactiveSwift
-@testable import Workflow
 
 
 extension Workflow {
@@ -332,3 +339,5 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
**Issue:**
`pod trunk push WorkflowTesting.podspec` fails during validation.

**Reason:**
`Workflow` is built with `ENABLE_TESTABILITY=NO` for `Release` builds, causing `@testable import WorkflowTesting` to fail compilation in `Release`. 

**Proposal:**
`WorkflowTesting` is meant to be used for Unit Testing only. Flag out the relevant bits when not in `Debug` mode.