### PR TITLE
Use KType instead of KClass in TypedWorker.

### DIFF
--- a/kotlin/workflow-core/src/test/java/com/squareup/workflow/WorkerTest.kt
+++ b/kotlin/workflow-core/src/test/java/com/squareup/workflow/WorkerTest.kt
@@ -20,4 +20,22 @@ class WorkerTest {
     assertTrue(Worker1().doesSameWorkAs(Worker1()))
     assertFalse(Worker1().doesSameWorkAs(Worker2()))
   }
+
+  @Test fun `createSideEffect workers are equivalent`() {
+    val worker1 = Worker.createSideEffect {}
+    val worker2 = Worker.createSideEffect {}
+    assertTrue(worker1.doesSameWorkAs(worker2))
+  }
+
+  @Test fun `TypedWorkers are compared by higher types`() {
+    val worker1 = Worker.create<List<Int>> { }
+    val worker2 = Worker.create<List<String>> { }
+    assertFalse(worker1.doesSameWorkAs(worker2))
+  }
+
+  @Test fun `TypedWorkers are equivalent with higher types`() {
+    val worker1 = Worker.create<List<Int>> { }
+    val worker2 = Worker.create<List<Int>> { }
+    assertTrue(worker1.doesSameWorkAs(worker2))
+  }
 }

--- a/kotlin/workflow-tracing/src/test/resources/com/squareup/workflow/diagnostic/tracing/expected_trace_file.txt
+++ b/kotlin/workflow-tracing/src/test/resources/com/squareup/workflow/diagnostic/tracing/expected_trace_file.txt
@@ -36,7 +36,7 @@
 {"name":"TracingDiagnosticListenerTest$TestWorkflow (0)","cat":"rendering","ph":"B","ts":0,"pid":0,"tid":0,"args":{"workflowId":"0","props":"2","state":"changed state"}},
 {"name":"TracingDiagnosticListenerTest$TestWorkflow (1)","cat":"rendering","ph":"B","ts":0,"pid":0,"tid":0,"args":{"workflowId":"1","props":"0","state":"initial"}},
 {"name":"TracingDiagnosticListenerTest$TestWorkflow (1)","cat":"rendering","ph":"E","ts":0,"pid":0,"tid":0,"args":{"rendering":"initial"}},
-{"name":"Worker: 2","cat":"workflow","ph":"b","ts":0,"pid":0,"tid":0,"id":"workflow","args":{"parent":"TracingDiagnosticListenerTest$TestWorkflow (0)","key":"","description":"TypedWorker(class kotlin.String)"}},
+{"name":"Worker: 2","cat":"workflow","ph":"b","ts":0,"pid":0,"tid":0,"id":"workflow","args":{"parent":"TracingDiagnosticListenerTest$TestWorkflow (0)","key":"","description":"TypedWorker(kotlin.String)"}},
 {"name":"TracingDiagnosticListenerTest$TestWorkflow (0)","cat":"rendering","ph":"E","ts":0,"pid":0,"tid":0,"args":{"rendering":"rendering"}},
 {"name":"Render Pass","cat":"rendering","ph":"E","ts":0,"pid":0,"tid":0,"args":{"rendering":"rendering"}},
 {"name":"used/free memory","ph":"C","ts":0,"pid":0,"tid":0,"args":{"usedMemory":1,"freeMemory":42}},


### PR DESCRIPTION
This change allows `TypedWorker`s to be distinguished by type parameters
on their type parameters (e.g. `Worker<List<String>>` vs `Worker<List<Int>>`),
instead of just the erased type (e.g. `Worker<List>` vs `Worker<List>`).