### PR TITLE
Drastically simplifies ModalViewContainer.

### DIFF
--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/SampleContainers.kt
@@ -17,6 +17,9 @@ package com.squareup.sample.container
 
 import com.squareup.sample.container.masterdetail.MasterDetailContainer
 import com.squareup.sample.container.panel.PanelContainer
+import com.squareup.sample.container.panel.ScrimContainer
 import com.squareup.workflow.ui.ViewRegistry
 
-val SampleContainers = ViewRegistry(MasterDetailContainer, PanelContainer, BackButtonScreen.Binding)
+val SampleContainers = ViewRegistry(
+    BackButtonScreen.Binding, MasterDetailContainer, PanelContainer, ScrimContainer
+)

--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/panel/Contexts.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/panel/Contexts.kt
@@ -20,6 +20,8 @@ import android.view.Display
 import android.view.WindowManager
 import com.squareup.sample.container.R
 
+val Context.isPortrait: Boolean get() = resources.getBoolean(R.bool.is_portrait)
+
 val Context.isTablet: Boolean get() = resources.getBoolean(R.bool.is_tablet)
 
 val Context.windowManager: WindowManager

--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.container.panel
+import android.animation.ValueAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import com.squareup.sample.container.R
+import com.squareup.workflow.ui.BuilderBinding
+import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.WorkflowViewStub
+import com.squareup.workflow.ui.bindShowRendering
+
+/**
+ * A view that renders only its first child, behind a smoke scrim if
+ * [isDimmed] is true (tablets only). Other children are ignored.
+ *
+ * Able to [render][com.squareup.workflow.ui.showRendering] [ScrimContainerScreen].
+ */
+class ScrimContainer @JvmOverloads constructor(
+  context: Context,
+  attributeSet: AttributeSet? = null,
+  defStyle: Int = 0,
+  defStyleRes: Int = 0
+) : ViewGroup(context, attributeSet, defStyle, defStyleRes) {
+  private val scrim = object : View(context, attributeSet, defStyle, defStyleRes) {
+    init {
+      @Suppress("DEPRECATION")
+      setBackgroundColor(resources.getColor(R.color.scrim))
+    }
+  }
+
+  private val child: View
+    get() = getChildAt(0)
+        ?: error("Child must be set immediately upon creation.")
+
+  var isDimmed: Boolean = false
+    set(value) {
+      if (field == value) return
+      field = value
+      if (!isAttachedToWindow) updateImmediate() else updateAnimated()
+    }
+
+  override fun onAttachedToWindow() {
+    updateImmediate()
+    super.onAttachedToWindow()
+  }
+
+  override fun addView(child: View?) {
+    if (scrim.parent != null) removeView(scrim)
+    super.addView(child)
+    super.addView(scrim)
+  }
+
+  override fun onLayout(
+    changed: Boolean,
+    l: Int,
+    t: Int,
+    r: Int,
+    b: Int
+  ) {
+    child.layout(0, 0, measuredWidth, measuredHeight)
+    scrim.layout(0, 0, measuredWidth, measuredHeight)
+  }
+
+  override fun onMeasure(
+    widthMeasureSpec: Int,
+    heightMeasureSpec: Int
+  ) {
+    child.measure(widthMeasureSpec, heightMeasureSpec)
+    scrim.measure(widthMeasureSpec, heightMeasureSpec)
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+  }
+
+  private fun updateImmediate() {
+    if (isDimmed) scrim.alpha = 1f else scrim.alpha = 0f
+  }
+
+  private fun updateAnimated() {
+    if (isDimmed) {
+      ValueAnimator.ofFloat(0f, 1f)
+    } else {
+      ValueAnimator.ofFloat(1f, 0f)
+    }.apply {
+      duration = resources.getInteger(android.R.integer.config_shortAnimTime)
+          .toLong()
+      addUpdateListener { animation -> scrim.alpha = animation.animatedValue as Float }
+      start()
+    }
+  }
+
+  companion object : ViewBinding<ScrimContainerScreen<*>> by BuilderBinding(
+      type = ScrimContainerScreen::class,
+      viewConstructor = { initialRendering, initialContainerHints, contextForNewView, _ ->
+        val stub = WorkflowViewStub(contextForNewView)
+
+        ScrimContainer(contextForNewView)
+            .apply {
+              layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+              addView(stub)
+
+              bindShowRendering(initialRendering, initialContainerHints) { rendering, hints ->
+                stub.update(rendering.wrapped, hints)
+                isDimmed = rendering.dimmed
+              }
+            }
+      }
+  )
+}

