### PR TITLE
Upgrade Dokka to 0.10.0 and maven publish to 0.9.0-SNAPSHOT.

### DIFF
--- a/kotlin/.buildscript/configure-dokka.gradle
+++ b/kotlin/.buildscript/configure-dokka.gradle
@@ -27,15 +27,17 @@ afterEvaluate { project ->
   project.tasks.dokka {
     outputDirectory = "$rootDir/../docs/kotlin/api"
     outputFormat = 'gfm'
-    reportUndocumented = false
-    skipDeprecated = true
-    jdkVersion = 8
-    packageOptions {
-      prefix = "com.squareup.workflow.internal"
-      suppress = true
-    }
-    if (project.file('Module.md').exists()) {
-      includes = ['Module.md']
+    configuration {
+      reportUndocumented = false
+      skipDeprecated = true
+      jdkVersion = 8
+      perPackageOption {
+        prefix = "com.squareup.workflow.internal"
+        suppress = true
+      }
+      if (project.file('Module.md').exists()) {
+        includes = ['Module.md']
+      }
     }
   }
 }

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -84,8 +84,7 @@ buildscript {
               'mockito': "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
           ]
       ],
-      'dokkaAndroid': "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18",
-      'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:0.9.18",
+      'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0",
       'jmh': [
           'gradlePlugin': "me.champeau.gradle:jmh-gradle-plugin:0.5.0",
           'core': "org.openjdk.jmh:jmh-core:1.22",
@@ -93,7 +92,7 @@ buildscript {
       ],
       // Source of "API 'variant.getJavaCompile()' is obsolete" warning, fixed in upcoming 0.9.0.
       // See https://github.com/vanniktech/gradle-maven-publish-plugin/issues/67.
-      'mavenPublish': "com.vanniktech:gradle-maven-publish-plugin:0.8.0",
+      'mavenPublish': "com.vanniktech:gradle-maven-publish-plugin:0.9.0-SNAPSHOT",
       'ktlint': "org.jlleitschuh.gradle:ktlint-gradle:9.1.1",
       'lanterna': "com.googlecode.lanterna:lanterna:3.0.2",
       'detekt': "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1",
@@ -127,7 +126,6 @@ buildscript {
     classpath deps.android_gradle_plugin
     classpath deps.detekt
     classpath deps.dokka
-    classpath deps.dokkaAndroid
     classpath deps.jmh.gradlePlugin
     classpath deps.kotlin.gradlePlugin
     classpath deps.ktlint
@@ -138,6 +136,10 @@ buildscript {
     mavenCentral()
     gradlePluginPortal()
     google()
+    // For the snapshot version of the maven publish plugin.
+    maven {
+      url { "https://oss.sonatype.org/content/repositories/snapshots" }
+    }
   }
 }
 

--- a/kotlin/workflow-ui-android/build.gradle
+++ b/kotlin/workflow-ui-android/build.gradle
@@ -15,7 +15,7 @@
  */
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'org.jetbrains.dokka-android'
+apply plugin: 'org.jetbrains.dokka'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Closes #651.

This technically fixes #569 as well (according to https://github.com/vanniktech/gradle-maven-publish-plugin/issues/54),
and after uploading the artifact server has the sources jar with the actual sources inside. However, when
consuming via gradle, IntelliJ still isn't showing the sources for AARs (it is for JARs). The android artifacts
have a `-api` suffix however, so I'm wondering if the source jars are getting lost in some transformation
(maybe Jetifier?).

Note that the javadocs jars are on the server but they're all empty (for android and non-android
artifacts), but IntelliJ seems to be just fine pulling the kdoc from the source jars, so I guess the source jars
are all that is required for documentation.