### PR TITLE
[WIP][DNR] Add `key` to Screen

### DIFF
--- a/swift/Samples/BackStackContainer/Sources/BackStackScreen.swift
+++ b/swift/Samples/BackStackContainer/Sources/BackStackScreen.swift
@@ -27,45 +27,21 @@ public struct BackStackScreen: Screen {
 extension BackStackScreen {
     /// A specific item in the back stack. The key and screen type is used to differentiate reused vs replaced screens.
     public struct Item {
-        public var key: AnyHashable
         public var screen: AnyScreen
-        var screenType: Any.Type
         public var barVisibility: BarVisibility
 
-        public init<ScreenType: Screen, Key: Hashable>(key: Key?, screen: ScreenType, barVisibility: BarVisibility) {
+        public init<ScreenType: Screen>(screen: ScreenType, barVisibility: BarVisibility) {
             self.screen = AnyScreen(screen)
-            self.screenType = ScreenType.self
-
-            if let key = key {
-                self.key = AnyHashable(key)
-            } else {
-                self.key = AnyHashable(ObjectIdentifier(ScreenType.self))
-            }
             self.barVisibility = barVisibility
         }
 
-        public init<ScreenType: Screen>(screen: ScreenType, barVisibility: BarVisibility) {
-            let key = Optional<AnyHashable>.none
-            self.init(key: key, screen: screen, barVisibility: barVisibility)
-        }
-
-        public init<ScreenType: Screen, Key: Hashable>(key: Key?, screen: ScreenType, barContent: BackStackScreen.BarContent) {
-            self.init(key: key, screen: screen, barVisibility: .visible(barContent))
-        }
-
         public init<ScreenType: Screen>(screen: ScreenType, barContent: BackStackScreen.BarContent) {
-            let key = Optional<AnyHashable>.none
-            self.init(key: key, screen: screen, barContent: barContent)
-        }
-
-        public init<ScreenType: Screen, Key: Hashable>(key: Key?, screen: ScreenType) {
-            let barVisibility: BarVisibility = .visible(BarContent())
-            self.init(key: key, screen: screen, barVisibility: barVisibility)
+            self.init(screen: screen, barVisibility: .visible(barContent))
         }
 
         public init<ScreenType: Screen>(screen: ScreenType) {
-            let key = Optional<AnyHashable>.none
-            self.init(key: key, screen: screen)
+            let barVisibility: BarVisibility = .visible(BarContent())
+            self.init(screen: screen, barVisibility: barVisibility)
         }
     }
 }

--- a/swift/Samples/BackStackContainer/Sources/ScreenWrapperViewController.swift
+++ b/swift/Samples/BackStackContainer/Sources/ScreenWrapperViewController.swift
@@ -20,14 +20,11 @@ import WorkflowUI
  Wrapper view controller for being hosted in a backstack. Handles updating the bar button items.
  */
 final class ScreenWrapperViewController: UIViewController {
-    let key: AnyHashable
-    let screenType: Any.Type
-
+    let key: AnyScreen.Key
     let contentViewController: ScreenViewController<AnyScreen>
 
     init(item: BackStackScreen.Item, registry: ViewRegistry) {
-        self.key = item.key
-        self.screenType = item.screenType
+        self.key = item.screen.key
         self.contentViewController = registry.provideView(for: item.screen)
 
         super.init(nibName: nil, bundle: nil)
@@ -57,8 +54,7 @@ final class ScreenWrapperViewController: UIViewController {
     }
 
     func matches(item: BackStackScreen.Item) -> Bool {
-        return item.key == key
-            && item.screenType == screenType
+        return item.screen.key == key
     }
 
     private func update(barVisibility: BackStackScreen.BarVisibility) {

--- a/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
@@ -126,7 +126,6 @@ extension RootWorkflow {
             .rendered(with: context)
 
         let welcomeBackStackItem = BackStackScreen.Item(
-            key: "welcome",
             screen: welcomeScreen,
             // Hide the navigation bar.
             barVisibility: .hidden)
@@ -147,7 +146,6 @@ extension RootWorkflow {
                 .rendered(with: context)
 
             let todoListBackStackItem = BackStackScreen.Item(
-                key: "todoList",
                 screen: todoListScreen,
                 // Specify the title, back button, and right button.
                 barContent: BackStackScreen.BarContent(

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
@@ -126,7 +126,6 @@ extension RootWorkflow {
             .rendered(with: context)
 
         let welcomeBackStackItem = BackStackScreen.Item(
-            key: "welcome",
             screen: welcomeScreen,
             // Hide the navigation bar.
             barVisibility: .hidden)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -140,7 +140,6 @@ extension TodoEditWorkflow {
             })
 
         let backStackItem = BackStackScreen.Item(
-            key: "edit",
             screen: todoEditScreen,
             barContent: BackStackScreen.BarContent(
                 title: "Edit",

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -150,7 +150,6 @@ extension TodoListWorkflow {
         })
 
         let todoListItem = BackStackScreen.Item(
-            key: "list",
             screen: todoListScreen,
             barContent: BackStackScreen.BarContent(
                 title: "Welcome \(name)",

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
@@ -126,7 +126,6 @@ extension RootWorkflow {
             .rendered(with: context)
 
         let welcomeBackStackItem = BackStackScreen.Item(
-            key: "welcome",
             screen: welcomeScreen,
             // Hide the navigation bar.
             barVisibility: .hidden)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -140,7 +140,6 @@ extension TodoEditWorkflow {
             })
 
         let backStackItem = BackStackScreen.Item(
-            key: "edit",
             screen: todoEditScreen,
             barContent: BackStackScreen.BarContent(
                 title: "Edit",

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -131,7 +131,6 @@ extension TodoListWorkflow {
         })
 
         let todoListItem = BackStackScreen.Item(
-            key: "list",
             screen: todoListScreen,
             barContent: BackStackScreen.BarContent(
                 title: "Welcome \(name)",

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
@@ -126,7 +126,6 @@ extension RootWorkflow {
             .rendered(with: context)
 
         let welcomeBackStackItem = BackStackScreen.Item(
-            key: "welcome",
             screen: welcomeScreen,
             // Hide the navigation bar.
             barVisibility: .hidden)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -140,7 +140,6 @@ extension TodoEditWorkflow {
             })
 
         let backStackItem = BackStackScreen.Item(
-            key: "edit",
             screen: todoEditScreen,
             barContent: BackStackScreen.BarContent(
                 title: "Edit",

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -131,7 +131,6 @@ extension TodoListWorkflow {
         })
 
         let todoListItem = BackStackScreen.Item(
-            key: "list",
             screen: todoListScreen,
             barContent: BackStackScreen.BarContent(
                 title: "Welcome \(name)",

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -19,14 +19,17 @@
 import UIKit
 
 public struct AnyScreen: Screen {
-    internal let wrappedScreen: Screen
+    internal let wrappedScreen: Any
     private let viewControllerBuilder: (ViewRegistry) -> AnyScreenViewController.WrappedViewController
+
+    public var key: AnyHashable
 
     public init<T: Screen>(_ screen: T) {
         if let anyScreen = screen as? AnyScreen {
             self = anyScreen
             return
         }
+        self.key = screen.key
         self.wrappedScreen = screen
         self.viewControllerBuilder = { viewRegistry in
             return viewRegistry.provideView(for: screen)

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/UntypedScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/UntypedScreenViewController.swift
@@ -18,15 +18,15 @@
 
 // Internal API for working with a screen view controller when the specific screen type is unknown.
 protocol UntypedScreenViewController {
-    var screenType: Screen.Type { get }
-    func update(untypedScreen: Screen)
+    var screenType: Any.Type { get }
+    func update(untypedScreen: Any)
 }
 
 extension ScreenViewController: UntypedScreenViewController {
 
     // `var screenType: Screen.Type` is already present in ScreenViewController
 
-    func update(untypedScreen: Screen) {
+    func update(untypedScreen: Any) {
         guard let typedScreen = untypedScreen as? ScreenType else {
             fatalError("Screen type mismatch: \(self) expected to receive a screen of type \(ScreenType.self), but instead received a screen of type \(type(of: screen))")
         }

--- a/swift/WorkflowUI/Sources/Screen/Screen.swift
+++ b/swift/WorkflowUI/Sources/Screen/Screen.swift
@@ -19,4 +19,21 @@
 ///
 /// Conforming types contain any information needed to populate a screen: data,
 /// styling, event handlers, etc.
-public protocol Screen {}
+public protocol Screen {
+
+    /// The type of key for this screen.
+    associatedtype Key: Hashable = ObjectIdentifier
+
+
+    /// The key for this screen. This is often used by containers to determine screen equality.
+    /// The default value is the object identifier of the screen type.
+    var key: Key { get }
+
+}
+
+
+extension Screen where Key == ObjectIdentifier {
+    public var key: ObjectIdentifier {
+        return ObjectIdentifier(Self.self)
+    }
+}

--- a/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
+++ b/swift/WorkflowUI/Sources/Screen/ScreenViewController.swift
@@ -31,7 +31,7 @@ open class ScreenViewController<ScreenType: Screen>: UIViewController {
         return currentScreen
     }
 
-    public final var screenType: Screen.Type {
+    public final var screenType: Any.Type {
         return ScreenType.self
     }
 


### PR DESCRIPTION
This allows us to drop the key arguments in containers and let screens provide their own keys.

Once we have the ability to have generic screen types (e.g. #815), we can provide something like the following to bring back easy customization of key values by consumers of a screen:

```swift
public struct KeyedScreen<Key: Hashable, ScreenType: Screen>: Screen {
    public init(key: Key, screen: ScreenType) { … }
}

extension Screen {
    func keyed<Key: Hashable>(_ key: Key) -> KeyedScreen<Key, Self> { … }
}
```