### PR TITLE
Introduce ComposableDecorator to provide shared context for all composable view bindings.

### DIFF
--- a/kotlin/.buildscript/configure-compose.gradle
+++ b/kotlin/.buildscript/configure-compose.gradle
@@ -14,11 +14,21 @@
  * limitations under the License.
  */
 
+/*
+In addition applying this file, as of dev10 modules that use Compose also need to include this
+code snippet to avoid warnings about using compiler version 1.4:
+
+tasks.withType<KotlinCompile>().configureEach {
+ kotlinOptions.apiVersion = "1.3"
+}
+*/
+
 android {
   buildFeatures {
     compose true
   }
   composeOptions {
+    kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
     kotlinCompilerExtensionVersion Versions.compose
   }
 }

--- a/kotlin/buildSrc/src/main/java/Dependencies.kt
+++ b/kotlin/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@ import java.util.Locale.US
 import kotlin.reflect.full.declaredMembers
 
 object Versions {
-  const val compose = "0.1.0-dev09"
+  const val compose = "0.1.0-dev10"
   const val coroutines = "1.3.4"
   const val kotlin = "1.3.71"
   const val targetSdk = 29

--- a/kotlin/samples/hello-compose-binding/build.gradle.kts
+++ b/kotlin/samples/hello-compose-binding/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 /*
  * Copyright 2019 Square Inc.
  *
@@ -28,6 +30,9 @@ android {
 }
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
+tasks.withType<KotlinCompile>().configureEach {
+  kotlinOptions.apiVersion = "1.3"
+}
 
 dependencies {
   implementation(project(":workflow-ui:core-compose"))

--- a/kotlin/samples/hello-compose-binding/src/androidTest/java/com/squareup/sample/hellocomposebinding/HelloBindingTest.kt
+++ b/kotlin/samples/hello-compose-binding/src/androidTest/java/com/squareup/sample/hellocomposebinding/HelloBindingTest.kt
@@ -15,8 +15,8 @@
  */
 package com.squareup.sample.hellocomposebinding
 
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.ui.test.android.AndroidComposeTestRule
 import androidx.ui.test.assertIsDisplayed
 import androidx.ui.test.doClick
 import androidx.ui.test.findByText
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 class HelloBindingTest {
 
   // Launches the activity.
-  @Rule @JvmField val scenario = ActivityScenarioRule(HelloBindingActivity::class.java)
+  @Rule @JvmField val composeRule = AndroidComposeTestRule<HelloBindingActivity>()
 
   @Test fun togglesBetweenStates() {
     findByText("Hello")

--- a/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
+++ b/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
@@ -30,9 +30,7 @@ import com.squareup.sample.hellocomposebinding.HelloWorkflow.Rendering
 import com.squareup.workflow.ui.compose.bindCompose
 
 val HelloBinding = bindCompose<Rendering> { rendering, _ ->
-  MaterialTheme {
-    DrawHelloRendering(rendering)
-  }
+  DrawHelloRendering(rendering)
 }
 
 @Composable

--- a/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBindingActivity.kt
+++ b/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBindingActivity.kt
@@ -17,17 +17,27 @@ package com.squareup.sample.hellocomposebinding
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.ui.material.MaterialTheme
 import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
+import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowRunner
+import com.squareup.workflow.ui.compose.ComposableDecorator
 import com.squareup.workflow.ui.setContentWorkflow
 
 private val viewRegistry = ViewRegistry(HelloBinding)
+private val composableDecorator = ComposableDecorator { children ->
+  MaterialTheme {
+    children()
+  }
+}
+private val containerHints = ContainerHints(viewRegistry) +
+    (ComposableDecorator to composableDecorator)
 
 class HelloBindingActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentWorkflow(viewRegistry) {
+    setContentWorkflow(containerHints) {
       WorkflowRunner.Config(
           HelloWorkflow,
           diagnosticListener = SimpleLoggingDiagnosticListener()

--- a/kotlin/workflow-ui/core-compose/README.md
+++ b/kotlin/workflow-ui/core-compose/README.md
@@ -29,21 +29,28 @@ android {
     compose true
   }
   composeOptions {
+    kotlinCompilerVersion "1.3.70-dev-withExperimentalGoogleExtensions-20200424"
     kotlinCompilerExtensionVersion "${compose_version}"
   }
 }
 ```
 
-To create a binding, call `bindCompose`. The lambda passed to `bindCompose` is a `@Composable`
+You may also need to set the Kotlin API version to 1.3:
+
+```groovy
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions.apiVersion = "1.3"
+}
+```
+
+To create a `ViewFactory`, call `bindCompose`. The lambda passed to `bindCompose` is a `@Composable`
 function.
 
 ```kotlin
 val HelloBinding = bindCompose<MyRendering> { rendering ->
   MaterialTheme {
     Clickable(onClick = { rendering.onClick() }) {
-      Center {
-        Text(rendering.message)
-      }
+      Text(rendering.message)
     }
   }
 }
@@ -57,5 +64,5 @@ val viewRegistry = ViewRegistry(HelloBinding)
 ```
 
 [1]: https://developer.android.com/jetpack/compose
-[2]: https://square.github.io/workflow/kotlin/api/workflow-ui-android/com.squareup.workflow.ui/-view-binding/
-[3]: https://square.github.io/workflow/kotlin/api/workflow-ui-android/com.squareup.workflow.ui/-view-registry/
+[2]: https://square.github.io/workflow/kotlin/api/workflow/com.squareup.workflow.ui/-view-factory/
+[3]: https://square.github.io/workflow/kotlin/api/workflow/com.squareup.workflow.ui/-view-registry/

--- a/kotlin/workflow-ui/core-compose/build.gradle.kts
+++ b/kotlin/workflow-ui/core-compose/build.gradle.kts
@@ -27,11 +27,17 @@ java {
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
 apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
+android {
+  defaultConfig {
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
+}
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
-tasks.withType<KotlinCompile>().configureEach {
-  kotlinOptions.apiVersion = "1.3"
-}
+tasks.withType<KotlinCompile>()
+    .configureEach {
+      kotlinOptions.apiVersion = "1.3"
+    }
 
 dependencies {
   api(project(":workflow-ui:core-android"))
@@ -44,4 +50,9 @@ dependencies {
 
   testImplementation(Dependencies.Test.junit)
   testImplementation(Dependencies.Test.truth)
+
+  androidTestImplementation(Dependencies.Compose.test)
+  androidTestImplementation(Dependencies.Kotlin.Test.jdk)
+  androidTestImplementation(Dependencies.Test.junit)
+  androidTestImplementation(Dependencies.Test.truth)
 }

--- a/kotlin/workflow-ui/core-compose/build.gradle.kts
+++ b/kotlin/workflow-ui/core-compose/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 /*
  * Copyright 2019 Square Inc.
  *
@@ -24,10 +26,12 @@ java {
 }
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
-
 apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
+tasks.withType<KotlinCompile>().configureEach {
+  kotlinOptions.apiVersion = "1.3"
+}
 
 dependencies {
   api(project(":workflow-ui:core-android"))

--- a/kotlin/workflow-ui/core-compose/src/androidTest/AndroidManifest.xml
+++ b/kotlin/workflow-ui/core-compose/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.squareup.workflow.ui.core.compose.test">
+
+  <application>
+    <!--  Required for createComposeRule.  -->
+    <activity
+        android:name="android.app.Activity"
+        android:theme="@android:style/Theme.Material.NoActionBar.Fullscreen" />
+  </application>
+</manifest>

--- a/kotlin/workflow-ui/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/ComposableDecoratorTest.kt
+++ b/kotlin/workflow-ui/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/ComposableDecoratorTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import androidx.ui.core.Text
+import androidx.ui.layout.Column
+import androidx.ui.test.assertIsVisible
+import androidx.ui.test.createComposeRule
+import androidx.ui.test.findByText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@RunWith(JUnit4::class)
+class ComposableDecoratorTest {
+
+  @Rule @JvmField val composeTestRule = createComposeRule()
+
+  @Test fun assertingComposableDecorator_works() {
+    val wrapped = ComposableDecorator { children ->
+      Column {
+        Text("Parent")
+        children()
+      }
+    }
+    val decorator = AssertingComposableDecorator(wrapped)
+
+    composeTestRule.setContent {
+      decorator.decorate {
+        Text("Child")
+      }
+    }
+
+    composeTestRule.runOnIdleCompose {
+      findByText("Parent")
+    }
+        .assertIsVisible()
+    findByText("Child").assertIsVisible()
+  }
+
+  @Test fun assertingComposableDecorator_throws_whenChildrenNotInvoked() {
+    val wrapped = ComposableDecorator { }
+    val decorator = AssertingComposableDecorator(wrapped)
+
+    val error = assertFailsWith<IllegalStateException> {
+      composeTestRule.setContent {
+        decorator.decorate {}
+      }
+    }
+
+    assertEquals(
+        "Expected ComposableDecorator to invoke children exactly once, but was invoked 0 times.",
+        error.message
+    )
+  }
+
+  @Test fun assertingComposableDecorator_throws_whenChildrenInvokedMultipleTimes() {
+    val wrapped = ComposableDecorator { children ->
+      children()
+      children()
+    }
+    val decorator = AssertingComposableDecorator(wrapped)
+
+    val error = assertFailsWith<IllegalStateException> {
+      composeTestRule.setContent {
+        decorator.decorate {
+          Text("Hello")
+        }
+      }
+    }
+
+    assertEquals(
+        "Expected ComposableDecorator to invoke children exactly once, but was invoked 2 times.",
+        error.message
+    )
+  }
+}

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposableDecorator.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposableDecorator.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+import com.squareup.workflow.ui.ViewEnvironmentKey
+
+// TODO a better way to do this whole thing is for ComposeViewFactory to look for a composition
+// reference in its ancestor somehow, and use that to propogate ambients and stuff down to itself.
+
+/**
+ * Defines a `@Composable` function that will be used to wrap every
+ * [composable view binding][bindCompose].
+ *
+ * This function can install ambients and configure things like theming. It will only be invoked
+ * at the top of a given compose tree:
+ *  - If multiple nested composable view bindings are used, it will only wrap the top-most one.
+ *  - If a composable tree nests a non-composable view binding, which then further nests a
+ *    composable binding, the decorator will be invoked twice.
+ */
+interface ComposableDecorator {
+
+  @Composable fun decorate(content: @Composable() () -> Unit)
+
+  companion object : ViewEnvironmentKey<ComposableDecorator>(ComposableDecorator::class) {
+    override val default: ComposableDecorator get() = NoopComposableDecorator
+  }
+}
+
+// This could be inline, but that makes the Compose compiler puke.
+@Suppress("FunctionName")
+fun ComposableDecorator(
+  decorator: @Composable() (content: @Composable() () -> Unit) -> Unit
+): ComposableDecorator = object : ComposableDecorator {
+  @Composable override fun decorate(content: @Composable() () -> Unit) = decorator(content)
+}
+
+/**
+ * [ComposableDecorator] that asserts that the [decorate] method invokes its children parameter
+ * exactly once, and throws an [IllegalStateException] if not.
+ */
+internal class AssertingComposableDecorator(
+  private val delegate: ComposableDecorator
+) : ComposableDecorator {
+  @Composable override fun decorate(content: @Composable() () -> Unit) {
+    var childrenCalledCount = 0
+    delegate.decorate {
+      childrenCalledCount++
+      content()
+    }
+    // TODO do we need to `remember` anything here? I think we don't because we want to assert
+    // on every compose pass, in case delegate has conditionals.
+    check(childrenCalledCount == 1) {
+      "Expected ComposableDecorator to invoke children exactly once, " +
+          "but was invoked $childrenCalledCount times."
+    }
+  }
+}
+
+private object NoopComposableDecorator : ComposableDecorator {
+  @Composable override fun decorate(content: () -> Unit) {
+    content()
+  }
+}

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.Composable
+import androidx.compose.Recomposer
 import androidx.compose.StructurallyEqual
 import androidx.compose.mutableStateOf
 import androidx.ui.core.setContent
@@ -84,7 +85,7 @@ internal class ComposeViewFactory<RenderingT : Any>(
     )
 
     // Entry point to the composition.
-    composeContainer.setContent {
+    composeContainer.setContent(Recomposer.current()) {
       // Don't compose anything until we have the first value (which should happen in the initial
       // frame).
       val (rendering, environment) = renderState.value ?: return@setContent


### PR DESCRIPTION
Based on #703.

Helpful for defining ambient context specific to Composable bindings (e.g. setting up a `MaterialTheme`).