### PR TITLE
Allow empty snapshots to be passed into launchWorkflowIn.

### DIFF
--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/LaunchWorkflow.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/LaunchWorkflow.kt
@@ -85,7 +85,7 @@ internal typealias Configurator <O, R, T> = CoroutineScope.(
  * will fail (report an exception up through [scope]). If this flow completes _after_ emitting at
  * least one value, the runtime will _not_ fail or stop, it will continue running with the
  * last-emitted input.
- * @param initialSnapshot If not null, used to restore the workflow.
+ * @param initialSnapshot If not null or empty, used to restore the workflow.
  * @param beforeStart Called exactly once with the flows for renderings/snapshots and outputs.
  * It also gets a sub-scope of [scope] with a newly created child [Job] which defines the lifetime
  * of the launched workflow tree. Cancelling that job ends the new workflow session.

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
@@ -35,8 +35,8 @@ internal interface WorkflowLoop {
    * Loops forever, or until the coroutine is cancelled, processing the workflow tree and emitting
    * updates by calling [onRendering] and [onOutput].
    *
-   * This function is the lowest-level entry point into the runtime. Don't call this directly, instead
-   * call [com.squareup.workflow.launchWorkflowIn].
+   * This function is the lowest-level entry point into the runtime. Don't call this directly,
+   * instead call [com.squareup.workflow.launchWorkflowIn].
    */
   @Suppress("LongParameterList")
   suspend fun <PropsT, StateT, OutputT : Any, RenderingT> runWorkflowLoop(
@@ -76,7 +76,7 @@ internal open class RealWorkflowLoop : WorkflowLoop {
           id = workflow.id(),
           workflow = workflow,
           initialProps = input,
-          snapshot = initialSnapshot?.bytes,
+          snapshot = initialSnapshot?.bytes?.takeUnless { it.size == 0 },
           baseContext = coroutineContext,
           parentDiagnosticId = null,
           diagnosticListener = diagnosticListener,

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/SnapshottingIntegrationTest.kt
@@ -49,6 +49,18 @@ class SnapshottingIntegrationTest {
     }
   }
 
+  @Test fun `empty snapshot is ignored`() {
+    val root = TreeWorkflow("root")
+    val snapshot = Snapshot.EMPTY
+
+    root.testFromStart(
+        props = "initial props",
+        testParams = WorkflowTestParams(startFrom = StartFromCompleteSnapshot(snapshot))
+    ) {
+      // Success!
+    }
+  }
+
   @Test fun `snapshots and restores parent child workflows`() {
     val root = TreeWorkflow("root", TreeWorkflow("leaf"))
     var snapshot: Snapshot? = null


### PR DESCRIPTION
Fixes #879.

cc @Blisse 