### PR TITLE
Add JetBrain's new kotlin binary compatibility validator to start tracking changes to our ABI.

### DIFF
--- a/kotlin/.buildscript/binary-validation.gradle
+++ b/kotlin/.buildscript/binary-validation.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * We use JetBrain's Kotlin Binary Compatibility Validator to track changes to our public binary
+ * APIs.
+ * When making a change that results in a public ABI change, the apiCheck task will fail. When this
+ * happens, run ./gradlew apiDump to generate updated *.api files, and add those to your commit.
+ * See https://github.com/Kotlin/binary-compatibility-validator
+ */
+
+apply plugin: 'binary-compatibility-validator'
+
+apiValidation {
+  // Only leaf project name is valid configuration, and every project must be individually ignored.
+  // See https://github.com/Kotlin/binary-compatibility-validator/issues/3
+  // Please keep this list sorted alphabetically.
+  ignoredProjects += [
+      "android",
+      "app",
+      "app-poetry",
+      "app-raven",
+      "common",
+      "hello-back-button",
+      "hello-terminal-app",
+      "hello-workflow",
+      "hello-workflow-fragment",
+      "poetry",
+      "recyclerview",
+      "terminal-workflow",
+      "timemachine",
+      "timemachine-shakeable",
+      "todo-terminal-app",
+  ]
+}

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -72,6 +72,7 @@ buildscript {
       'timber': "com.jakewharton.timber:timber:4.7.1",
 
       'kotlin': [
+          'binaryCompatibilityValidatorPlugin': "org.jetbrains.kotlinx:binary-compatibility-validator:0.1.1",
           'gradlePlugin': "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61",
           'stdLib': [
               'common': "org.jetbrains.kotlin:kotlin-stdlib-common",
@@ -142,6 +143,7 @@ buildscript {
     classpath deps.detekt
     classpath deps.dokka
     classpath deps.jmh.gradlePlugin
+    classpath deps.kotlin.binaryCompatibilityValidatorPlugin
     classpath deps.kotlin.gradlePlugin
     classpath deps.kotlin.serialization.gradlePlugin
     classpath deps.ktlint
@@ -156,6 +158,8 @@ buildscript {
     maven {
       url { "https://oss.sonatype.org/content/repositories/snapshots" }
     }
+    // For binary compatibility validator.
+    maven { url "https://kotlin.bintray.com/kotlinx" }
   }
 }
 
@@ -206,3 +210,5 @@ subprojects {
     ]
   }
 }
+
+apply from: rootProject.file('.buildscript/binary-validation.gradle')

--- a/kotlin/internal-testing-utils/api/internal-testing-utils.api
+++ b/kotlin/internal-testing-utils/api/internal-testing-utils.api
@@ -1,0 +1,10 @@
+public final class com/squareup/workflow/internal/util/UncaughtExceptionGuard {
+	public fun <init> ()V
+	public final fun reportUncaught (Ljava/lang/Throwable;)V
+	public final fun runRethrowingUncaught (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/internal/util/UncaughtExceptionGuardKt {
+	public static final fun rethrowingUncaughtExceptions (Lkotlin/jvm/functions/Function0;)V
+}
+

--- a/kotlin/legacy/legacy-workflow-core/api/legacy-workflow-core.api
+++ b/kotlin/legacy/legacy-workflow-core/api/legacy-workflow-core.api
@@ -1,0 +1,201 @@
+public final class com/squareup/workflow/legacy/CoroutineWorkflowKt {
+	public static final fun workflow (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function4;)Lcom/squareup/workflow/legacy/Workflow;
+	public static synthetic fun workflow$default (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/Workflow;
+}
+
+public final class com/squareup/workflow/legacy/EnterState : com/squareup/workflow/legacy/Reaction {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/squareup/workflow/legacy/EnterState;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/legacy/EnterState;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/EnterState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/legacy/FinishWith : com/squareup/workflow/legacy/Reaction {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/squareup/workflow/legacy/FinishWith;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/legacy/FinishWith;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/FinishWith;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResult ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/legacy/Finished : com/squareup/workflow/legacy/WorkflowUpdate {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/squareup/workflow/legacy/Finished;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/legacy/Finished;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/Finished;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResult ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/squareup/workflow/legacy/Reaction {
+}
+
+public abstract interface class com/squareup/workflow/legacy/Reactor : com/squareup/workflow/legacy/WorkflowPool$Launcher {
+	public abstract fun launch (Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;)Lcom/squareup/workflow/legacy/Workflow;
+	public abstract fun onReact (Ljava/lang/Object;Lkotlinx/coroutines/channels/ReceiveChannel;Lcom/squareup/workflow/legacy/WorkflowPool;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/legacy/Reactor$DefaultImpls {
+	public static fun launch (Lcom/squareup/workflow/legacy/Reactor;Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;)Lcom/squareup/workflow/legacy/Workflow;
+}
+
+public final class com/squareup/workflow/legacy/ReactorException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/Throwable;Lcom/squareup/workflow/legacy/Reactor;Ljava/lang/Object;)V
+	public fun getMessage ()Ljava/lang/String;
+	public final fun getReactor ()Lcom/squareup/workflow/legacy/Reactor;
+	public final fun getReactorState ()Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/legacy/ReactorKt {
+	public static final fun doLaunch (Lcom/squareup/workflow/legacy/Reactor;Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;Lkotlin/coroutines/CoroutineContext;)Lcom/squareup/workflow/legacy/Workflow;
+	public static synthetic fun doLaunch$default (Lcom/squareup/workflow/legacy/Reactor;Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/Workflow;
+}
+
+public abstract interface class com/squareup/workflow/legacy/Renderer {
+	public abstract fun render (Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowInput;Lcom/squareup/workflow/legacy/WorkflowPool;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/legacy/RendererKt {
+	public static final fun render (Lcom/squareup/workflow/legacy/Renderer;Lcom/squareup/workflow/legacy/WorkflowPool$Handle;Lcom/squareup/workflow/legacy/WorkflowPool;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/legacy/Running : com/squareup/workflow/legacy/WorkflowUpdate {
+	public fun <init> (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)V
+	public final fun component1 ()Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+	public final fun copy (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)Lcom/squareup/workflow/legacy/Running;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/legacy/Running;Lcom/squareup/workflow/legacy/WorkflowPool$Handle;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/Running;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHandle ()Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/squareup/workflow/legacy/Worker {
+	public abstract fun call (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/legacy/WorkerKt {
+	public static final fun asWorker (Lkotlinx/coroutines/Deferred;)Lcom/squareup/workflow/legacy/Worker;
+	public static final fun worker (Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/legacy/Worker;
+}
+
+public abstract interface class com/squareup/workflow/legacy/Workflow : com/squareup/workflow/legacy/WorkflowInput, kotlinx/coroutines/Deferred {
+	public abstract fun openSubscriptionToState ()Lkotlinx/coroutines/channels/ReceiveChannel;
+}
+
+public final class com/squareup/workflow/legacy/Workflow$DefaultImpls {
+	public static synthetic fun cancel (Lcom/squareup/workflow/legacy/Workflow;)V
+	public static fun fold (Lcom/squareup/workflow/legacy/Workflow;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static fun get (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
+	public static fun minusKey (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
+	public static fun plus (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
+	public static fun plus (Lcom/squareup/workflow/legacy/Workflow;Lkotlinx/coroutines/Job;)Lkotlinx/coroutines/Job;
+}
+
+public abstract interface class com/squareup/workflow/legacy/WorkflowInput {
+	public static final field Companion Lcom/squareup/workflow/legacy/WorkflowInput$Companion;
+	public abstract fun sendEvent (Ljava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/legacy/WorkflowInput$Companion {
+	public final fun disabled ()Lcom/squareup/workflow/legacy/WorkflowInput;
+}
+
+public final class com/squareup/workflow/legacy/WorkflowInput$ReadOnly : com/squareup/workflow/legacy/WorkflowInput {
+	public static final field INSTANCE Lcom/squareup/workflow/legacy/WorkflowInput$ReadOnly;
+	public synthetic fun sendEvent (Ljava/lang/Object;)V
+	public fun sendEvent (Ljava/lang/Void;)V
+}
+
+public final class com/squareup/workflow/legacy/WorkflowInputKt {
+	public static final fun WorkflowInput (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/legacy/WorkflowInput;
+	public static final fun adaptEvents (Lcom/squareup/workflow/legacy/WorkflowInput;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/legacy/WorkflowInput;
+}
+
+public final class com/squareup/workflow/legacy/WorkflowOperatorsKt {
+	public static final fun adaptEvents (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/legacy/Workflow;
+	public static final fun mapResult (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/legacy/Workflow;
+	public static final fun mapState (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/legacy/Workflow;
+	public static final fun switchMapState (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow/legacy/Workflow;
+}
+
+public final class com/squareup/workflow/legacy/WorkflowPool {
+	public static final field Companion Lcom/squareup/workflow/legacy/WorkflowPool$Companion;
+	public fun <init> ()V
+	public final fun abandonAll ()V
+	public final synthetic fun abandonWorker (Lcom/squareup/workflow/legacy/Worker;Ljava/lang/String;)V
+	public static synthetic fun abandonWorker$default (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun abandonWorkflow (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)V
+	public final fun abandonWorkflow (Lcom/squareup/workflow/legacy/WorkflowPool$Id;)V
+	public final fun awaitWorkerResult (Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lcom/squareup/workflow/legacy/WorkflowPool$Type;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final synthetic fun awaitWorkerResult (Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitWorkerResult$default (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun awaitWorkflowUpdate (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getPeekWorkflowsCount ()I
+	public final fun input (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)Lcom/squareup/workflow/legacy/WorkflowInput;
+	public final fun register (Lcom/squareup/workflow/legacy/WorkflowPool$Launcher;Lcom/squareup/workflow/legacy/WorkflowPool$Type;)V
+}
+
+public final class com/squareup/workflow/legacy/WorkflowPool$Companion {
+	public final synthetic fun handle (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+	public final synthetic fun handle (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+	public static synthetic fun handle$default (Lcom/squareup/workflow/legacy/WorkflowPool$Companion;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+	public static synthetic fun handle$default (Lcom/squareup/workflow/legacy/WorkflowPool$Companion;Lkotlin/reflect/KClass;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+}
+
+public final class com/squareup/workflow/legacy/WorkflowPool$Handle {
+	public fun <init> (Lcom/squareup/workflow/legacy/WorkflowPool$Id;Ljava/lang/Object;)V
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lcom/squareup/workflow/legacy/WorkflowPool$Id;Ljava/lang/Object;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;Lcom/squareup/workflow/legacy/WorkflowPool$Id;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/legacy/WorkflowPool$Id {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/squareup/workflow/legacy/WorkflowPool$Type;
+	public final fun copy (Ljava/lang/String;Lcom/squareup/workflow/legacy/WorkflowPool$Type;)Lcom/squareup/workflow/legacy/WorkflowPool$Id;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/legacy/WorkflowPool$Id;Ljava/lang/String;Lcom/squareup/workflow/legacy/WorkflowPool$Type;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/WorkflowPool$Id;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getWorkflowType ()Lcom/squareup/workflow/legacy/WorkflowPool$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/squareup/workflow/legacy/WorkflowPool$Launcher {
+	public abstract fun launch (Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;)Lcom/squareup/workflow/legacy/Workflow;
+}
+
+public final class com/squareup/workflow/legacy/WorkflowPool$Type {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;Lkotlin/reflect/KClass;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun makeWorkflowId (Ljava/lang/String;)Lcom/squareup/workflow/legacy/WorkflowPool$Id;
+}
+
+public final class com/squareup/workflow/legacy/WorkflowPoolKt {
+	public static final synthetic fun getWorkflowType (Lcom/squareup/workflow/legacy/WorkflowPool$Launcher;)Lcom/squareup/workflow/legacy/WorkflowPool$Type;
+	public static final synthetic fun getWorkflowType (Lkotlin/reflect/KClass;)Lcom/squareup/workflow/legacy/WorkflowPool$Type;
+	public static final synthetic fun register (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/WorkflowPool$Launcher;)V
+	public static final synthetic fun workerResult (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;)Lkotlinx/coroutines/Deferred;
+	public static final fun workerResult (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lcom/squareup/workflow/legacy/WorkflowPool$Type;)Lkotlinx/coroutines/Deferred;
+	public static synthetic fun workerResult$default (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lkotlinx/coroutines/Deferred;
+	public static final fun workflowUpdate (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)Lkotlinx/coroutines/Deferred;
+}
+
+public abstract class com/squareup/workflow/legacy/WorkflowUpdate {
+}
+

--- a/kotlin/legacy/legacy-workflow-rx2/api/legacy-workflow-rx2.api
+++ b/kotlin/legacy/legacy-workflow-rx2/api/legacy-workflow-rx2.api
@@ -1,0 +1,48 @@
+public abstract interface class com/squareup/workflow/legacy/rx2/EventChannel {
+	public abstract fun select (Lkotlin/jvm/functions/Function1;)Lio/reactivex/Single;
+}
+
+public final class com/squareup/workflow/legacy/rx2/EventChannelKt {
+	public static final fun asEventChannel (Lkotlinx/coroutines/channels/ReceiveChannel;)Lcom/squareup/workflow/legacy/rx2/EventChannel;
+}
+
+public final class com/squareup/workflow/legacy/rx2/EventSelectBuilder {
+	public final fun addEventCase (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun onEvent (Lkotlin/jvm/functions/Function1;)V
+	public final fun onSuccess (Lio/reactivex/Single;Lkotlin/jvm/functions/Function1;)V
+	public final fun onSuspending (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public final synthetic fun onWorkerResult (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun onWorkerResult$default (Lcom/squareup/workflow/legacy/rx2/EventSelectBuilder;Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun onWorkflowUpdate (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/WorkflowPool$Handle;Lkotlin/jvm/functions/Function1;)V
+}
+
+public abstract interface class com/squareup/workflow/legacy/rx2/Reactor : com/squareup/workflow/legacy/WorkflowPool$Launcher {
+	public abstract fun launch (Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;)Lcom/squareup/workflow/legacy/Workflow;
+	public abstract fun onReact (Ljava/lang/Object;Lcom/squareup/workflow/legacy/rx2/EventChannel;Lcom/squareup/workflow/legacy/WorkflowPool;)Lio/reactivex/Single;
+}
+
+public final class com/squareup/workflow/legacy/rx2/Reactor$DefaultImpls {
+	public static fun launch (Lcom/squareup/workflow/legacy/rx2/Reactor;Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;)Lcom/squareup/workflow/legacy/Workflow;
+}
+
+public final class com/squareup/workflow/legacy/rx2/ReactorKt {
+	public static final fun doLaunch (Lcom/squareup/workflow/legacy/rx2/Reactor;Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;Ljava/lang/String;)Lcom/squareup/workflow/legacy/Workflow;
+	public static synthetic fun doLaunch$default (Lcom/squareup/workflow/legacy/rx2/Reactor;Ljava/lang/Object;Lcom/squareup/workflow/legacy/WorkflowPool;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/Workflow;
+	public static final fun toCoroutineReactor (Lcom/squareup/workflow/legacy/rx2/Reactor;)Lcom/squareup/workflow/legacy/Reactor;
+}
+
+public final class com/squareup/workflow/legacy/rx2/WorkersKt {
+	public static final fun asWorker (Lio/reactivex/Single;)Lcom/squareup/workflow/legacy/Worker;
+	public static final fun singleWorker (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/legacy/Worker;
+}
+
+public final class com/squareup/workflow/legacy/rx2/WorkflowOperatorsKt {
+	public static final fun switchMapState (Lcom/squareup/workflow/legacy/Workflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/legacy/Workflow;
+	public static final fun toCompletable (Lcom/squareup/workflow/legacy/Workflow;)Lio/reactivex/Completable;
+}
+
+public final class com/squareup/workflow/legacy/rx2/WorkflowsKt {
+	public static final fun getResult (Lcom/squareup/workflow/legacy/Workflow;)Lio/reactivex/Maybe;
+	public static final fun getState (Lcom/squareup/workflow/legacy/Workflow;)Lio/reactivex/Observable;
+}
+

--- a/kotlin/legacy/legacy-workflow-test/api/legacy-workflow-test.api
+++ b/kotlin/legacy/legacy-workflow-test/api/legacy-workflow-test.api
@@ -1,0 +1,9 @@
+public final class com/squareup/workflow/legacy/test/Assertions {
+	public static final fun assertFinish (Lcom/squareup/workflow/legacy/rx2/Reactor;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public static final fun assertTransition (Lcom/squareup/workflow/legacy/rx2/Reactor;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/legacy/test/rx2/EventChannels {
+	public static final fun eventChannelOf ([Ljava/lang/Object;)Lcom/squareup/workflow/legacy/rx2/EventChannel;
+}
+

--- a/kotlin/trace-encoder/api/trace-encoder.api
+++ b/kotlin/trace-encoder/api/trace-encoder.api
@@ -1,0 +1,168 @@
+public final class com/squareup/tracing/TraceEncoder : java/io/Closeable {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/ClockMark;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/ClockMark;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun createLogger (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/tracing/TraceLogger;
+	public static synthetic fun createLogger$default (Lcom/squareup/tracing/TraceEncoder;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceLogger;
+}
+
+public abstract class com/squareup/tracing/TraceEvent {
+	public fun getCategory ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$AsyncDurationBegin : com/squareup/tracing/TraceEvent {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Lcom/squareup/tracing/TraceEvent$AsyncDurationBegin;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$AsyncDurationBegin;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$AsyncDurationBegin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/Map;
+	public fun getCategory ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/Object;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$AsyncDurationEnd : com/squareup/tracing/TraceEvent {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Lcom/squareup/tracing/TraceEvent$AsyncDurationEnd;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$AsyncDurationEnd;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$AsyncDurationEnd;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/Map;
+	public fun getCategory ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/Object;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$Counter : com/squareup/tracing/TraceEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/Long;)Lcom/squareup/tracing/TraceEvent$Counter;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$Counter;Ljava/lang/String;Ljava/util/Map;Ljava/lang/Long;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$Counter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/Long;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSeries ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$DurationBegin : com/squareup/tracing/TraceEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Lcom/squareup/tracing/TraceEvent$DurationBegin;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$DurationBegin;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$DurationBegin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/Map;
+	public fun getCategory ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$DurationEnd : com/squareup/tracing/TraceEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Lcom/squareup/tracing/TraceEvent$DurationEnd;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$DurationEnd;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$DurationEnd;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/Map;
+	public fun getCategory ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$Instant : com/squareup/tracing/TraceEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;Ljava/lang/String;)Lcom/squareup/tracing/TraceEvent$Instant;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$Instant;Ljava/lang/String;Ljava/util/Map;Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$Instant;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/Map;
+	public fun getCategory ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getScope ()Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$Instant$InstantScope : java/lang/Enum {
+	public static final field GLOBAL Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;
+	public static final field PROCESS Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;
+	public static final field THREAD Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;
+	public static fun valueOf (Ljava/lang/String;)Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;
+	public static fun values ()[Lcom/squareup/tracing/TraceEvent$Instant$InstantScope;
+}
+
+public final class com/squareup/tracing/TraceEvent$ObjectCreated : com/squareup/tracing/TraceEvent {
+	public fun <init> (JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lcom/squareup/tracing/TraceEvent$ObjectCreated;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$ObjectCreated;JLjava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$ObjectCreated;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getObjectType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$ObjectDestroyed : com/squareup/tracing/TraceEvent {
+	public fun <init> (JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lcom/squareup/tracing/TraceEvent$ObjectDestroyed;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$ObjectDestroyed;JLjava/lang/String;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$ObjectDestroyed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getObjectType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/tracing/TraceEvent$ObjectSnapshot : com/squareup/tracing/TraceEvent {
+	public fun <init> (JLjava/lang/String;Ljava/lang/Object;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun copy (JLjava/lang/String;Ljava/lang/Object;)Lcom/squareup/tracing/TraceEvent$ObjectSnapshot;
+	public static synthetic fun copy$default (Lcom/squareup/tracing/TraceEvent$ObjectSnapshot;JLjava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/tracing/TraceEvent$ObjectSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getSnapshot ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/squareup/tracing/TraceLogger {
+	public abstract fun log (Lcom/squareup/tracing/TraceEvent;)V
+	public abstract fun log (Ljava/util/List;)V
+}
+

--- a/kotlin/workflow-core/api/workflow-core.api
+++ b/kotlin/workflow-core/api/workflow-core.api
@@ -1,0 +1,231 @@
+public final class com/squareup/workflow/EventHandler : kotlin/jvm/functions/Function1 {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public synthetic fun invoke (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun invoke (Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/EventHandlerKt {
+	public static final fun invoke (Lcom/squareup/workflow/EventHandler;)V
+}
+
+public abstract class com/squareup/workflow/LifecycleWorker : com/squareup/workflow/Worker {
+	public fun <init> ()V
+	public fun doesSameWorkAs (Lcom/squareup/workflow/Worker;)Z
+	public fun onStarted ()V
+	public fun onStopped ()V
+	public final fun run ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/squareup/workflow/RenderContext {
+	public abstract fun getActionSink ()Lcom/squareup/workflow/Sink;
+	public abstract fun makeActionSink ()Lcom/squareup/workflow/Sink;
+	public abstract fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public abstract fun renderChild (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public abstract fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/squareup/workflow/RenderContext$DefaultImpls {
+	public static fun makeActionSink (Lcom/squareup/workflow/RenderContext;)Lcom/squareup/workflow/Sink;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun runningWorker$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/RenderContextKt {
+	public static final fun makeEventSink (Lcom/squareup/workflow/RenderContext;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/Sink;
+	public static final fun onWorkerOutput (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun onWorkerOutput$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun renderChild (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun renderChild (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun renderChild (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun renderChild$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Workflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun runningWorker (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Worker;Ljava/lang/String;)V
+	public static synthetic fun runningWorker$default (Lcom/squareup/workflow/RenderContext;Lcom/squareup/workflow/Worker;Ljava/lang/String;ILjava/lang/Object;)V
+}
+
+public abstract interface class com/squareup/workflow/Sink {
+	public abstract fun send (Ljava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/SinkKt {
+	public static final fun contraMap (Lcom/squareup/workflow/Sink;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Sink;
+}
+
+public final class com/squareup/workflow/Snapshot {
+	public static final field Companion Lcom/squareup/workflow/Snapshot$Companion;
+	public static final field EMPTY Lcom/squareup/workflow/Snapshot;
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun bytes ()Lokio/ByteString;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public static final fun of (I)Lcom/squareup/workflow/Snapshot;
+	public static final fun of (Ljava/lang/String;)Lcom/squareup/workflow/Snapshot;
+	public static final fun of (Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/Snapshot;
+	public static final fun of (Lokio/ByteString;)Lcom/squareup/workflow/Snapshot;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Snapshot;
+}
+
+public final class com/squareup/workflow/Snapshot$Companion {
+	public final fun of (I)Lcom/squareup/workflow/Snapshot;
+	public final fun of (Ljava/lang/String;)Lcom/squareup/workflow/Snapshot;
+	public final fun of (Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/Snapshot;
+	public final fun of (Lokio/ByteString;)Lcom/squareup/workflow/Snapshot;
+	public final fun write (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Snapshot;
+}
+
+public final class com/squareup/workflow/SnapshotKt {
+	public static final fun parse (Lokio/ByteString;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun readBooleanFromInt (Lokio/BufferedSource;)Z
+	public static final fun readByteStringWithLength (Lokio/BufferedSource;)Lokio/ByteString;
+	public static final synthetic fun readEnumByOrdinal (Lokio/BufferedSource;)Ljava/lang/Enum;
+	public static final fun readFloat (Lokio/BufferedSource;)F
+	public static final fun readList (Lokio/BufferedSource;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static final fun readNullable (Lokio/BufferedSource;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final synthetic fun readOptionalEnumByOrdinal (Lokio/BufferedSource;)Ljava/lang/Enum;
+	public static final fun readOptionalUtf8WithLength (Lokio/BufferedSource;)Ljava/lang/String;
+	public static final fun readUtf8WithLength (Lokio/BufferedSource;)Ljava/lang/String;
+	public static final fun writeBooleanAsInt (Lokio/BufferedSink;Z)Lokio/BufferedSink;
+	public static final fun writeByteStringWithLength (Lokio/BufferedSink;Lokio/ByteString;)Lokio/BufferedSink;
+	public static final fun writeEnumByOrdinal (Lokio/BufferedSink;Ljava/lang/Enum;)Lokio/BufferedSink;
+	public static final fun writeFloat (Lokio/BufferedSink;F)Lokio/BufferedSink;
+	public static final fun writeList (Lokio/BufferedSink;Ljava/util/List;Lkotlin/jvm/functions/Function2;)Lokio/BufferedSink;
+	public static final fun writeNullable (Lokio/BufferedSink;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lokio/BufferedSink;
+	public static final fun writeOptionalEnumByOrdinal (Lokio/BufferedSink;Ljava/lang/Enum;)Lokio/BufferedSink;
+	public static final fun writeOptionalUtf8WithLength (Lokio/BufferedSink;Ljava/lang/String;)Lokio/BufferedSink;
+	public static final fun writeUtf8WithLength (Lokio/BufferedSink;Ljava/lang/String;)Lokio/BufferedSink;
+}
+
+public abstract class com/squareup/workflow/StatefulWorkflow : com/squareup/workflow/Workflow {
+	public fun <init> ()V
+	public final fun asStatefulWorkflow ()Lcom/squareup/workflow/StatefulWorkflow;
+	public abstract fun initialState (Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;)Ljava/lang/Object;
+	public fun onPropsChanged (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun render (Ljava/lang/Object;Ljava/lang/Object;Lcom/squareup/workflow/RenderContext;)Ljava/lang/Object;
+	public abstract fun snapshotState (Ljava/lang/Object;)Lcom/squareup/workflow/Snapshot;
+}
+
+public final class com/squareup/workflow/StatefulWorkflowKt {
+	public static final fun action (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static final fun action (Lcom/squareup/workflow/StatefulWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static synthetic fun action$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public static final fun stateful (Lcom/squareup/workflow/Workflow$Companion;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/StatefulWorkflow;
+	public static final fun stateful (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/StatefulWorkflow;
+	public static final fun stateful (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow/StatefulWorkflow;
+	public static final fun stateful (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)Lcom/squareup/workflow/StatefulWorkflow;
+	public static synthetic fun stateful$default (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/squareup/workflow/StatefulWorkflow;
+	public static synthetic fun stateful$default (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/squareup/workflow/StatefulWorkflow;
+	public static final fun workflowAction (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static final fun workflowAction (Lcom/squareup/workflow/StatefulWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static synthetic fun workflowAction$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+}
+
+public abstract class com/squareup/workflow/StatelessWorkflow : com/squareup/workflow/Workflow {
+	public fun <init> ()V
+	public final fun asStatefulWorkflow ()Lcom/squareup/workflow/StatefulWorkflow;
+	public abstract fun render (Ljava/lang/Object;Lcom/squareup/workflow/RenderContext;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/StatelessWorkflowKt {
+	public static final fun action (Lcom/squareup/workflow/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static final fun action (Lcom/squareup/workflow/StatelessWorkflow;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static synthetic fun action$default (Lcom/squareup/workflow/StatelessWorkflow;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public static final fun mapRendering (Lcom/squareup/workflow/Workflow;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Workflow;
+	public static final fun rendering (Lcom/squareup/workflow/Workflow$Companion;Ljava/lang/Object;)Lcom/squareup/workflow/Workflow;
+	public static final fun stateless (Lcom/squareup/workflow/Workflow$Companion;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/Workflow;
+}
+
+public final class com/squareup/workflow/TypedWorker : com/squareup/workflow/Worker {
+	public fun <init> (Lkotlin/reflect/KType;Lkotlinx/coroutines/flow/Flow;)V
+	public fun doesSameWorkAs (Lcom/squareup/workflow/Worker;)Z
+	public fun run ()Lkotlinx/coroutines/flow/Flow;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface annotation class com/squareup/workflow/VeryExperimentalWorkflow : java/lang/annotation/Annotation {
+}
+
+public abstract interface class com/squareup/workflow/Worker {
+	public static final field Companion Lcom/squareup/workflow/Worker$Companion;
+	public abstract fun doesSameWorkAs (Lcom/squareup/workflow/Worker;)Z
+	public abstract fun run ()Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/squareup/workflow/Worker$Companion {
+	public final synthetic fun create (Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/Worker;
+	public final fun createSideEffect (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
+	public final fun finished ()Lcom/squareup/workflow/Worker;
+	public final synthetic fun from (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
+	public final synthetic fun fromNullable (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
+	public final fun timer (JLjava/lang/String;)Lcom/squareup/workflow/Worker;
+	public static synthetic fun timer$default (Lcom/squareup/workflow/Worker$Companion;JLjava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/Worker;
+}
+
+public final class com/squareup/workflow/Worker$DefaultImpls {
+	public static fun doesSameWorkAs (Lcom/squareup/workflow/Worker;Lcom/squareup/workflow/Worker;)Z
+}
+
+public final class com/squareup/workflow/WorkerKt {
+	public static final synthetic fun asWorker (Lkotlinx/coroutines/Deferred;)Lcom/squareup/workflow/Worker;
+	public static final synthetic fun asWorker (Lkotlinx/coroutines/channels/BroadcastChannel;)Lcom/squareup/workflow/Worker;
+	public static final synthetic fun asWorker (Lkotlinx/coroutines/channels/ReceiveChannel;Z)Lcom/squareup/workflow/Worker;
+	public static final synthetic fun asWorker (Lkotlinx/coroutines/flow/Flow;)Lcom/squareup/workflow/Worker;
+	public static synthetic fun asWorker$default (Lkotlinx/coroutines/channels/ReceiveChannel;ZILjava/lang/Object;)Lcom/squareup/workflow/Worker;
+	public static final fun transform (Lcom/squareup/workflow/Worker;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
+}
+
+public abstract interface class com/squareup/workflow/Workflow {
+	public static final field Companion Lcom/squareup/workflow/Workflow$Companion;
+	public abstract fun asStatefulWorkflow ()Lcom/squareup/workflow/StatefulWorkflow;
+}
+
+public final class com/squareup/workflow/Workflow$Companion {
+}
+
+public abstract interface class com/squareup/workflow/WorkflowAction {
+	public static final field Companion Lcom/squareup/workflow/WorkflowAction$Companion;
+	public abstract fun apply (Lcom/squareup/workflow/WorkflowAction$Mutator;)Ljava/lang/Object;
+	public abstract fun apply (Lcom/squareup/workflow/WorkflowAction$Updater;)V
+}
+
+public final class com/squareup/workflow/WorkflowAction$Companion {
+	public final fun emitOutput (Ljava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public final fun emitOutput (Ljava/lang/String;Ljava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public final fun enterState (Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public final fun enterState (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public static synthetic fun enterState$default (Lcom/squareup/workflow/WorkflowAction$Companion;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public static synthetic fun enterState$default (Lcom/squareup/workflow/WorkflowAction$Companion;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public final fun modifyState (Lkotlin/jvm/functions/Function0;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static synthetic fun modifyState$default (Lcom/squareup/workflow/WorkflowAction$Companion;Lkotlin/jvm/functions/Function0;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public final fun noAction ()Lcom/squareup/workflow/WorkflowAction;
+}
+
+public final class com/squareup/workflow/WorkflowAction$DefaultImpls {
+	public static fun apply (Lcom/squareup/workflow/WorkflowAction;Lcom/squareup/workflow/WorkflowAction$Mutator;)Ljava/lang/Object;
+	public static fun apply (Lcom/squareup/workflow/WorkflowAction;Lcom/squareup/workflow/WorkflowAction$Updater;)V
+}
+
+public final class com/squareup/workflow/WorkflowAction$Mutator {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getState ()Ljava/lang/Object;
+	public final fun setState (Ljava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/WorkflowAction$Updater {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getNextState ()Ljava/lang/Object;
+	public final fun setNextState (Ljava/lang/Object;)V
+	public final fun setOutput (Ljava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/WorkflowActionKt {
+	public static final fun action (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static final fun action (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/WorkflowAction;
+	public static synthetic fun action$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/WorkflowAction;
+	public static final fun applyTo (Lcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;)Lkotlin/Pair;
+}
+

--- a/kotlin/workflow-runtime/api/workflow-runtime.api
+++ b/kotlin/workflow-runtime/api/workflow-runtime.api
@@ -1,0 +1,326 @@
+public final class com/squareup/workflow/LaunchWorkflowKt {
+	public static final fun launchWorkflowIn (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public static synthetic fun launchWorkflowIn$default (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/Snapshot;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/RenderingAndSnapshot {
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/squareup/workflow/Snapshot;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;)Lcom/squareup/workflow/RenderingAndSnapshot;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/RenderingAndSnapshot;Ljava/lang/Object;Lcom/squareup/workflow/Snapshot;ILjava/lang/Object;)Lcom/squareup/workflow/RenderingAndSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRendering ()Ljava/lang/Object;
+	public final fun getSnapshot ()Lcom/squareup/workflow/Snapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/WorkflowSession {
+	public fun <init> (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDiagnosticListener ()Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;
+	public final fun getOutputs ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getRenderingsAndSnapshots ()Lkotlinx/coroutines/flow/Flow;
+	public final fun setDiagnosticListener (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)V
+}
+
+public final class com/squareup/workflow/diagnostic/ChainedDiagnosticListenerKt {
+	public static final fun andThen (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;
+}
+
+public final class com/squareup/workflow/diagnostic/DebugSnapshotRecordingListener : com/squareup/workflow/diagnostic/WorkflowDiagnosticListener {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public fun onAfterRenderPass (Ljava/lang/Object;)V
+	public fun onAfterSnapshotPass ()V
+	public fun onAfterWorkflowRendered (JLjava/lang/Object;)V
+	public fun onBeforeRenderPass (Ljava/lang/Object;)V
+	public fun onBeforeSnapshotPass ()V
+	public fun onBeforeWorkflowRendered (JLjava/lang/Object;Ljava/lang/Object;)V
+	public fun onPropsChanged (Ljava/lang/Long;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun onRuntimeStarted (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)V
+	public fun onRuntimeStopped ()V
+	public fun onSinkReceived (JLcom/squareup/workflow/WorkflowAction;)V
+	public fun onWorkerOutput (JJLjava/lang/Object;)V
+	public fun onWorkerStarted (JJLjava/lang/String;Ljava/lang/String;)V
+	public fun onWorkerStopped (JJ)V
+	public fun onWorkflowAction (JLcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun onWorkflowStarted (JLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)V
+	public fun onWorkflowStopped (J)V
+}
+
+public class com/squareup/workflow/diagnostic/SimpleLoggingDiagnosticListener : com/squareup/workflow/diagnostic/WorkflowDiagnosticListener {
+	public fun <init> ()V
+	public fun onAfterRenderPass (Ljava/lang/Object;)V
+	public fun onAfterSnapshotPass ()V
+	public fun onAfterWorkflowRendered (JLjava/lang/Object;)V
+	public fun onBeforeRenderPass (Ljava/lang/Object;)V
+	public fun onBeforeSnapshotPass ()V
+	public fun onBeforeWorkflowRendered (JLjava/lang/Object;Ljava/lang/Object;)V
+	public fun onPropsChanged (Ljava/lang/Long;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun onRuntimeStarted (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)V
+	public fun onRuntimeStopped ()V
+	public fun onSinkReceived (JLcom/squareup/workflow/WorkflowAction;)V
+	public fun onWorkerOutput (JJLjava/lang/Object;)V
+	public fun onWorkerStarted (JJLjava/lang/String;Ljava/lang/String;)V
+	public fun onWorkerStopped (JJ)V
+	public fun onWorkflowAction (JLcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun onWorkflowStarted (JLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)V
+	public fun onWorkflowStopped (J)V
+	protected fun println (Ljava/lang/String;)V
+}
+
+public abstract interface class com/squareup/workflow/diagnostic/WorkflowDiagnosticListener {
+	public abstract fun onAfterRenderPass (Ljava/lang/Object;)V
+	public abstract fun onAfterSnapshotPass ()V
+	public abstract fun onAfterWorkflowRendered (JLjava/lang/Object;)V
+	public abstract fun onBeforeRenderPass (Ljava/lang/Object;)V
+	public abstract fun onBeforeSnapshotPass ()V
+	public abstract fun onBeforeWorkflowRendered (JLjava/lang/Object;Ljava/lang/Object;)V
+	public abstract fun onPropsChanged (Ljava/lang/Long;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public abstract fun onRuntimeStarted (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)V
+	public abstract fun onRuntimeStopped ()V
+	public abstract fun onSinkReceived (JLcom/squareup/workflow/WorkflowAction;)V
+	public abstract fun onWorkerOutput (JJLjava/lang/Object;)V
+	public abstract fun onWorkerStarted (JJLjava/lang/String;Ljava/lang/String;)V
+	public abstract fun onWorkerStopped (JJ)V
+	public abstract fun onWorkflowAction (JLcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public abstract fun onWorkflowStarted (JLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)V
+	public abstract fun onWorkflowStopped (J)V
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowDiagnosticListener$DefaultImpls {
+	public static fun onAfterRenderPass (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Ljava/lang/Object;)V
+	public static fun onAfterSnapshotPass (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)V
+	public static fun onAfterWorkflowRendered (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JLjava/lang/Object;)V
+	public static fun onBeforeRenderPass (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Ljava/lang/Object;)V
+	public static fun onBeforeSnapshotPass (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)V
+	public static fun onBeforeWorkflowRendered (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JLjava/lang/Object;Ljava/lang/Object;)V
+	public static fun onPropsChanged (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Ljava/lang/Long;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public static fun onRuntimeStarted (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)V
+	public static fun onRuntimeStopped (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)V
+	public static fun onSinkReceived (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JLcom/squareup/workflow/WorkflowAction;)V
+	public static fun onWorkerOutput (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JJLjava/lang/Object;)V
+	public static fun onWorkerStarted (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JJLjava/lang/String;Ljava/lang/String;)V
+	public static fun onWorkerStopped (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JJ)V
+	public static fun onWorkflowAction (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JLcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public static fun onWorkflowStarted (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;JLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)V
+	public static fun onWorkflowStopped (Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;J)V
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun component4 ()Ljava/lang/Object;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/List;Ljava/util/List;)Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getProps ()Ljava/lang/Object;
+	public final fun getRendering ()Ljava/lang/Object;
+	public final fun getState ()Ljava/lang/Object;
+	public final fun getWorkers ()Ljava/util/List;
+	public final fun getWorkflowType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toDescriptionString ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorker {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorker;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorker;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorker;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorkflow {
+	public fun <init> (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;
+	public final fun copy (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;)Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorkflow;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorkflow;Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot$ChildWorkflow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getSnapshot ()Lcom/squareup/workflow/diagnostic/WorkflowHierarchyDebugSnapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo {
+	public fun <init> (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind;
+	public final fun copy (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind;
+	public final fun getWorkflowType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toDescriptionString ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind {
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Passthrough : com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind {
+	public fun <init> (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;
+	public final fun copy (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Passthrough;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Passthrough;Ljava/lang/String;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Passthrough;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildInfo ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;
+	public final fun getKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Updated : com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind {
+	public fun <init> (Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source;)V
+	public final fun component1 ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source;
+	public final fun copy (Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Updated;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Updated;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Kind$Updated;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSource ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source {
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Sink : com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source {
+	public static final field INSTANCE Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Sink;
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Subtree : com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Subtree;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Subtree;Ljava/lang/String;Ljava/lang/Object;Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Subtree;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildInfo ()Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getOutput ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Worker : com/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Worker;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Worker;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/WorkflowUpdateDebugInfo$Source$Worker;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getOutput ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/internal/RealRenderContext : com/squareup/workflow/RenderContext, com/squareup/workflow/Sink {
+	public fun <init> (Lcom/squareup/workflow/internal/RealRenderContext$Renderer;Lcom/squareup/workflow/internal/RealRenderContext$WorkerRunner;Lkotlinx/coroutines/channels/SendChannel;)V
+	public final fun freeze ()V
+	public fun getActionSink ()Lcom/squareup/workflow/Sink;
+	public fun makeActionSink ()Lcom/squareup/workflow/Sink;
+	public fun onEvent (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/EventHandler;
+	public synthetic fun onEvent (Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+	public fun renderChild (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun send (Lcom/squareup/workflow/WorkflowAction;)V
+	public synthetic fun send (Ljava/lang/Object;)V
+}
+
+public abstract interface class com/squareup/workflow/internal/RealRenderContext$Renderer {
+	public abstract fun render (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract interface class com/squareup/workflow/internal/RealRenderContext$WorkerRunner {
+	public abstract fun runningWorker (Lcom/squareup/workflow/Worker;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/squareup/workflow/internal/WorkflowId {
+	public fun <init> (Lcom/squareup/workflow/Workflow;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/squareup/workflow/Workflow;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/reflect/KClass;Ljava/lang/String;)V
+	public final fun copy (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/squareup/workflow/internal/WorkflowId;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/internal/WorkflowId;Lkotlin/reflect/KClass;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/internal/WorkflowId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTypeDebugString ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/testing/LaunchWorkflowKt {
+	public static final fun launchWorkflowForTestFromStateIn (Lkotlinx/coroutines/CoroutineScope;Lcom/squareup/workflow/StatefulWorkflow;Lkotlinx/coroutines/flow/Flow;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/testing/WorkflowTestParams {
+	public fun <init> ()V
+	public fun <init> (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;Z)V
+	public synthetic fun <init> (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;
+	public final fun component2 ()Z
+	public final fun copy (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;Z)Lcom/squareup/workflow/testing/WorkflowTestParams;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams;Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;ZILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCheckRenderIdempotence ()Z
+	public final fun getStartFrom ()Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/squareup/workflow/testing/WorkflowTestParams$StartMode {
+}
+
+public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFresh : com/squareup/workflow/testing/WorkflowTestParams$StartMode {
+	public static final field INSTANCE Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFresh;
+}
+
+public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot : com/squareup/workflow/testing/WorkflowTestParams$StartMode {
+	public fun <init> (Lcom/squareup/workflow/Snapshot;)V
+	public final fun component1 ()Lcom/squareup/workflow/Snapshot;
+	public final fun copy (Lcom/squareup/workflow/Snapshot;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot;Lcom/squareup/workflow/Snapshot;ILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromCompleteSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSnapshot ()Lcom/squareup/workflow/Snapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState : com/squareup/workflow/testing/WorkflowTestParams$StartMode {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot : com/squareup/workflow/testing/WorkflowTestParams$StartMode {
+	public fun <init> (Lcom/squareup/workflow/Snapshot;)V
+	public final fun component1 ()Lcom/squareup/workflow/Snapshot;
+	public final fun copy (Lcom/squareup/workflow/Snapshot;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot;Lcom/squareup/workflow/Snapshot;ILjava/lang/Object;)Lcom/squareup/workflow/testing/WorkflowTestParams$StartMode$StartFromWorkflowSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSnapshot ()Lcom/squareup/workflow/Snapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/kotlin/workflow-rx2/api/workflow-rx2.api
+++ b/kotlin/workflow-rx2/api/workflow-rx2.api
@@ -1,0 +1,15 @@
+public abstract class com/squareup/workflow/rx2/PublisherWorker : com/squareup/workflow/Worker {
+	public fun <init> ()V
+	public fun doesSameWorkAs (Lcom/squareup/workflow/Worker;)Z
+	public final fun run ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun runPublisher ()Lorg/reactivestreams/Publisher;
+}
+
+public final class com/squareup/workflow/rx2/RxWorkersKt {
+	public static final fun asWorker (Lio/reactivex/Completable;)Lcom/squareup/workflow/Worker;
+	public static final synthetic fun asWorker (Lio/reactivex/Maybe;)Lcom/squareup/workflow/Worker;
+	public static final synthetic fun asWorker (Lio/reactivex/Observable;)Lcom/squareup/workflow/Worker;
+	public static final synthetic fun asWorker (Lio/reactivex/Single;)Lcom/squareup/workflow/Worker;
+	public static final synthetic fun asWorker (Lorg/reactivestreams/Publisher;)Lcom/squareup/workflow/Worker;
+}
+

--- a/kotlin/workflow-testing/api/workflow-testing.api
+++ b/kotlin/workflow-testing/api/workflow-testing.api
@@ -1,0 +1,92 @@
+public final class com/squareup/workflow/testing/EmittedOutput {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/squareup/workflow/testing/EmittedOutput;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/testing/EmittedOutput;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/testing/EmittedOutput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOutput ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/squareup/workflow/testing/RenderTestResult {
+	public abstract fun verifyAction (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun verifyActionResult (Lkotlin/jvm/functions/Function2;)V
+}
+
+public abstract interface class com/squareup/workflow/testing/RenderTester {
+	public abstract fun expectWorker (Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/testing/EmittedOutput;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun expectWorkflow (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/testing/EmittedOutput;)Lcom/squareup/workflow/testing/RenderTester;
+	public abstract fun render (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/testing/RenderTestResult;
+}
+
+public final class com/squareup/workflow/testing/RenderTester$DefaultImpls {
+	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/jvm/functions/Function1;Ljava/lang/String;Lcom/squareup/workflow/testing/EmittedOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorkflow$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lcom/squareup/workflow/testing/EmittedOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun render$default (Lcom/squareup/workflow/testing/RenderTester;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTestResult;
+}
+
+public final class com/squareup/workflow/testing/RenderTesterKt {
+	public static final fun expectWorker (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/testing/EmittedOutput;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/testing/EmittedOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun renderTester (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun renderTester (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+}
+
+public final class com/squareup/workflow/testing/WorkerSink : com/squareup/workflow/Worker {
+	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;)V
+	public fun doesSameWorkAs (Lcom/squareup/workflow/Worker;)Z
+	public fun run ()Lkotlinx/coroutines/flow/Flow;
+	public final fun send (Ljava/lang/Object;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/testing/WorkerSinkKt {
+	public static final synthetic fun WorkerSink (Ljava/lang/String;)Lcom/squareup/workflow/testing/WorkerSink;
+}
+
+public abstract interface class com/squareup/workflow/testing/WorkerTester {
+	public abstract fun assertFinished (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun assertNoOutput ()V
+	public abstract fun assertNotFinished ()V
+	public abstract fun cancelWorker (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getException (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun nextOutput (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/testing/WorkerTesterKt {
+	public static final fun test (Lcom/squareup/workflow/Worker;JLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun test$default (Lcom/squareup/workflow/Worker;JLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/testing/WorkflowTester {
+	public static final field Companion Lcom/squareup/workflow/testing/WorkflowTester$Companion;
+	public static final field DEFAULT_TIMEOUT_MS J
+	public final fun awaitNextOutput (Ljava/lang/Long;)Ljava/lang/Object;
+	public static synthetic fun awaitNextOutput$default (Lcom/squareup/workflow/testing/WorkflowTester;Ljava/lang/Long;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun awaitNextRendering (Ljava/lang/Long;Z)Ljava/lang/Object;
+	public static synthetic fun awaitNextRendering$default (Lcom/squareup/workflow/testing/WorkflowTester;Ljava/lang/Long;ZILjava/lang/Object;)Ljava/lang/Object;
+	public final fun awaitNextSnapshot (Ljava/lang/Long;Z)Lcom/squareup/workflow/Snapshot;
+	public static synthetic fun awaitNextSnapshot$default (Lcom/squareup/workflow/testing/WorkflowTester;Ljava/lang/Long;ZILjava/lang/Object;)Lcom/squareup/workflow/Snapshot;
+	public final fun getHasOutput ()Z
+	public final fun getHasRendering ()Z
+	public final fun getHasSnapshot ()Z
+	public final fun sendProps (Ljava/lang/Object;)V
+}
+
+public final class com/squareup/workflow/testing/WorkflowTester$Companion {
+}
+
+public final class com/squareup/workflow/testing/WorkflowTesterKt {
+	public static final fun test (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun test$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun testFromStart (Lcom/squareup/workflow/Workflow;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun testFromStart (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun testFromStart$default (Lcom/squareup/workflow/Workflow;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun testFromStart$default (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Lcom/squareup/workflow/testing/WorkflowTestParams;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun testFromState (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun testFromState (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun testFromState$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun testFromState$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+

--- a/kotlin/workflow-tracing/api/workflow-tracing.api
+++ b/kotlin/workflow-tracing/api/workflow-tracing.api
@@ -1,0 +1,39 @@
+public abstract interface class com/squareup/workflow/diagnostic/tracing/MemoryStats {
+	public abstract fun freeMemory ()J
+	public abstract fun totalMemory ()J
+}
+
+public final class com/squareup/workflow/diagnostic/tracing/RuntimeMemoryStats : com/squareup/workflow/diagnostic/tracing/MemoryStats {
+	public static final field INSTANCE Lcom/squareup/workflow/diagnostic/tracing/RuntimeMemoryStats;
+	public fun freeMemory ()J
+	public fun totalMemory ()J
+}
+
+public final class com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListener : com/squareup/workflow/diagnostic/WorkflowDiagnosticListener {
+	public fun <init> (Lcom/squareup/workflow/diagnostic/tracing/MemoryStats;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lcom/squareup/workflow/diagnostic/tracing/MemoryStats;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun onAfterRenderPass (Ljava/lang/Object;)V
+	public fun onAfterSnapshotPass ()V
+	public fun onAfterWorkflowRendered (JLjava/lang/Object;)V
+	public fun onBeforeRenderPass (Ljava/lang/Object;)V
+	public fun onBeforeSnapshotPass ()V
+	public fun onBeforeWorkflowRendered (JLjava/lang/Object;Ljava/lang/Object;)V
+	public fun onPropsChanged (Ljava/lang/Long;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun onRuntimeStarted (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/String;)V
+	public fun onRuntimeStopped ()V
+	public fun onSinkReceived (JLcom/squareup/workflow/WorkflowAction;)V
+	public fun onWorkerOutput (JJLjava/lang/Object;)V
+	public fun onWorkerStarted (JJLjava/lang/String;Ljava/lang/String;)V
+	public fun onWorkerStopped (JJ)V
+	public fun onWorkflowAction (JLcom/squareup/workflow/WorkflowAction;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun onWorkflowStarted (JLjava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Z)V
+	public fun onWorkflowStopped (J)V
+}
+
+public final class com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListenerKt {
+	public static final fun TracingDiagnosticListener (Ljava/io/File;Ljava/lang/String;)Lcom/squareup/workflow/diagnostic/tracing/TracingDiagnosticListener;
+	public static final fun TracingDiagnosticListener (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/tracing/MemoryStats;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/diagnostic/tracing/TracingDiagnosticListener;
+	public static synthetic fun TracingDiagnosticListener$default (Ljava/io/File;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/tracing/TracingDiagnosticListener;
+	public static synthetic fun TracingDiagnosticListener$default (Ljava/lang/String;Lcom/squareup/workflow/diagnostic/tracing/MemoryStats;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/diagnostic/tracing/TracingDiagnosticListener;
+}
+

--- a/kotlin/workflow-ui/backstack-common/api/backstack-common.api
+++ b/kotlin/workflow-ui/backstack-common/api/backstack-common.api
@@ -1,0 +1,20 @@
+public final class com/squareup/workflow/ui/backstack/BackStackScreen {
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/Object;[Ljava/lang/Object;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (I)Ljava/lang/Object;
+	public final fun getBackStack ()Ljava/util/List;
+	public final fun getFrames ()Ljava/util/List;
+	public final fun getTop ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun map (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/ui/backstack/BackStackScreen;
+	public final fun mapIndexed (Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/ui/backstack/BackStackScreen;
+	public final fun plus (Lcom/squareup/workflow/ui/backstack/BackStackScreen;)Lcom/squareup/workflow/ui/backstack/BackStackScreen;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/ui/backstack/BackStackScreenKt {
+	public static final fun toBackStackScreen (Ljava/util/List;)Lcom/squareup/workflow/ui/backstack/BackStackScreen;
+	public static final fun toBackStackScreenOrNull (Ljava/util/List;)Lcom/squareup/workflow/ui/backstack/BackStackScreen;
+}
+

--- a/kotlin/workflow-ui/core-common/api/core-common.api
+++ b/kotlin/workflow-ui/core-common/api/core-common.api
@@ -1,0 +1,29 @@
+public abstract interface class com/squareup/workflow/ui/Compatible {
+	public abstract fun getCompatibilityKey ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/ui/CompatibleKt {
+	public static final fun compatible (Ljava/lang/Object;Ljava/lang/Object;)Z
+	public static final fun goTo (Ljava/util/List;Ljava/lang/Object;)Ljava/util/List;
+}
+
+public final class com/squareup/workflow/ui/Named : com/squareup/workflow/ui/Compatible {
+	public static final field Companion Lcom/squareup/workflow/ui/Named$Companion;
+	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/String;)Lcom/squareup/workflow/ui/Named;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/Named;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/ui/Named;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCompatibilityKey ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getWrapped ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/ui/Named$Companion {
+	public final fun keyFor (Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun keyFor$default (Lcom/squareup/workflow/ui/Named$Companion;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+}
+

--- a/kotlin/workflow-ui/modal-common/api/modal-common.api
+++ b/kotlin/workflow-ui/modal-common/api/modal-common.api
@@ -1,0 +1,67 @@
+public final class com/squareup/workflow/ui/modal/AlertContainerScreen : com/squareup/workflow/ui/modal/HasModals {
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/modal/AlertScreen;)V
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Object;[Lcom/squareup/workflow/ui/modal/AlertScreen;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Object;Ljava/util/List;)Lcom/squareup/workflow/ui/modal/AlertContainerScreen;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/modal/AlertContainerScreen;Ljava/lang/Object;Ljava/util/List;ILjava/lang/Object;)Lcom/squareup/workflow/ui/modal/AlertContainerScreen;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBeneathModals ()Ljava/lang/Object;
+	public fun getModals ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/ui/modal/AlertScreen {
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/ui/modal/AlertScreen;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/modal/AlertScreen;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/squareup/workflow/ui/modal/AlertScreen;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getButtons ()Ljava/util/Map;
+	public final fun getCancelable ()Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getOnEvent ()Lkotlin/jvm/functions/Function1;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/ui/modal/AlertScreen$Button : java/lang/Enum {
+	public static final field NEGATIVE Lcom/squareup/workflow/ui/modal/AlertScreen$Button;
+	public static final field NEUTRAL Lcom/squareup/workflow/ui/modal/AlertScreen$Button;
+	public static final field POSITIVE Lcom/squareup/workflow/ui/modal/AlertScreen$Button;
+	public static fun valueOf (Ljava/lang/String;)Lcom/squareup/workflow/ui/modal/AlertScreen$Button;
+	public static fun values ()[Lcom/squareup/workflow/ui/modal/AlertScreen$Button;
+}
+
+public abstract class com/squareup/workflow/ui/modal/AlertScreen$Event {
+}
+
+public final class com/squareup/workflow/ui/modal/AlertScreen$Event$ButtonClicked : com/squareup/workflow/ui/modal/AlertScreen$Event {
+	public fun <init> (Lcom/squareup/workflow/ui/modal/AlertScreen$Button;)V
+	public final fun component1 ()Lcom/squareup/workflow/ui/modal/AlertScreen$Button;
+	public final fun copy (Lcom/squareup/workflow/ui/modal/AlertScreen$Button;)Lcom/squareup/workflow/ui/modal/AlertScreen$Event$ButtonClicked;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/modal/AlertScreen$Event$ButtonClicked;Lcom/squareup/workflow/ui/modal/AlertScreen$Button;ILjava/lang/Object;)Lcom/squareup/workflow/ui/modal/AlertScreen$Event$ButtonClicked;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getButton ()Lcom/squareup/workflow/ui/modal/AlertScreen$Button;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/ui/modal/AlertScreen$Event$Canceled : com/squareup/workflow/ui/modal/AlertScreen$Event {
+	public static final field INSTANCE Lcom/squareup/workflow/ui/modal/AlertScreen$Event$Canceled;
+}
+
+public abstract interface class com/squareup/workflow/ui/modal/HasModals {
+	public abstract fun getBeneathModals ()Ljava/lang/Object;
+	public abstract fun getModals ()Ljava/util/List;
+}
+


### PR DESCRIPTION
Ignores all leaf sample projects individually, wildcards are not supported (see https://github.com/Kotlin/binary-compatibility-validator/issues/3).

Closes #243.