### PR TITLE
Pass acceptOutput function to WorkflowNode constructor instead of every tick pass.

### DIFF
--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowLoop.kt
@@ -121,7 +121,7 @@ internal open class RealWorkflowLoop : WorkflowLoop {
             }
 
             // Tick the workflow tree.
-            rootNode.tick(this) { it }
+            rootNode.tick(this)
           }
         }
         // Compiler gets confused, and thinks both that this throw is unreachable, and without the


### PR DESCRIPTION
This doesn't change any behavior, it is just more efficient: there's no need to
define the function at the tick pass, so this is not only more efficient but also
just easier to read, since there are fewer moving parts.

This is also required for #910.