### PR TITLE
Make WorkflowTester tests use the main context as the worker context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Change Log
 
 ### Kotlin
 
- * Make the context used to start workers configurable for tests. (#940)
+ * Make the context used to start workers configurable for tests. (#940, #943)
 
 ### Swift
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/LaunchWorkflow.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/LaunchWorkflow.kt
@@ -131,6 +131,7 @@ internal fun <PropsT, StateT, OutputT : Any, RenderingT, RunnerT> launchWorkflow
   val renderingsAndSnapshots = ConflatedBroadcastChannel<RenderingAndSnapshot<RenderingT>>()
   val outputs = BroadcastChannel<OutputT>(capacity = 1)
   val workflowScope = scope + Job(parent = scope.coroutineContext[Job])
+  require(workerContext[Job] == null) { "Expected workerContext not to have a Job." }
 
   // Give the caller a chance to start collecting outputs.
   val session = WorkflowSession(renderingsAndSnapshots.asFlow(), outputs.asFlow())

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -44,6 +44,10 @@ import kotlin.coroutines.EmptyCoroutineContext
  * value to its parent. Returns either the output to be emitted from the root workflow, or null.
  * @param initialState Allows unit tests to start the node from a given state, instead of calling
  * [StatefulWorkflow.initialState].
+ * @param workerContext [CoroutineContext] that is appended to the end of the context used to launch
+ * worker coroutines. This context will override anything from the workflow's scope and any other
+ * hard-coded values added to worker contexts. It must not contain a [Job] element (it would violate
+ * structured concurrency).
  */
 @UseExperimental(VeryExperimentalWorkflow::class)
 internal class WorkflowNode<PropsT, StateT, OutputT : Any, RenderingT>(

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/testing/LaunchWorkflow.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/testing/LaunchWorkflow.kt
@@ -26,6 +26,7 @@ import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromCompl
 import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromState
 import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromWorkflowSnapshot
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import org.jetbrains.annotations.TestOnly
 
@@ -63,6 +64,10 @@ fun <PropsT, StateT, OutputT : Any, RenderingT, RunnerT> launchWorkflowForTestFr
       initialState = initialState,
       initialSnapshot = initialSnapshot,
       beforeStart = beforeStart,
-      workerContext = testParams.workerContext
+      // Use the base context as the starting point for the worker context since it's often used
+      // to pass in test dispatchers.
+      // Remove any job present in the base context since worker context aren't allowed to contain
+      // jobs (it would violate structured concurrency).
+      workerContext = scope.coroutineContext.minusKey(Job)
   )
 }

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/testing/WorkflowTestParams.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/testing/WorkflowTestParams.kt
@@ -22,8 +22,6 @@ import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromCompl
 import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromState
 import com.squareup.workflow.testing.WorkflowTestParams.StartMode.StartFromWorkflowSnapshot
 import org.jetbrains.annotations.TestOnly
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Defines configuration for workflow testing infrastructure such as `testRender`, `testFromStart`.
@@ -36,15 +34,11 @@ import kotlin.coroutines.EmptyCoroutineContext
  * for any given state, so performing side effects in `render` will almost always result in bugs.
  * It is recommended to leave this on, but if you need to debug a test and don't want to have to
  * deal with the extra passes, you can temporarily set it to false.
- * @param workerContext Used to customize the context in which workers are started for tests.
- * Default is [EmptyCoroutineContext], which means the workers will use the context from their
- * workflow and use the [Unconfined][kotlinx.coroutines.Dispatchers.Unconfined] dispatcher.
  */
 @TestOnly
 data class WorkflowTestParams<out StateT>(
   val startFrom: StartMode<StateT> = StartFresh,
-  val checkRenderIdempotence: Boolean = true,
-  val workerContext: CoroutineContext = EmptyCoroutineContext
+  val checkRenderIdempotence: Boolean = true
 ) {
   /**
    * Defines how to start the workflow for tests.


### PR DESCRIPTION
This is an enhancement to #940 that gives more reasonable behavior. The context
parameter to the test methods are primarily used to pass in test dispatchers, and
those dispatchers often really only need to be used for workers.

Since I don't know of a use case for specifying context separately just for workers,
this also removes the `WorkflowTestParams.workerContext` property.