--- a/kotlin/samples/containers/android/src/main/res/anim-sw600dp/panel_enter.xml
+++ b/kotlin/samples/containers/android/src/main/res/anim-sw600dp/panel_enter.xml
@@ -16,7 +16,7 @@
   -->
 <set xmlns:android="http://schemas.android.com/apk/res/android"
     android:interpolator="@android:anim/decelerate_interpolator"
-    android:duration="@android:integer/config_mediumAnimTime"
+    android:duration="@android:integer/config_shortAnimTime"
     >
 
   <scale

--- a/kotlin/samples/containers/android/src/main/res/anim/panel_enter.xml
+++ b/kotlin/samples/containers/android/src/main/res/anim/panel_enter.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 <translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="@android:integer/config_mediumAnimTime"
+    android:duration="@android:integer/config_shortAnimTime"
     android:fromYDelta="100%p"
     android:interpolator="@android:anim/decelerate_interpolator"
     android:toYDelta="0"

--- a/kotlin/samples/containers/android/src/main/res/values-land/bools.xml
+++ b/kotlin/samples/containers/android/src/main/res/values-land/bools.xml
@@ -14,23 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:interpolator="@android:anim/accelerate_interpolator"
-    android:duration="@android:integer/config_shortAnimTime"
-    >
-
-  <scale
-      android:fromXScale="1"
-      android:toXScale="0.9"
-      android:fromYScale="1"
-      android:toYScale="0.9"
-      android:pivotX="50%p"
-      android:pivotY="50%p"
-      />
-
-  <alpha
-      android:fromAlpha="1"
-      android:toAlpha="0"
-      />
-
-</set>
+<resources>
+  <bool name="is_portrait">false</bool>
+</resources>

--- a/kotlin/samples/containers/android/src/main/res/values/bools.xml
+++ b/kotlin/samples/containers/android/src/main/res/values/bools.xml
@@ -15,5 +15,6 @@
   ~ limitations under the License.
   -->
 <resources>
+  <bool name="is_portrait">true</bool>
   <bool name="is_tablet">false</bool>
 </resources>

--- a/kotlin/samples/containers/android/src/main/res/values/colors.xml
+++ b/kotlin/samples/containers/android/src/main/res/values/colors.xml
@@ -14,23 +14,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<set xmlns:android="http://schemas.android.com/apk/res/android"
-    android:interpolator="@android:anim/accelerate_interpolator"
-    android:duration="@android:integer/config_shortAnimTime"
-    >
-
-  <scale
-      android:fromXScale="1"
-      android:toXScale="0.9"
-      android:fromYScale="1"
-      android:toYScale="0.9"
-      android:pivotX="50%p"
-      android:pivotY="50%p"
-      />
-
-  <alpha
-      android:fromAlpha="1"
-      android:toAlpha="0"
-      />
-
-</set>
+<resources>
+  <color name="scrim">#cc000000</color>
+</resources>

--- a/kotlin/samples/containers/android/src/main/res/values/styles.xml
+++ b/kotlin/samples/containers/android/src/main/res/values/styles.xml
@@ -18,8 +18,8 @@
 
   <style name="PanelDialog">
     <item name="android:windowAnimationStyle">@style/PanelDialogAnimation</item>
-    <!-- For some reason this is required to get our windowEnterAnimation honored. -->
-    <item name="android:windowIsFloating">true</item>
+    <item name="android:backgroundDimAmount">0</item>
+    <item name="android:windowSoftInputMode">adjustResize</item>
   </style>
 
   <style name="PanelDialogAnimation">

