### PR TITLE
Support nested ViewBindings in Composable bindings.

### DIFF
--- a/kotlin/.buildscript/configure-compose.gradle
+++ b/kotlin/.buildscript/configure-compose.gradle
@@ -14,11 +14,21 @@
  * limitations under the License.
  */
 
+/*
+In addition applying this file, as of dev10 modules that use Compose also need to include this
+code snippet to avoid warnings about using compiler version 1.4:
+
+tasks.withType<KotlinCompile>().configureEach {
+ kotlinOptions.apiVersion = "1.3"
+}
+*/
+
 android {
   buildFeatures {
     compose true
   }
   composeOptions {
+    kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
     kotlinCompilerExtensionVersion Versions.compose
   }
 }

--- a/kotlin/buildSrc/src/main/java/Dependencies.kt
+++ b/kotlin/buildSrc/src/main/java/Dependencies.kt
@@ -46,6 +46,7 @@ object Dependencies {
     const val tooling = "androidx.ui:ui-tooling:${Versions.compose}"
   }
 
+  const val coil = "io.coil-kt:coil:0.9.2"
   const val cycler = "com.squareup.cycler:cycler:0.1.3"
 
   // Required for Dungeon Crawler sample.

--- a/kotlin/buildSrc/src/main/java/Dependencies.kt
+++ b/kotlin/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@ import java.util.Locale.US
 import kotlin.reflect.full.declaredMembers
 
 object Versions {
-  const val compose = "0.1.0-dev09"
+  const val compose = "0.1.0-dev10"
   const val coroutines = "1.3.4"
   const val kotlin = "1.3.71"
   const val targetSdk = 29

--- a/kotlin/samples/containers/compose/build.gradle.kts
+++ b/kotlin/samples/containers/compose/build.gradle.kts
@@ -26,6 +26,7 @@ android {
     applicationId = "com.squareup.sample.composecontainer"
   }
 }
+apply(from = rootProject.file(".buildscript/android-ui-tests.gradle"))
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
 tasks.withType<KotlinCompile> {
@@ -44,5 +45,8 @@ dependencies {
   implementation(Dependencies.Compose.material)
   implementation(Dependencies.RxJava2.rxjava2)
 
+  compileOnly(project(":workflow-ui:compose-tooling"))
   compileOnly(Dependencies.Compose.tooling)
+
+  androidTestImplementation(Dependencies.Compose.test)
 }

--- a/kotlin/samples/containers/compose/build.gradle.kts
+++ b/kotlin/samples/containers/compose/build.gradle.kts
@@ -1,0 +1,48 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+  id("com.android.application")
+  kotlin("android")
+}
+
+apply(from = rootProject.file(".buildscript/android-sample-app.gradle"))
+android {
+  defaultConfig {
+    applicationId = "com.squareup.sample.composecontainer"
+  }
+}
+
+apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
+tasks.withType<KotlinCompile> {
+  kotlinOptions.apiVersion = "1.3"
+}
+
+dependencies {
+  implementation(project(":workflow-core"))
+  implementation(project(":workflow-runtime"))
+  implementation(project(":workflow-ui:core-compose"))
+
+  implementation(Dependencies.AndroidX.appcompat)
+  implementation(Dependencies.coil)
+  implementation(Dependencies.Compose.foundation)
+  implementation(Dependencies.Compose.layout)
+  implementation(Dependencies.Compose.material)
+  implementation(Dependencies.RxJava2.rxjava2)
+
+  compileOnly(Dependencies.Compose.tooling)
+}

--- a/kotlin/samples/containers/compose/src/androidTest/java/com/squareup/sample/composecontainer/ComposeContainerAppTest.kt
+++ b/kotlin/samples/containers/compose/src/androidTest/java/com/squareup/sample/composecontainer/ComposeContainerAppTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.composecontainer
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.ui.test.assertIsDisplayed
+import androidx.ui.test.doClick
+import androidx.ui.test.findByText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ComposeContainerAppTest {
+
+  // Launches the activity.
+  @Rule @JvmField val scenario = ActivityScenarioRule(ComposeContainerActivity::class.java)
+
+  @Test fun togglesBetweenStates() {
+    findByText("Hello")
+        .assertIsDisplayed()
+        .doClick()
+    findByText("Goodbye")
+        .assertIsDisplayed()
+        .doClick()
+    findByText("Hello")
+        .assertIsDisplayed()
+  }
+}

