### PR TITLE
Make ViewRegistry's key set strictly-typed to KClass<*> instead of Any.

### DIFF
--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/BindingViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/BindingViewRegistry.kt
@@ -36,7 +36,7 @@ internal class BindingViewRegistry private constructor(
       }
   )
 
-  override val keys: Set<Any> get() = bindings.keys
+  override val keys: Set<KClass<*>> get() = bindings.keys
 
   override fun <RenderingT : Any> buildView(
     initialRendering: RenderingT,

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/CompositeViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/CompositeViewRegistry.kt
@@ -18,6 +18,7 @@ package com.squareup.workflow.ui
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import kotlin.reflect.KClass
 
 /**
  * A [ViewRegistry] that contains only other registries and delegates to their [buildView] methods.
@@ -34,12 +35,12 @@ import android.view.ViewGroup
  * a reference to another [CompositeViewRegistry].
  */
 internal class CompositeViewRegistry private constructor(
-  private val registriesByKey: Map<Any, ViewRegistry>
+  private val registriesByKey: Map<KClass<*>, ViewRegistry>
 ) : ViewRegistry {
 
   constructor (vararg registries: ViewRegistry) : this(mergeRegistries(*registries))
 
-  override val keys: Set<Any> get() = registriesByKey.keys
+  override val keys: Set<KClass<*>> get() = registriesByKey.keys
 
   override fun <RenderingT : Any> buildView(
     initialRendering: RenderingT,
@@ -56,10 +57,10 @@ internal class CompositeViewRegistry private constructor(
   }
 
   companion object {
-    private fun mergeRegistries(vararg registries: ViewRegistry): Map<Any, ViewRegistry> {
-      val registriesByKey = mutableMapOf<Any, ViewRegistry>()
+    private fun mergeRegistries(vararg registries: ViewRegistry): Map<KClass<*>, ViewRegistry> {
+      val registriesByKey = mutableMapOf<KClass<*>, ViewRegistry>()
 
-      fun putAllUnique(other: Map<Any, ViewRegistry>) {
+      fun putAllUnique(other: Map<KClass<*>, ViewRegistry>) {
         val duplicateKeys = registriesByKey.keys.intersect(other.keys)
         check(duplicateKeys.isEmpty()) { "Must not have duplicate entries: $duplicateKeys" }
         registriesByKey.putAll(other)

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
@@ -20,6 +20,7 @@ package com.squareup.workflow.ui
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import kotlin.reflect.KClass
 
 /**
  * [ViewBinding]s that are always available.
@@ -63,7 +64,7 @@ interface ViewRegistry {
    *
    * Used to ensure that duplicate bindings are never registered.
    */
-  val keys: Set<Any>
+  val keys: Set<KClass<*>>
 
   /**
    * It is usually more convenient to use [WorkflowViewStub] than to call this method directly.

--- a/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/CompositeViewRegistryTest.kt
+++ b/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/CompositeViewRegistryTest.kt
@@ -102,7 +102,7 @@ class CompositeViewRegistryTest {
   private object BazRendering
 
   private class TestRegistry(private val bindings: Map<KClass<*>, View>) : ViewRegistry {
-    override val keys: Set<Any> get() = bindings.keys
+    override val keys: Set<KClass<*>> get() = bindings.keys
 
     override fun <RenderingT : Any> buildView(
       initialRendering: RenderingT,


### PR DESCRIPTION
The lack of typing caused a bug integrating with some legacy code, and wasn't
needed or useful, so fixing the type.