### PR TITLE
Paramaterize the return type of Worker.finished() to make it more convenient to use in tests.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/Worker.kt
@@ -213,7 +213,7 @@ interface Worker<out OutputT> {
     /**
      * Returns a [Worker] that finishes immediately without emitting anything.
      */
-    fun finished(): Worker<Nothing> = FinishedWorker
+    fun <T> finished(): Worker<T> = FinishedWorker
 
     /**
      * Creates a [Worker] from a function that returns a single value.

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/WorkerTest.kt
@@ -234,7 +234,7 @@ class WorkerTest {
   }
 
   @Test fun `finished worker is equivalent to self`() {
-    assertTrue(Worker.finished().doesSameWorkAs(Worker.finished()))
+    assertTrue(Worker.finished<Nothing>().doesSameWorkAs(Worker.finished<Nothing>()))
   }
 
   @Test fun `transformed workers are equivalent with equivalent source`() {

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
@@ -189,7 +189,7 @@ class RealRenderTesterTest {
         initialState = Unit,
         render = {
           // Need to satisfy the expectation.
-          runningWorker(Worker.finished() as Worker<Unit>) { noAction() }
+          runningWorker(Worker.finished<Unit>()) { noAction() }
           return@stateful actionSink.contraMap { it }
         }
     )
@@ -571,7 +571,7 @@ class RealRenderTesterTest {
   }
 
   @Test fun `verifyAction verifies worker output`() {
-    val worker: Worker<String> = Worker.finished()
+    val worker = Worker.finished<String>()
     val workflow = Workflow.stateless<Unit, Nothing, Unit> {
       runningWorker(worker) { TestAction(it) }
     }


### PR DESCRIPTION
It was initially like this, and then I switched it to `Nothing` to make the function simpler,
but I just realized that most of the uses do a cast anyway so it's better to just have a more
generic type. This is also more consistent with `emptyList()`, `emptyFlow()`, etc.

cc @ellapolo 