--- a/kotlin/samples/containers/compose/src/main/AndroidManifest.xml
+++ b/kotlin/samples/containers/compose/src/main/AndroidManifest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2019 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.squareup.sample.composecontainer">
+
+  <application
+      android:allowBackup="false"
+      android:label="@string/app_name"
+      android:theme="@style/AppTheme"
+      tools:ignore="GoogleAppIndexingWarning,MissingApplicationIcon">
+
+    <activity
+        android:name=".ComposeContainerActivity"
+        android:configChanges="orientation|screenLayout|screenSize|density|fontScale|keyboardHidden">
+
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+
+    </activity>
+
+  </application>
+
+  <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/ComposeContainerActivity.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/ComposeContainerActivity.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.composecontainer
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.squareup.sample.composecontainer.pictureframe.PictureFrameViewFactory
+import com.squareup.sample.composecontainer.pictures.PicturesViewFactory
+import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
+import com.squareup.workflow.ui.ViewRegistry
+import com.squareup.workflow.ui.WorkflowRunner
+import com.squareup.workflow.ui.setContentWorkflow
+
+private val viewRegistry = ViewRegistry(
+    PictureFrameViewFactory,
+    PicturesViewFactory
+)
+
+class ComposeContainerActivity : AppCompatActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentWorkflow(viewRegistry) {
+      WorkflowRunner.Config(
+          ComposeContainerWorkflow,
+          diagnosticListener = SimpleLoggingDiagnosticListener()
+      )
+    }
+  }
+}

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/ComposeContainerWorkflow.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/ComposeContainerWorkflow.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.composecontainer
+
+import com.squareup.sample.composecontainer.pictureframe.PictureFrameRendering
+import com.squareup.sample.composecontainer.pictures.PicturesWorkflow
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.StatelessWorkflow
+import com.squareup.workflow.renderChild
+
+/**
+ * Root workflow for this sample. Wraps renderings from a [PicturesWorkflow] in
+ * [PictureFrameRendering]s.
+ */
+object ComposeContainerWorkflow : StatelessWorkflow<Unit, Nothing, PictureFrameRendering>() {
+  override fun render(
+    props: Unit,
+    context: RenderContext<Nothing, Nothing>
+  ): PictureFrameRendering = PictureFrameRendering(
+      contents = context.renderChild(PicturesWorkflow)
+  )
+}

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrame.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrame.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// See https://youtrack.jetbrains.com/issue/KT-31734
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.sample.composecontainer.pictureframe
+
+import androidx.compose.Composable
+import androidx.compose.remember
+import androidx.ui.core.Alignment
+import androidx.ui.core.ContentDrawScope
+import androidx.ui.core.DrawModifier
+import androidx.ui.core.Modifier
+import androidx.ui.foundation.Box
+import androidx.ui.foundation.Text
+import androidx.ui.geometry.Offset
+import androidx.ui.geometry.RRect
+import androidx.ui.geometry.Radius
+import androidx.ui.graphics.Color
+import androidx.ui.graphics.Paint
+import androidx.ui.graphics.StrokeCap.square
+import androidx.ui.graphics.withSaveLayer
+import androidx.ui.layout.fillMaxSize
+import androidx.ui.layout.padding
+import androidx.ui.layout.wrapContentSize
+import androidx.ui.material.MaterialTheme
+import androidx.ui.material.Surface
+import androidx.ui.tooling.preview.Preview
+import androidx.ui.unit.Dp
+import androidx.ui.unit.PxSize
+import androidx.ui.unit.dp
+import androidx.ui.unit.toRect
+
+/**
+ * Composable function that draws a fancy picture frame around its children.
+ */
+@Composable fun PictureFrame(
+  thickness: Dp,
+  colors: List<Color> = listOf(Color.Green.copy(green = .75f), Color.Red, Color.Blue),
+  children: @Composable() () -> Unit
+) {
+  val cache = remember { PictureFrameCache() }
+  Box(
+      modifier = Modifier.fillMaxSize()
+          .wrapContentSize(Alignment.Center) +
+          PictureFrameModifier(thickness, colors, cache),
+      children = children
+  )
+}
+
+@Preview(widthDp = 100, heightDp = 150)
+@Composable private fun PictureFramePreview() {
+  MaterialTheme {
+    PictureFrame(thickness = 5.dp) {
+      Surface {
+        Text("Hello", modifier = Modifier.padding(10.dp))
+      }
+    }
+  }
+}
+
+/**
+ * This cache/modifier pair is the same technique `Border` uses.
+ */
+private class PictureFrameCache {
+  var lastSize: PxSize? = null
+  var paints: List<Paint>? = null
+  var offsets: List<List<Pair<Offset, Offset>>>? = null
+  var edges: List<List<Offset>>? = null
+}
+
+private class PictureFrameModifier(
+  private val thickness: Dp,
+  private val colors: List<Color>,
+  private val cache: PictureFrameCache
+) : DrawModifier {
+
+  override fun ContentDrawScope.draw() {
+    // Re-calculate when the size changes.
+    if (cache.lastSize != size) {
+      cache.lastSize = size
+      cache.offsets = null
+      cache.paints = null
+      cache.edges = null
+    }
+
+    val thicknessPx = thickness.toPx()
+        .value
+    val paints = cache.paints ?: colors.map { color ->
+          Paint().also {
+            it.strokeWidth = thicknessPx
+            it.strokeCap = square
+            it.color = color
+          }
+        }
+        .also { cache.paints = it }
+
+    val offsets = cache.offsets ?: run {
+      val parentWidth = size.width.value
+      val parentHeight = size.height.value
+      List(colors.size) { index: Int ->
+        val indexOffset = index + 1
+        listOf(
+            // top left
+            Offset(0f, thicknessPx * indexOffset) to Offset(thicknessPx * indexOffset, 0f),
+            // top right
+            Offset(parentWidth - thicknessPx * indexOffset, 0f) to Offset(
+                parentWidth, thicknessPx * indexOffset
+            ),
+            // bottom right
+            Offset(parentWidth, parentHeight - thicknessPx * indexOffset) to Offset(
+                parentWidth - thicknessPx * indexOffset, parentHeight
+            ),
+            // bottom left
+            Offset(thicknessPx * indexOffset, parentHeight) to Offset(
+                0f, parentHeight - thicknessPx * indexOffset
+            )
+        )
+      }
+    }.also { cache.offsets = it }
+
+    // Rotate all the corner points around the get the points for the edges in between them.
+    val edges = cache.edges ?: run {
+      offsets.last()
+          .flatMap { it.toList() }
+          .shifted()
+          .chunked(2)
+    }.also { cache.edges = it }
+
+    val edgeRadius = thickness.toPx()
+    withSaveLayer(size.toRect(), Paint()) {
+      clipRRect(RRect(size.toRect(), Radius.circular(edgeRadius.value)))
+      drawContent()
+
+      for ((index, corners) in offsets.withIndex()) {
+        for ((p1, p2) in corners) {
+          drawLine(p1, p2, paints[index])
+        }
+      }
+
+      val innerPaint = paints.last()
+      for ((p1, p2) in edges) {
+        drawLine(p1, p2, innerPaint)
+      }
+    }
+  }
+}
+
+private fun <T> List<T>.shifted(): List<T> = subList(1, size) + first()

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrameRendering.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrameRendering.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.composecontainer.pictureframe
+
+import androidx.annotation.DimenRes
+import com.squareup.sample.composecontainer.R
+
+/**
+ * A rendering that draws a picture frame around its [contents] using [PictureFrame].
+ *
+ * @param contents The rendering to show in the frame. Must have a binding in the `ViewRegistry`.
+ */
+data class PictureFrameRendering(
+  val contents: Any,
+  @DimenRes val thicknessRes: Int = R.dimen.default_picture_frame_thickness
+)

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrameViewFactory.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrameViewFactory.kt
@@ -15,13 +15,24 @@
  */
 package com.squareup.sample.composecontainer.pictureframe
 
