### PR TITLE
Plumb workerContext to child workflows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Change Log
 
 ### Kotlin
 
- * Make the context used to start workers configurable for tests. (#940, #943)
+ * Make the context used to start workers configurable for tests. (#940, #943, #950)
 
 ### Swift
 

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/SubtreeManager.kt
@@ -23,6 +23,7 @@ import com.squareup.workflow.diagnostic.WorkflowDiagnosticListener
 import kotlinx.coroutines.selects.SelectBuilder
 import okio.ByteString
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Responsible for tracking child workflows, starting them and tearing them down when necessary.
@@ -95,7 +96,8 @@ internal class SubtreeManager<StateT, OutputT : Any>(
   private val emitActionToParent: (WorkflowAction<StateT, OutputT>) -> Any?,
   private val parentDiagnosticId: Long,
   private val diagnosticListener: WorkflowDiagnosticListener? = null,
-  private val idCounter: IdCounter? = null
+  private val idCounter: IdCounter? = null,
+  private val workerContext: CoroutineContext = EmptyCoroutineContext
 ) : RealRenderContext.Renderer<StateT, OutputT> {
 
   /**
@@ -197,7 +199,8 @@ internal class SubtreeManager<StateT, OutputT : Any>(
         ::acceptChildOutput,
         parentDiagnosticId,
         diagnosticListener,
-        idCounter
+        idCounter,
+        workerContext = workerContext
     )
     return WorkflowChildNode(child, handler, workflowNode)
         .also { node = it }

--- a/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
+++ b/kotlin/workflow-runtime/src/main/java/com/squareup/workflow/internal/WorkflowNode.kt
@@ -78,7 +78,7 @@ internal class WorkflowNode<PropsT, StateT, OutputT : Any, RenderingT>(
   internal val diagnosticId = idCounter.createId()
 
   private val subtreeManager = SubtreeManager<StateT, OutputT>(
-      coroutineContext, ::applyAction, diagnosticId, diagnosticListener, idCounter
+      coroutineContext, ::applyAction, diagnosticId, diagnosticListener, idCounter, workerContext
   )
 
   private val workers = ActiveStagingList<WorkerChildNode<*, *, *>>()


### PR DESCRIPTION
PRs #940 and #943 have a bug where the worker context isn't passed from a parent workflow
to child `WorkflowNode`s. This fixes that.