### PR TITLE
Replaced activity-ktx dependency with activity. 

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -39,7 +39,7 @@ buildscript {
       'android_gradle_plugin': "com.android.tools.build:gradle:3.5.3",
 
       'androidx': [
-          'activity': "androidx.activity:activity-ktx:1.1.0",
+          'activity': "androidx.activity:activity:1.1.0",
           'annotations': "androidx.annotation:annotation:1.1.0",
           'appcompat': "androidx.appcompat:appcompat:1.1.0",
           'constraint_layout': "androidx.constraintlayout:constraintlayout:1.1.3",


### PR DESCRIPTION
`activity-ktx` includes [only two helper classes ](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-master-dev/activity/activity-ktx/src/main/java/androidx/activity) which are not used by workflow. If someone needs this functionality, they can add extensions manually.
`activity`, on the other hand is used - it contains `OnBackPressedDispatcher` & friends. 