+import androidx.compose.Composable
+import androidx.ui.material.MaterialTheme
 import androidx.ui.res.dimensionResource
+import androidx.ui.tooling.preview.Preview
 import com.squareup.workflow.ui.compose.bindCompose
 import com.squareup.workflow.ui.compose.showRendering
+import com.squareup.workflow.ui.compose.tooling.preview
 
 val PictureFrameViewFactory = bindCompose<PictureFrameRendering> { rendering, hints ->
   val thickness = dimensionResource(id = rendering.thicknessRes)
   PictureFrame(thickness) {
     hints.showRendering(rendering.contents)
+  }
+}
+
+@Preview(widthDp = 200, heightDp = 200)
+@Composable fun PictureFrameBindingPreview() {
+  MaterialTheme {
+    PictureFrameViewFactory.preview(PictureFrameRendering(contents = "placeholder"))
   }
 }

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrameViewFactory.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictureframe/PictureFrameViewFactory.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.composecontainer.pictureframe
+
+import androidx.ui.res.dimensionResource
+import com.squareup.workflow.ui.compose.bindCompose
+import com.squareup.workflow.ui.compose.showRendering
+
+val PictureFrameViewFactory = bindCompose<PictureFrameRendering> { rendering, hints ->
+  val thickness = dimensionResource(id = rendering.thicknessRes)
+  PictureFrame(thickness) {
+    hints.showRendering(rendering.contents)
+  }
+}

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/CoilImage.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/CoilImage.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.sample.composecontainer.pictures
+
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.Composable
+import androidx.compose.onCommit
+import androidx.compose.state
+import androidx.ui.core.ContextAmbient
+import androidx.ui.core.DensityAmbient
+import androidx.ui.core.Modifier
+import androidx.ui.core.WithConstraints
+import androidx.ui.core.drawBehind
+import androidx.ui.foundation.Box
+import androidx.ui.layout.preferredSize
+import androidx.ui.unit.IntPx
+import coil.Coil
+import coil.api.load
+import coil.size.Precision.EXACT
+import coil.size.Scale.FIT
+
+typealias DrawImage = @Composable() () -> Unit
+
+/**
+ * Loads an image from the network using [Coil] and draws it into the composition.
+ *
+ * @param drawLoading Composable to draw while the image is being loaded.
+ * @param drawLoaded Composable to draw when the image has loaded successfully. This function
+ * receives another composable function that it should call to actually draw the image.
+ */
+@Composable fun CoilImage(
+  url: String,
+  drawLoading: @Composable() () -> Unit,
+  drawLoaded: @Composable() (DrawImage) -> Unit = { it() }
+) {
+  WithConstraints { constraints, _ ->
+    val image = image(
+        url = url,
+        width = constraints.maxWidth,
+        height = constraints.maxHeight
+    )
+
+    if (image == null) {
+      drawLoading()
+    } else {
+      drawLoaded {
+        with(DensityAmbient.current) {
+          // TODO i think this is built in now
+          Box(modifier = Modifier.preferredSize(image.width.toDp(), image.height.toDp())
+              .drawBehind {
+                nativeCanvas.drawBitmap(image, 0f, 0f, null)
+              })
+        }
+      }
+    }
+  }
+}
+
+@Composable private fun image(
+  url: String,
+  width: IntPx,
+  height: IntPx
+): Bitmap? {
+  val image = state<Bitmap?> { null }
+  val context = ContextAmbient.current
+
+  onCommit(url, width, height, context) {
+    val requestDisposable = Coil.load(context, url) {
+      size(width.value, height.value)
+      precision(EXACT)
+      scale(FIT)
+      target(
+          onSuccess = { image.value = (it as? BitmapDrawable)?.bitmap },
+          onError = { image.value = null }
+      )
+    }
+
+    onDispose { requestDisposable.dispose() }
+  }
+
+  return image.value
+}

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/PicturesViewFactory.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/PicturesViewFactory.kt
@@ -15,14 +15,19 @@
  */
 package com.squareup.sample.composecontainer.pictures
 
+import androidx.compose.Composable
 import androidx.ui.core.Alignment
 import androidx.ui.foundation.Box
 import androidx.ui.foundation.Clickable
 import androidx.ui.layout.LayoutPadding
 import androidx.ui.material.CircularProgressIndicator