--- a/kotlin/samples/containers/common/src/main/java/com/squareup/sample/container/panel/PanelContainerScreen.kt
+++ b/kotlin/samples/containers/common/src/main/java/com/squareup/sample/container/panel/PanelContainerScreen.kt
@@ -23,6 +23,10 @@ import com.squareup.workflow.ui.HasModals
  * nested [sub-flows][modals] over a [baseScreen]. Demonstrates how an app
  * can set up a custom modal design element.
  *
+ * Note the trickiness with our implementation of [HasModals], the interface
+ * that drives Workflow's `ModalContainer`. We wrap the base in a [ScrimContainerScreen]
+ * to give ourselves control over how the base is dimmed when the card modal is shown.
+ *
  * Tic Tac Workflow uses modals for two purposes:
  *
  *  - Alerts, via the stock `AlertContainerScreen`
@@ -32,9 +36,15 @@ import com.squareup.workflow.ui.HasModals
  *    tasks which take multiple steps and involve going backward and forward.
  */
 data class PanelContainerScreen<B : Any, T : Any>(
-  override val baseScreen: B,
+  val baseScreen: B,
   override val modals: List<BackStackScreen<T>> = emptyList()
-) : HasModals<B, BackStackScreen<T>>
+) : HasModals<ScrimContainerScreen<B>, BackStackScreen<T>> {
+  override val beneathModals: ScrimContainerScreen<B>
+    get() = ScrimContainerScreen(
+        wrapped = baseScreen,
+        dimmed = modals.isNotEmpty()
+    )
+}
 
 /**
  * Shows the receiving [BackStackScreen] in the only panel over [baseScreen].

--- a/kotlin/samples/containers/common/src/main/java/com/squareup/sample/container/panel/ScrimContainerScreen.kt
+++ b/kotlin/samples/containers/common/src/main/java/com/squareup/sample/container/panel/ScrimContainerScreen.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Square Inc.
+ * Copyright 2020 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.sample.recyclerview
-
-import com.squareup.workflow.ui.ModalContainer
-import com.squareup.workflow.ui.ModalViewContainer
-import com.squareup.workflow.ui.ViewBinding
+package com.squareup.sample.container.panel
 
 /**
- * A simple [ModalContainer] [ViewBinding] that knows how to render [AppWorkflow.Rendering]s.
+ * Show a scrim over the [wrapped] item, which is invisible if [dimmed] is false,
+ * dark if it is true.
  */
