### PR TITLE
Disable Jetifier.

### DIFF
--- a/kotlin/gradle.properties
+++ b/kotlin/gradle.properties
@@ -15,7 +15,6 @@
 #
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.parallel=true
-android.enableJetifier=true
 android.useAndroidX=true
 # Uncomment this to diagnose "API $s is obsolete" warnings. Commented out b/c it's pretty noisy.
 #android.debug.obsoleteApi=true


### PR DESCRIPTION
I don't think we're using any libraries any more that use the support library,
so we don't need to waste build time jetifying everything.