+import androidx.ui.material.MaterialTheme
+import androidx.ui.material.Surface
+import androidx.ui.tooling.preview.Preview
 import androidx.ui.unit.dp
 import com.squareup.sample.composecontainer.pictures.PicturesWorkflow.Rendering
 import com.squareup.workflow.ui.compose.bindCompose
+import com.squareup.workflow.ui.compose.tooling.preview
 
 val PicturesViewFactory = bindCompose<Rendering> { rendering, _ ->
   CoilImage(
@@ -37,4 +42,20 @@ val PicturesViewFactory = bindCompose<Rendering> { rendering, _ ->
           drawImage()
         }
       })
+}
+
+@Preview
+@Composable
+fun PicturesBindingPreview() {
+  MaterialTheme {
+    Surface {
+      PicturesViewFactory.preview(
+          Rendering(
+              pictureUrl = "todo",
+              pictureDescription = "The Picture",
+              onTap = {}
+          )
+      )
+    }
+  }
 }

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/PicturesViewFactory.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/PicturesViewFactory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.composecontainer.pictures
+
+import androidx.ui.core.Alignment
+import androidx.ui.foundation.Box
+import androidx.ui.foundation.Clickable
+import androidx.ui.layout.LayoutPadding
+import androidx.ui.material.CircularProgressIndicator
+import androidx.ui.unit.dp
+import com.squareup.sample.composecontainer.pictures.PicturesWorkflow.Rendering
+import com.squareup.workflow.ui.compose.bindCompose
+
+val PicturesViewFactory = bindCompose<Rendering> { rendering, _ ->
+  CoilImage(
+      url = rendering.pictureUrl,
+      drawLoading = {
+        Box(modifier = LayoutPadding(200.dp), gravity = Alignment.Center) {
+          CircularProgressIndicator()
+        }
+      },
+      drawLoaded = { drawImage ->
+        Clickable(onClick = rendering.onTap) {
+          drawImage()
+        }
+      })
+}

--- a/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/PicturesWorkflow.kt
+++ b/kotlin/samples/containers/compose/src/main/java/com/squareup/sample/composecontainer/pictures/PicturesWorkflow.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.composecontainer.pictures
+
+import com.squareup.sample.composecontainer.pictures.PicturesWorkflow.Rendering
+import com.squareup.sample.composecontainer.pictures.PicturesWorkflow.State
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.action
+
+/**
+ * Workflow that shows a set of pictures from the internet, and cycles through them when tapped.
+ */
+object PicturesWorkflow : StatefulWorkflow<Unit, State, Nothing, Rendering>() {
+
+  enum class Picture(val url: String) {
+    Terrier("https://free-images.com/md/b436/1yorkshire_terrier_171701_640.jpg"),
+    Coffee("https://free-images.com/md/86a4/aroma_aromatic_beverage_bio.jpg"),
+    ;
+
+    val next: Picture get() = values()[(ordinal + 1) % values().size]
+  }
+
+  data class State(val picture: Picture)
+
+  data class Rendering(
+    val pictureUrl: String,
+    val pictureDescription: String,
+    val onTap: () -> Unit
+  )
+
+  override fun initialState(
+    props: Unit,
+    snapshot: Snapshot?
+  ): State = State(Picture.values().first())
+
+  override fun render(
+    props: Unit,
+    state: State,
+    context: RenderContext<State, Nothing>
+  ): Rendering = Rendering(
+      pictureUrl = state.picture.url,
+      pictureDescription = state.picture.name,
+      onTap = { context.actionSink.send(showNextPicture()) }
+  )
+
+  override fun snapshotState(state: State): Snapshot = Snapshot.of("")
+
+  private fun showNextPicture() = action {
+    nextState = nextState.copy(picture = nextState.picture.next)
+  }
+}

--- a/kotlin/samples/containers/compose/src/main/res/values/dimens.xml
+++ b/kotlin/samples/containers/compose/src/main/res/values/dimens.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2019 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <dimen name="default_picture_frame_thickness">20dp</dimen>
+</resources>

--- a/kotlin/samples/containers/compose/src/main/res/values/strings.xml
+++ b/kotlin/samples/containers/compose/src/main/res/values/strings.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2019 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="app_name">Compose Container</string>
+</resources>

--- a/kotlin/samples/containers/compose/src/main/res/values/styles.xml
+++ b/kotlin/samples/containers/compose/src/main/res/values/styles.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2019 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+
+  <!-- Base application theme. -->
+  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <!-- Customize your theme here. -->
+  </style>
+
+</resources>