-object AddRowContainer : ViewBinding<AppWorkflow.Rendering> by ModalViewContainer.binding()
+class ScrimContainerScreen<T : Any>(
+  val wrapped: T,
+  val dimmed: Boolean
+)

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/AppWorkflow.kt
@@ -67,7 +67,7 @@ object AppWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
   )
 
   data class Rendering(
-    override val baseScreen: BaseScreen,
+    override val beneathModals: BaseScreen,
     val popup: ChooseRowTypeScreen? = null
   ) : HasModals<BaseScreen, ChooseRowTypeScreen> {
     override val modals: List<ChooseRowTypeScreen>
@@ -105,7 +105,7 @@ object AppWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
     return when (state) {
       is ShowList -> Rendering(baseScreen)
       is ChooseNewRow -> Rendering(
-          baseScreen = baseScreen,
+          beneathModals = baseScreen,
           popup = ChooseRowTypeScreen(
               options = allRowTypes.map { it.description },
               onSelectionTapped = { index -> context.actionSink.send(CommitNewRowAction(index)) }

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/mainactivity/MainActivity.kt
@@ -19,12 +19,11 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.espresso.IdlingResource
 import com.squareup.sample.authworkflow.AuthViewBindings
+import com.squareup.sample.container.SampleContainers
 import com.squareup.sample.gameworkflow.TicTacToeViewBindings
-import com.squareup.sample.container.panel.PanelContainer
 import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
 import com.squareup.workflow.diagnostic.andThen
 import com.squareup.workflow.diagnostic.tracing.TracingDiagnosticListener
-import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowRunner
 import com.squareup.workflow.ui.plus
 import com.squareup.workflow.ui.setContentWorkflow
@@ -77,6 +76,6 @@ class MainActivity : AppCompatActivity() {
   }
 
   private companion object {
-    val viewRegistry = ViewRegistry(PanelContainer) + AuthViewBindings + TicTacToeViewBindings
+    val viewRegistry = SampleContainers + AuthViewBindings + TicTacToeViewBindings
   }
 }

--- a/kotlin/samples/tictactoe/app/src/main/res/layout/second_factor_layout.xml
+++ b/kotlin/samples/tictactoe/app/src/main/res/layout/second_factor_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2017 Square Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +13,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     >
   <androidx.appcompat.widget.Toolbar
@@ -29,43 +27,60 @@
       app:title="Enter Second Factor"
       />
 
-  <TextView
-      android:id="@+id/second_factor_error_message"
+  <ScrollView
       android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:gravity="center"
-      android:textColor="@color/colorAccent"
-      android:textSize="24sp"
-      />
+      android:layout_height="match_parent"
+      >
 
-  <Space
-      android:layout_width="match_parent"
-      android:layout_height="0dp"
-      android:layout_weight="1"
-      />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:orientation="vertical"
+        >
 
-  <EditText
-      android:id="@+id/second_factor"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:gravity="center"
-      android:hint="@string/second_factor_hint"
-      android:inputType="textEmailAddress"
-      />
+      <TextView
+          android:id="@+id/second_factor_error_message"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:gravity="center"
+          android:textColor="@color/colorAccent"
+          android:textSize="24sp"
+          />
 
-  <Button
-      android:id="@+id/second_factor_submit_button"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_gravity="center"
-      android:text="@string/login_button"
-      style="@style/Base.TextAppearance.AppCompat.Button"
-      />
+      <Space
+          android:layout_width="match_parent"
+          android:layout_height="0dp"
+          android:layout_weight="1"
+          />
 
-  <Space
-      android:layout_width="match_parent"
-      android:layout_height="0dp"
-      android:layout_weight="1"
-      />
+      <EditText
+          android:id="@+id/second_factor"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:gravity="center"
+          android:hint="@string/second_factor_hint"
+          android:inputType="textEmailAddress"
+          />
+
+      <Button
+          android:id="@+id/second_factor_submit_button"
+          style="@style/Base.TextAppearance.AppCompat.Button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center"
+          android:text="@string/login_button"
+          />
+
+      <Space
+          android:layout_width="match_parent"
+          android:layout_height="0dp"
+          android:layout_weight="1"
+          />
+
+    </LinearLayout>
+
+  </ScrollView>
 
 </LinearLayout>

--- a/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
+++ b/kotlin/samples/tictactoe/common/src/main/java/com/squareup/sample/mainworkflow/MainWorkflow.kt
@@ -80,7 +80,7 @@ class MainWorkflow(
     is RunningGame -> {
       val childRendering = context.renderChild(runGameWorkflow) { startAuth }
 
-      val panels = childRendering.baseScreen.modals
+      val panels = childRendering.beneathModals.modals
 
       if (panels.isEmpty()) {
         childRendering
@@ -97,7 +97,7 @@ class MainWorkflow(
 
         val panelsMod = panels.toMutableList()
         panelsMod[0] = stubAuthBackStack + panels[0]
-        childRendering.copy(baseScreen = childRendering.baseScreen.copy(modals = panelsMod))
+        childRendering.copy(beneathModals = childRendering.beneathModals.copy(modals = panelsMod))
       }
     }
   }

--- a/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
+++ b/kotlin/samples/tictactoe/common/src/test/java/com/squareup/sample/mainworkflow/MainWorkflowTest.kt
@@ -58,8 +58,8 @@ class MainWorkflowTest {
   private fun authScreen(wrapped: String = DEFAULT_AUTH) =
     BackStackScreen<Any>(wrapped)
 
-  private val RunGameScreen.panels: List<Any> get() = baseScreen.modals.map { it.top }
-  private val RunGameScreen.body: Any get() = baseScreen.baseScreen
+  private val RunGameScreen.panels: List<Any> get() = beneathModals.modals.map { it.top }
+  private val RunGameScreen.body: Any get() = beneathModals.beneathModals.wrapped
 
   private fun authWorkflow(
     screen: String = DEFAULT_AUTH

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/AlertContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/AlertContainer.kt
@@ -31,9 +31,9 @@ import com.squareup.workflow.ui.AlertScreen.Event.ButtonClicked
 import com.squareup.workflow.ui.AlertScreen.Event.Canceled
 
 /**
- * Class returned by [ModalContainer.forAlertContainerScreen], qv for details.
+ * Renders the [AlertScreen]s of an [AlertContainerScreen] as [AlertDialog]s.
  */
-internal class AlertContainer @JvmOverloads constructor(
+class AlertContainer @JvmOverloads constructor(
   context: Context,
   attributeSet: AttributeSet? = null,
   defStyle: Int = 0,
@@ -86,7 +86,7 @@ internal class AlertContainer @JvmOverloads constructor(
     NEUTRAL -> DialogInterface.BUTTON_NEUTRAL
   }
 
-  class Binding(
+  private class Binding(
     @StyleRes private val dialogThemeResId: Int = 0
   ) : ViewBinding<AlertContainerScreen<*>>
   by BuilderBinding(
@@ -100,4 +100,17 @@ internal class AlertContainer @JvmOverloads constructor(
             }
       }
   )
+
+  companion object {
+    /**
+     * Creates a [ViewBinding] to show the [AlertScreen]s of an [AlertContainerScreen]
+     * as Android `AlertDialog`s.
+     *
+     * @param dialogThemeResId the resource ID of the theme against which to inflate
+     * dialogs. Defaults to `0` to use the parent `context`'s default alert dialog theme.
+     */
+    fun binding(
+      @StyleRes dialogThemeResId: Int = 0
+    ): ViewBinding<AlertContainerScreen<*>> = AlertContainer.Binding(dialogThemeResId)
+  }
 }

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ModalContainer.kt
@@ -26,21 +26,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
-import androidx.annotation.IdRes
-import androidx.annotation.StyleRes
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
-import com.squareup.workflow.ui.ModalContainer.Companion.forAlertContainerScreen
-import com.squareup.workflow.ui.ModalContainer.Companion.forContainerScreen
 
 /**
- * Base class for containers that show [HasModals.modals] in [Dialog]s.
- *
- * The concrete implementations returned by the factory methods [forAlertContainerScreen]
- * and [forContainerScreen] should cover many specific needs, and where those are too
- * limiting subclasses are simple to create.
+ * Base class for containers that show [HasModals.modals] in [Dialog] windows.
  *
  * @param ModalRenderingT the type of the nested renderings to be shown in a dialog window.
  */
@@ -61,7 +53,7 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
     newScreen: HasModals<*, ModalRenderingT>,
     containerHints: ContainerHints
   ) {
-    baseView.update(newScreen.baseScreen, containerHints)
+    baseView.update(newScreen.beneathModals, containerHints)
 
     val newDialogs = mutableListOf<DialogRef<ModalRenderingT>>()
     for ((i, modal) in newScreen.modals.withIndex()) {
@@ -204,46 +196,6 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
 
       override fun newArray(size: Int): Array<SavedState?> = arrayOfNulls(size)
     }
-  }
-
-  companion object {
-    /**
-     * Creates a [ViewBinding] to show the [AlertScreen]s of an [AlertContainerScreen]
-     * as Android `AlertDialog`s.
-     *
-     * @param dialogThemeResId the resource ID of the theme against which to inflate
-     * dialogs. Defaults to `0` to use the parent `context`'s default alert dialog theme.
-     */
-    fun forAlertContainerScreen(
-      @StyleRes dialogThemeResId: Int = 0
-    ): ViewBinding<AlertContainerScreen<*>> = AlertContainer.Binding(dialogThemeResId)
-
-    /**
-     * Creates a [ViewBinding] for modal container screens of type [H].
-     *
-     * Each view created for [HasModals.modals] will be shown in a [Dialog]
-     * whose window is set to size itself to `WRAP_CONTENT` (see [android.view.Window.setLayout]).
-     * Two customization hooks are provided: you can specify a [theme][dialogThemeResId] to be
-     * applied to the dialog window; and/or provide a [function][modalDecorator] to decorate
-     * the view to set as the [dialog's content][Dialog.setContentView].
-     *
-     * @param id a unique identifier for containers of this type, allowing them to participate
-     * view persistence
-     *
-     * @param dialogThemeResId a style resource describing the theme to use for dialog
-     * windows. Defaults to `0` to use the default dialog theme.
-     *
-     * @param modalDecorator a function to apply to each [modal][HasModals.modals] view
-     * created before it is passed to [android.app.Dialog.setContentView].
-     * Defaults to making no changes.
-     */
-    inline fun <reified H : HasModals<*, *>> forContainerScreen(
-      @IdRes id: Int,
-      @StyleRes dialogThemeResId: Int = 0,
-      noinline modalDecorator: (View) -> View = { it }
-    ): ViewBinding<H> = ModalViewContainer.Binding(
-        id, H::class, dialogThemeResId, modalDecorator
-    )
   }
 }
 

--- a/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
+++ b/kotlin/workflow-ui-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
@@ -31,7 +31,7 @@ import com.squareup.workflow.ui.backstack.BackStackContainer
 internal val defaultViewBindings = ViewRegistry(
     NamedBinding,
     BackStackContainer,
-    ModalContainer.forAlertContainerScreen()
+    AlertContainer.binding()
 )
 
 /**
@@ -67,7 +67,7 @@ internal val defaultViewBindings = ViewRegistry(
  *
  *  - [Named]`<*>` (Delegates to the registered binding for [Named.wrapped].)
  *  - [BackStackScreen]`<*>`
- *  - [AlertContainerScreen]`<*>` (Use [ModalContainer.forAlertContainerScreen] to set
+ *  - [AlertContainerScreen]`<*>` (Use [ModalContainer.binding] to set
  *    a different dialog theme.)
  */
 interface ViewRegistry {

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/AlertContainerScreen.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/AlertContainerScreen.kt
@@ -16,12 +16,12 @@
 package com.squareup.workflow.ui
 
 /**
- * May show a stack of [AlertScreen] over a [baseScreen].
+ * May show a stack of [AlertScreen] over a [beneathModals].
  *
- * @param B the type of [baseScreen]
+ * @param B the type of [beneathModals]
  */
 data class AlertContainerScreen<B : Any>(
-  override val baseScreen: B,
+  override val beneathModals: B,
   override val modals: List<AlertScreen> = emptyList()
 ) : HasModals<B, AlertScreen> {
   constructor(

--- a/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/HasModals.kt
+++ b/kotlin/workflow-ui-core/src/main/java/com/squareup/workflow/ui/HasModals.kt
@@ -17,11 +17,12 @@ package com.squareup.workflow.ui
 
 /**
  * Interface implemented by screen classes that represent a stack of
- * zero or more [modal][M] screens above a [baseScreen]. Use of this
- * interface allows platform specific containers to share base classes,
+ * zero or more [modal][M] screens above a [base screen][beneathModals].
+ *
+ * Use of this interface allows platform specific containers to share base classes,
  * like `ModalContainer` in the `workflow-ui-android` module.
  */
 interface HasModals<out B : Any, out M : Any> {
-  val baseScreen: B
+  val beneathModals: B
   val modals: List<M>
 }


### PR DESCRIPTION
Trying to protect container authors from calling the `Dialog`
constructor was foolish. Didn't actually simplify anything,
and made it very difficult to manage window size.

Panel sample behavior around soft keyboard is a lot better now.