### PR TITLE
[Exploration] Use a run loop observer to trigger render passes asynchronously

### DIFF
--- a/swift/Workflow/Sources/RunLoopObserver.swift
+++ b/swift/Workflow/Sources/RunLoopObserver.swift
@@ -18,8 +18,6 @@ import CoreFoundation
 
 /// Swift wrapper for `CFRunLoopObserver`
 internal final class RunLoopObserver {
-    private let runLoop: CFRunLoop
-    private let runLoopModes: CFRunLoopMode
     private var observer: CFRunLoopObserver!
 
     /// Creates a `RunLoopObserver` and adds it to the given run loop for the given run loop modes. See the docs for `CFRunLoopObserverCreateWithHandler` for documentation.
@@ -31,8 +29,6 @@ internal final class RunLoopObserver {
         runLoopModes: CFRunLoopMode = .defaultMode,
         callback: @escaping (_ activityStage: CFRunLoopActivity) -> Void
     ) {
-        self.runLoop = runLoop
-        self.runLoopModes = runLoopModes
         observer = CFRunLoopObserverCreateWithHandler(
             kCFAllocatorDefault,
             activityStages.rawValue,
@@ -47,6 +43,6 @@ internal final class RunLoopObserver {
 
     deinit {
         // Clean up the observer
-        CFRunLoopRemoveObserver(runLoop, observer, runLoopModes)
+        CFRunLoopObserverInvalidate(observer)
     }
 }

--- a/swift/Workflow/Sources/RunLoopObserver.swift
+++ b/swift/Workflow/Sources/RunLoopObserver.swift
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CoreFoundation
+
+/// Swift wrapper for `CFRunLoopObserver`
+internal final class RunLoopObserver {
+    private let runLoop: CFRunLoop
+    private let runLoopModes: CFRunLoopMode
+    private var observer: CFRunLoopObserver!
+
+    /// Creates a `RunLoopObserver` and adds it to the given run loop for the given run loop modes. See the docs for `CFRunLoopObserverCreateWithHandler` for documentation.
+    init(
+        runLoop: CFRunLoop = CFRunLoopGetCurrent(),
+        activityStages: CFRunLoopActivity,
+        repeats: Bool = true,
+        order: CFIndex = 0,
+        runLoopModes: CFRunLoopMode = .defaultMode,
+        callback: @escaping (_ activityStage: CFRunLoopActivity) -> Void
+    ) {
+        self.runLoop = runLoop
+        self.runLoopModes = runLoopModes
+        observer = CFRunLoopObserverCreateWithHandler(
+            kCFAllocatorDefault,
+            activityStages.rawValue,
+            repeats,
+            order,
+            { (observer, activityStage) in
+                callback(activityStage)
+            }
+        )
+        CFRunLoopAddObserver(runLoop, observer, runLoopModes)
+    }
+
+    deinit {
+        // Clean up the observer
+        CFRunLoopRemoveObserver(runLoop, observer, runLoopModes)
+    }
+}

--- a/swift/Workflow/Sources/RunLoopObserver.swift
+++ b/swift/Workflow/Sources/RunLoopObserver.swift
@@ -18,10 +18,10 @@ import CoreFoundation
 
 /// Swift wrapper for `CFRunLoopObserver`
 internal final class RunLoopObserver {
-    private var observer: CFRunLoopObserver!
+    private let observer: CFRunLoopObserver
 
     /// Creates a `RunLoopObserver` and adds it to the given run loop for the given run loop modes. See the docs for `CFRunLoopObserverCreateWithHandler` for documentation.
-    init(
+    init?(
         runLoop: CFRunLoop = CFRunLoopGetCurrent(),
         activityStages: CFRunLoopActivity,
         repeats: Bool = true,
@@ -29,15 +29,15 @@ internal final class RunLoopObserver {
         runLoopModes: CFRunLoopMode = .defaultMode,
         callback: @escaping (_ activityStage: CFRunLoopActivity) -> Void
     ) {
-        observer = CFRunLoopObserverCreateWithHandler(
+        guard let observer = CFRunLoopObserverCreateWithHandler(
             kCFAllocatorDefault,
             activityStages.rawValue,
             repeats,
             order,
-            { (observer, activityStage) in
-                callback(activityStage)
-            }
-        )
+            { _, activityStage in callback(activityStage) }
+        ) else { return nil }
+
+        self.observer = observer
         CFRunLoopAddObserver(runLoop, observer, runLoopModes)
     }
 

--- a/swift/Workflow/Sources/WorkflowHost.swift
+++ b/swift/Workflow/Sources/WorkflowHost.swift
@@ -69,9 +69,13 @@ public final class WorkflowHost<WorkflowType: Workflow> {
             self?.handle(output: output)
         }
 
-        runLoopObserver = RunLoopObserver(activityStages: .beforeWaiting, runLoopModes: .commonModes) { [weak self] activity in
+        guard let observer = RunLoopObserver(activityStages: .beforeWaiting, runLoopModes: .commonModes, callback: { [weak self] activity in
             self?.renderIfNeeded()
+        }) else {
+            fatalError("RunLoopObserver initialization failed")
         }
+
+        self.runLoopObserver = observer
     }
 
     public func setNeedsRender() {

--- a/swift/Workflow/Sources/WorkflowHost.swift
+++ b/swift/Workflow/Sources/WorkflowHost.swift
@@ -78,7 +78,7 @@ public final class WorkflowHost<WorkflowType: Workflow> {
         self.runLoopObserver = observer
     }
 
-    public func setNeedsRender() {
+    private func setNeedsRender() {
         needsRender = true
     }
 

--- a/swift/Workflow/Tests/WorkflowHostTests.swift
+++ b/swift/Workflow/Tests/WorkflowHostTests.swift
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import XCTest
-import Workflow
+@testable import Workflow
 
 
 final class WorkflowHostTests: XCTestCase {
@@ -25,6 +25,7 @@ final class WorkflowHostTests: XCTestCase {
         XCTAssertEqual(1, host.rendering.value)
 
         host.update(workflow: TestWorkflow(step: .second))
+        host.renderIfNeeded()
 
         XCTAssertEqual(2, host.rendering.value)
     }


### PR DESCRIPTION
This changes the render pass to be asynchronous instead of synchronous and will happen **at most** once per run loop. There are likely issues with how this is set up, but I wanted to get some eyes on it sooner rather than later.

I _believe_ this addresses #402.