--- a/kotlin/samples/hello-compose-binding/build.gradle.kts
+++ b/kotlin/samples/hello-compose-binding/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 /*
  * Copyright 2019 Square Inc.
  *
@@ -28,6 +30,9 @@ android {
 }
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
+tasks.withType<KotlinCompile> {
+  kotlinOptions.apiVersion = "1.3"
+}
 
 dependencies {
   implementation(project(":workflow-ui:core-compose"))

--- a/kotlin/samples/hello-compose-binding/src/androidTest/java/com/squareup/sample/hellocomposebinding/HelloBindingTest.kt
+++ b/kotlin/samples/hello-compose-binding/src/androidTest/java/com/squareup/sample/hellocomposebinding/HelloBindingTest.kt
@@ -15,8 +15,8 @@
  */
 package com.squareup.sample.hellocomposebinding
 
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.ui.test.android.AndroidComposeTestRule
 import androidx.ui.test.assertIsDisplayed
 import androidx.ui.test.doClick
 import androidx.ui.test.findByText
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 class HelloBindingTest {
 
   // Launches the activity.
-  @Rule @JvmField val scenario = ActivityScenarioRule(HelloBindingActivity::class.java)
+  @Rule @JvmField val composeRule = AndroidComposeTestRule<HelloBindingActivity>()
 
   @Test fun togglesBetweenStates() {
     findByText("Hello")

--- a/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
+++ b/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
@@ -28,6 +28,7 @@ import androidx.ui.material.ripple.ripple
 import androidx.ui.tooling.preview.Preview
 import com.squareup.sample.hellocomposebinding.HelloWorkflow.Rendering
 import com.squareup.workflow.ui.compose.bindCompose
+import com.squareup.workflow.ui.compose.tooling.preview
 
 val HelloBinding = bindCompose<Rendering> { rendering, _ ->
   MaterialTheme {
@@ -51,7 +52,7 @@ private fun DrawHelloRendering(rendering: Rendering) {
 fun DrawHelloRenderingPreview() {
   MaterialTheme {
     Surface {
-      DrawHelloRendering(Rendering("Hello!", onClick = {}))
+      HelloBinding.preview(Rendering("Hello!", onClick = {}))
     }
   }
 }

--- a/kotlin/settings.gradle.kts
+++ b/kotlin/settings.gradle.kts
@@ -24,6 +24,7 @@ include(
     ":samples:containers:app-raven",
     ":samples:containers:android",
     ":samples:containers:common",
+    ":samples:containers:compose",
     ":samples:containers:hello-back-button",
     ":samples:containers:poetry",
     ":samples:dungeon:app",

--- a/kotlin/settings.gradle.kts
+++ b/kotlin/settings.gradle.kts
@@ -50,6 +50,7 @@ include(
     ":workflow-tracing",
     ":workflow-ui:backstack-common",
     ":workflow-ui:backstack-android",
+    ":workflow-ui:compose-tooling",
     ":workflow-ui:core-common",
     ":workflow-ui:core-compose",
     ":workflow-ui:core-android",

--- a/kotlin/workflow-ui/compose-tooling/build.gradle.kts
+++ b/kotlin/workflow-ui/compose-tooling/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /*
- * Copyright 2019 Square Inc.
+ * Copyright 2020 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,17 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  * limitations under the License.
  */
 plugins {
-  id("com.android.application")
+  id("com.android.library")
   kotlin("android")
 }
 
-apply(from = rootProject.file(".buildscript/android-sample-app.gradle"))
-apply(from = rootProject.file(".buildscript/android-ui-tests.gradle"))
-
-android {
-  defaultConfig {
-    applicationId = "com.squareup.sample.hellocomposebinding"
-  }
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
+
+apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
+apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
 tasks.withType<KotlinCompile> {
@@ -35,17 +34,12 @@ tasks.withType<KotlinCompile> {
 }
 
 dependencies {
-  implementation(project(":workflow-ui:core-compose"))
+  api(project(":workflow-ui:core-compose"))
+  api(Dependencies.Compose.tooling)
+  api(Dependencies.Kotlin.Stdlib.jdk8)
 
-  implementation(Dependencies.Compose.layout)
-  implementation(Dependencies.Compose.material)
-  implementation(Dependencies.Compose.tooling)
   implementation(Dependencies.Compose.foundation)
-  implementation(Dependencies.RxJava2.rxjava2)
 
-  compileOnly(project(":workflow-ui:compose-tooling"))
-  compileOnly(Dependencies.Compose.tooling)
-
-  androidTestImplementation(Dependencies.Compose.test)
-  androidTestImplementation(Dependencies.Test.junit)
+  testImplementation(Dependencies.Test.junit)
+  testImplementation(Dependencies.Test.truth)
 }

--- a/kotlin/workflow-ui/compose-tooling/gradle.properties
+++ b/kotlin/workflow-ui/compose-tooling/gradle.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2020 Square Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+POM_ARTIFACT_ID=workflow-ui-compose-tooling
+POM_NAME=Workflow UI Compose Tooling
+POM_PACKAGING=aar

--- a/kotlin/workflow-ui/compose-tooling/src/main/AndroidManifest.xml
+++ b/kotlin/workflow-ui/compose-tooling/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest package="com.squareup.workflow.ui.compose.tooling" />

--- a/kotlin/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow/ui/compose/tooling/PreviewContainerHints.kt
+++ b/kotlin/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow/ui/compose/tooling/PreviewContainerHints.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose.tooling
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.Composable
+import androidx.compose.remember
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewFactory
+import com.squareup.workflow.ui.ViewRegistry
+import kotlin.reflect.KClass
+
+@Composable internal fun PreviewContainerHints(stubBinding: ViewFactory<Any>) =
+  remember(stubBinding) { ViewEnvironment(PreviewViewRegistry(stubBinding)) }
+
+/**
+ * TODO kdoc
+ */
+private class PreviewViewRegistry(private val stubBinding: ViewFactory<Any>) :
+    ViewRegistry {
+
+  override val keys: Set<KClass<*>> get() = emptySet()
+
+  override fun <RenderingT : Any> buildView(
+    initialRendering: RenderingT,
+    initialViewEnvironment: ViewEnvironment,
+    contextForNewView: Context,
+    container: ViewGroup?
+  ): View = getBindingFor(initialRendering::class).buildView(
+      initialRendering, initialViewEnvironment, contextForNewView, container
+  )
+
+  @Suppress("UNCHECKED_CAST")
+  override fun <RenderingT : Any> getBindingFor(
+    renderingType: KClass<out RenderingT>
+  ): ViewFactory<RenderingT> = stubBinding
+}

--- a/kotlin/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow/ui/compose/tooling/PreviewStubViewBinding.kt
+++ b/kotlin/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow/ui/compose/tooling/PreviewStubViewBinding.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose.tooling
+
+import androidx.compose.Composable
+import androidx.compose.remember
+import androidx.ui.core.Alignment
+import androidx.ui.core.DensityAmbient
+import androidx.ui.core.Draw
+import androidx.ui.core.Modifier
+import androidx.ui.core.drawOpacity
+import androidx.ui.foundation.Box
+import androidx.ui.foundation.Text
+import androidx.ui.geometry.Offset
+import androidx.ui.graphics.Color
+import androidx.ui.graphics.Paint
+import androidx.ui.graphics.Shadow
+import androidx.ui.graphics.withSave
+import androidx.ui.layout.fillMaxSize
+import androidx.ui.layout.wrapContentSize
+import androidx.ui.text.TextStyle
+import androidx.ui.text.style.TextAlign
+import androidx.ui.tooling.preview.Preview
+import androidx.ui.unit.Dp
+import androidx.ui.unit.dp
+import androidx.ui.unit.px
+import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.compose.bindCompose
+
+/**
+ * TODO kdoc
+ */
+internal val PreviewStubViewBinding: ViewBinding<Any> = bindCompose { rendering, _ ->
+  StubBackground()
+  Text(
+      modifier = Modifier.fillMaxSize()
+          .wrapContentSize(Alignment.Center),
+      text = rendering.toString(),
+      style = TextStyle(
+          textAlign = TextAlign.Center,
+          color = Color.White,
+          shadow = Shadow(blurRadius = 10.px, color = Color.Black)
+      )
+  )
+}
+
+@Preview(widthDp = 100, heightDp = 200)
+@Composable private fun PreviewStubViewBinding() {
+  PreviewStubViewBinding.preview(rendering = "preview")
+}
+
+@Composable private fun StubBackground() {
+  DrawCrossHatch(
+      color = Color.Red,
+      strokeWidth = 2.dp,
+      spaceWidth = 5.dp,
+      angle = 45f,
+      modifier = Modifier.drawOpacity(.7f)
+  )
+}
+
+@Composable private fun DrawCrossHatch(
+  color: Color,
+  strokeWidth: Dp,
+  spaceWidth: Dp,
+  angle: Float,
+  modifier: Modifier = Modifier
+) {
+  Box(modifier = modifier) {
+    DrawHatch(color, strokeWidth, spaceWidth, angle)
+    DrawHatch(color, strokeWidth, spaceWidth, angle + 90)
+  }
+}
+
+@Composable private fun DrawHatch(
+  color: Color,
+  strokeWidth: Dp,
+  spaceWidth: Dp,
+  angle: Float
+) {
+  with(DensityAmbient.current) {
+    val strokeWidthPx = strokeWidth.toPx()
+        .value
+    val paint = remember {
+      Paint().also {
+        it.color = color.scaleColors(.5f)
+        it.strokeWidth = strokeWidthPx
+      }
+    }
+
+    // TODO update
+    Draw { canvas, parentSize ->
+      canvas.withSave {
+        val halfWidth = parentSize.width.value / 2
+        val halfHeight = parentSize.height.value / 2
+        canvas.translate(halfWidth, halfHeight)
+        canvas.rotate(angle)
+        canvas.translate(-halfWidth, -halfHeight)
+
+        // Draw outside our bounds to fill the space even when rotated.
+        val left = -parentSize.width.value
+        val right = parentSize.width.value * 2
+        val top = -parentSize.height.value
+        val bottom = parentSize.height.value * 2
+
+        var y = top + strokeWidthPx * 2f
+        while (y < bottom) {
+          canvas.drawLine(
+              Offset(left, y),
+              Offset(right, y),
+              paint
+          )
+          y += spaceWidth.toPx().value * 2
+        }
+      }
+    }
+  }
+}
+
+private fun Color.scaleColors(factor: Float) =
+  copy(red = red * factor, green = green * factor, blue = blue * factor)

--- a/kotlin/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow/ui/compose/tooling/ViewBindings.kt
+++ b/kotlin/workflow-ui/compose-tooling/src/main/java/com/squareup/workflow/ui/compose/tooling/ViewBindings.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose.tooling
+
+import androidx.compose.Composable
+import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewFactory
+import com.squareup.workflow.ui.compose.showRendering
+
+/**
+ * Draws this [ViewBinding] using a special preview `ViewRegistry`.
+ *
+ * Use inside `@Preview` Composable functions.
+ */
+@Composable fun <RenderingT : Any> ViewFactory<RenderingT>.preview(
+  rendering: RenderingT,
+  stubBinding: ViewFactory<Any> = PreviewStubViewBinding
+) {
+  val containerHints = PreviewContainerHints(stubBinding)
+  showRendering(rendering, containerHints)
+}

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/CompositeViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/CompositeViewRegistry.kt
@@ -48,12 +48,22 @@ internal class CompositeViewRegistry private constructor(
     contextForNewView: Context,
     container: ViewGroup?
   ): View {
-    val registry = registriesByKey[initialRendering::class]
+    val registry = getRegistryFor(initialRendering::class)
+    return registry.buildView(
+        initialRendering, initialViewEnvironment, contextForNewView, container
+    )
+  }
+
+  override fun <RenderingT : Any> getBindingFor(
+    renderingType: KClass<out RenderingT>
+  ): ViewFactory<RenderingT> = getRegistryFor(renderingType).getBindingFor(renderingType)
+
+  private fun getRegistryFor(renderingType: KClass<out Any>): ViewRegistry {
+    return registriesByKey[renderingType]
         ?: throw IllegalArgumentException(
             "A ${ViewFactory::class.java.name} should have been registered " +
-                "to display $initialRendering."
+                "to display a $renderingType."
         )
-    return registry.buildView(initialRendering, initialViewEnvironment, contextForNewView, container)
   }
 
   companion object {

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewFactory.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewFactory.kt
@@ -27,8 +27,8 @@ import kotlin.reflect.KClass
  *
  * Sets of bindings are gathered in [ViewRegistry] instances.
  */
-interface ViewFactory<RenderingT : Any> {
-  val type: KClass<RenderingT>
+interface ViewFactory<in RenderingT : Any> {
+  val type: KClass<in RenderingT>
 
   /**
    * Returns a View ready to display [initialRendering] (and any succeeding values)

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
@@ -84,6 +84,13 @@ interface ViewRegistry {
     container: ViewGroup? = null
   ): View
 
+  /**
+   * TODO kdoc
+   */
+  fun <RenderingT : Any> getBindingFor(
+    renderingType: KClass<out RenderingT>
+  ): ViewFactory<RenderingT>
+
   companion object : ViewEnvironmentKey<ViewRegistry>(ViewRegistry::class) {
     override val default: ViewRegistry
       get() = error("There should always be a ViewRegistry hint, this is bug in Workflow.")

--- a/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/BindingViewRegistryTest.kt
+++ b/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/BindingViewRegistryTest.kt
@@ -52,7 +52,7 @@ class BindingViewRegistryTest {
     }
     assertThat(error).hasMessageThat()
         .isEqualTo(
-            "A ${ViewFactory::class.java.name} should have been registered to display $BarRendering."
+            "A ${ViewFactory::class.java.name} should have been registered to display a ${BarRendering::class}."
         )
   }
 

--- a/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/CompositeViewRegistryTest.kt
+++ b/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/CompositeViewRegistryTest.kt
@@ -93,7 +93,7 @@ class CompositeViewRegistryTest {
     }
     assertThat(error).hasMessageThat()
         .isEqualTo(
-            "A ${ViewFactory::class.java.name} should have been registered to display $BarRendering."
+            "A ${ViewFactory::class.java.name} should have been registered to display a ${BarRendering::class}."
         )
   }
 
@@ -110,5 +110,9 @@ class CompositeViewRegistryTest {
       contextForNewView: Context,
       container: ViewGroup?
     ): View = bindings.getValue(initialRendering::class)
+
+    override fun <RenderingT : Any> getBindingFor(
+      renderingType: KClass<out RenderingT>
+    ): ViewFactory<RenderingT> = throw UnsupportedOperationException()
   }
 }

--- a/kotlin/workflow-ui/core-compose/README.md
+++ b/kotlin/workflow-ui/core-compose/README.md
@@ -29,21 +29,28 @@ android {
     compose true
   }
   composeOptions {
+    kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
     kotlinCompilerExtensionVersion "${compose_version}"
   }
 }
 ```
 
-To create a binding, call `bindCompose`. The lambda passed to `bindCompose` is a `@Composable`
+You may also need to set the Kotlin API version to 1.3:
+
+```groovy
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions.apiVersion = "1.3"
+}
+```
+
+To create a `ViewFactory`, call `bindCompose`. The lambda passed to `bindCompose` is a `@Composable`
 function.
 
 ```kotlin
 val HelloBinding = bindCompose<MyRendering> { rendering ->
   MaterialTheme {
     Clickable(onClick = { rendering.onClick() }) {
-      Center {
-        Text(rendering.message)
-      }
+      Text(rendering.message)
     }
   }
 }
@@ -57,5 +64,5 @@ val viewRegistry = ViewRegistry(HelloBinding)
 ```
 
 [1]: https://developer.android.com/jetpack/compose
-[2]: https://square.github.io/workflow/kotlin/api/workflow-ui-android/com.squareup.workflow.ui/-view-binding/
-[3]: https://square.github.io/workflow/kotlin/api/workflow-ui-android/com.squareup.workflow.ui/-view-registry/
+[2]: https://square.github.io/workflow/kotlin/api/workflow/com.squareup.workflow.ui/-view-factory/
+[3]: https://square.github.io/workflow/kotlin/api/workflow/com.squareup.workflow.ui/-view-registry/

--- a/kotlin/workflow-ui/core-compose/build.gradle.kts
+++ b/kotlin/workflow-ui/core-compose/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 /*
  * Copyright 2019 Square Inc.
  *
@@ -24,10 +26,12 @@ java {
 }
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
-
 apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
+tasks.withType<KotlinCompile> {
+  kotlinOptions.apiVersion = "1.3"
+}
 
 dependencies {
   api(project(":workflow-ui:core-android"))

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
@@ -55,6 +55,13 @@ import kotlin.reflect.KClass
  *
  * val viewRegistry = ViewRegistry(FooBinding, …)
  * ```
+ *
+ * ## Implementing Containers
+ *
+ * Views that act as containers (i.e. they delegate to the
+ * [ViewRegistry][com.squareup.workflow.ui.ViewRegistry] to render other rendering types) may use
+ * [ViewEnvironment.showRendering] to compose child renderings. See the kdoc on that function for
+ * more information.
  */
 inline fun <reified RenderingT : Any> bindCompose(
   noinline showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
@@ -65,7 +72,7 @@ inline fun <reified RenderingT : Any> bindCompose(
 @PublishedApi
 internal class ComposeViewFactory<RenderingT : Any>(
   override val type: KClass<RenderingT>,
-  private val showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
+  val showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
 ) : ViewFactory<RenderingT> {
 
   override fun buildView(

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.Composable
+import androidx.compose.Recomposer
 import androidx.compose.StructurallyEqual
 import androidx.compose.mutableStateOf
 import androidx.ui.core.setContent
@@ -84,7 +85,7 @@ internal class ComposeViewFactory<RenderingT : Any>(
     )
 
     // Entry point to the composition.
-    composeContainer.setContent {
+    composeContainer.setContent(Recomposer.current()) {
       // Don't compose anything until we have the first value (which should happen in the initial
       // frame).
       val (rendering, environment) = renderState.value ?: return@setContent

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewEnvironments.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewEnvironments.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+import androidx.compose.remember
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewRegistry
+
+/**
+ * Renders [rendering] into the composition using this [ViewEnvironment].
+ * [ViewRegistry][com.squareup.workflow.ui.ViewRegistry] to generate the view.
+ *
+ * ## Example
+ *
+ * ```
+ * data class FramedRendering(
+ *   val borderColor: Color,
+ *   val child: Any
+ * )
+ *
+ * val FramedContainerViewFactory = bindCompose { rendering: FramedRendering, hints: ContainerHints ->
+ *   Surface(border = Border(rendering.borderColor, 8.dp)) {
+ *     hints.showRendering(rendering.child)
+ *   }
+ * }
+ * ```
+ */
+@Composable fun ViewEnvironment.showRendering(rendering: Any) {
+  val viewRegistry = remember(this) { this[ViewRegistry] }
+  viewRegistry.showRendering(rendering, this)
+}

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewFactories.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewFactories.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import android.content.Context
+import android.widget.FrameLayout
+import android.widget.FrameLayout.LayoutParams.MATCH_PARENT
+import androidx.compose.Composable
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewFactory
+import com.squareup.workflow.ui.WorkflowViewStub
+import com.squareup.workflow.ui.compose.ComposableViewStubWrapper.Update
+
+/**
+ * Renders [rendering] into the composition using the `ViewRegistry` from the [ContainerHints] to
+ * determine how to draw it.
+ *
+ * To display a nested rendering from a [Composable view binding][bindCompose], use
+ * [ViewEnvironment.showRendering].
+ *
+ * To preview your layout bindings, use the `ViewBinding.preview` method instead.
+ *
+ * @see ViewEnvironment.showRendering
+ * @see com.squareup.workflow.ui.ViewRegistry.showRendering
+ */
+@Composable fun <RenderingT : Any> ViewFactory<RenderingT>.showRendering(
+  rendering: RenderingT,
+  hints: ViewEnvironment
+) {
+  // Fast path: If the child binding is also a Composable, we don't need to go through the legacy
+  // view system and can just invoke the binding's composable function directly.
+  if (this is ComposeViewFactory) {
+    showRendering(rendering, hints)
+    return
+  }
+
+  // IntelliJ currently complains very loudly about this function call, but it actually compiles.
+  // The IDE tooling isn't currently able to recognize that the Compose compiler accepts this code.
+  ComposableViewStubWrapper(update = Update(rendering, hints))
+}
+
+/**
+ * Wraps a [WorkflowViewStub] with an API that is more Compose-friendly.
+ *
+ * In particular, Compose will only generate `Emittable`s for views with a single constructor
+ * that takes a [Context].
+ *
+ * See [this slack message](https://kotlinlang.slack.com/archives/CJLTWPH7S/p1576264533012000?thread_ts=1576262311.008800&cid=CJLTWPH7S).
+ */
+private class ComposableViewStubWrapper(context: Context) : FrameLayout(context) {
+
+  data class Update(
+    val rendering: Any,
+    val containerHints: ViewEnvironment
+  )
+
+  private val viewStub = WorkflowViewStub(context)
+
+  init {
+    addView(viewStub, LayoutParams(MATCH_PARENT, MATCH_PARENT))
+  }
+
+  // Compose turns this into a parameter when you invoke this class as a Composable.
+  fun setUpdate(update: Update) {
+    println("Updating WorkflowViewStub with $update…")
+    viewStub.update(update.rendering, update.containerHints)
+  }
+}

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewRegistries.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewRegistries.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+import androidx.compose.remember
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewFactory
+import com.squareup.workflow.ui.ViewRegistry
+
+/**
+ * Renders [rendering] into the composition using this [ViewRegistry] to determine how to draw it.
+ *
+ * To display a nested rendering from a [Composable view binding][bindCompose], use
+ * [ContainerHints.showRendering].
+ *
+ * @see ContainerHints.showRendering
+ * @see ViewBinding.showRendering
+ */
+@Composable fun ViewRegistry.showRendering(
+  rendering: Any,
+  hints: ViewEnvironment
+) {
+  val renderingType = rendering::class
+  val binding: ViewFactory<Any> = remember(renderingType) { getBindingFor(renderingType) }
+  binding.showRendering(rendering = rendering, hints = hints)
+}


### PR DESCRIPTION
Based on #703.

Add the ability to implement containers with composable view bindings and introduce tooling module with support for previewing `ViewBinding`s with Compose's Preview.

![image](https://user-images.githubusercontent.com/101754/73681395-1d00da80-4673-11ea-9164-8aab6aa2dc64.png)
