### PR TITLE
Update CocoaPods, cocoapods-generate, and Xcodeproj

### DIFF
--- a/.gen_config.yml
+++ b/.gen_config.yml
@@ -4,3 +4,5 @@ local_sources:
   - swift/Samples/BackStackContainer
 platforms:
   - ios
+podspec_paths:
+  - Development.podspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', '1.8.4'
-# Unreleased version required for the --local-sources option
-gem 'cocoapods-generate', git: 'https://github.com/square/cocoapods-generate', ref: '2dcee88'
+# Remove once Xcodeproj 1.16 is released, and/or when CocoaPods 1.10 is released
+# Needed for latest CocoaPods
+gem 'xcodeproj', git: 'https://github.com/CocoaPods/Xcodeproj', ref: '94a6bcd8c'
+
+# Remove once CocoaPods 1.10 is released
+# Needed for scheme macro expansion & test host configuration
+gem 'cocoapods', git: 'https://github.com/CocoaPods/Cocoapods', ref: 'a1c94aaaa'
+
+# Remove once v1.7 is released
+# Needed for the --local-sources option, and for :podspec_paths within .gen_config.yml
+gem 'cocoapods-generate', git: 'https://github.com/square/cocoapods-generate', ref: '58886dc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,44 @@
 GIT
+  remote: https://github.com/CocoaPods/Cocoapods
+  revision: a1c94aaaa21b3da318208c7426433753c0332716
+  ref: a1c94aaaa
+  specs:
+    cocoapods (1.9.0.beta.3)
+      activesupport (>= 4.0.2, < 5)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.9.0.beta.3)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.4.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.6.6)
+      nap (~> 1.0)
+      ruby-macho (~> 1.4)
+      xcodeproj (>= 1.14.0, < 2.0)
+
+GIT
+  remote: https://github.com/CocoaPods/Xcodeproj
+  revision: 94a6bcd8c75981a9f899fca970491e329172325d
+  ref: 94a6bcd8c
+  specs:
+    xcodeproj (1.15.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.2.6)
+
+GIT
   remote: https://github.com/square/cocoapods-generate
-  revision: 2dcee8858af795d1e396125b7f0a8ce0aba6cb81
-  ref: 2dcee88
+  revision: 58886dcd9fd449a9835da3b4ff75548f20c44fbd
+  ref: 58886dc
   specs:
     cocoapods-generate (2.0.0)
       cocoapods-disable-podfile-validations (~> 0.1.1)
@@ -20,31 +57,14 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.0.3)
-    cocoapods (1.8.4)
-      activesupport (>= 4.0.2, < 5)
-      claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.8.4)
-      cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.2.2, < 2.0)
-      cocoapods-plugins (>= 1.0.0, < 2.0)
-      cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-stats (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.4.0, < 2.0)
-      cocoapods-try (>= 1.1.0, < 2.0)
-      colored2 (~> 3.1)
-      escape (~> 0.0.4)
-      fourflusher (>= 2.3.0, < 3.0)
-      gh_inspector (~> 1.0)
-      molinillo (~> 0.6.6)
-      nap (~> 1.0)
-      ruby-macho (~> 1.4)
-      xcodeproj (>= 1.11.1, < 2.0)
-    cocoapods-core (1.8.4)
+    cocoapods-core (1.9.0.beta.3)
       activesupport (>= 4.0.2, < 6)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
+      netrc (~> 0.11)
+      typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.4)
     cocoapods-disable-podfile-validations (0.1.1)
     cocoapods-downloader (1.3.0)
@@ -59,6 +79,9 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.1.6)
     escape (0.0.4)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
+    ffi (1.12.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -73,21 +96,18 @@ GEM
     netrc (0.11.0)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    xcodeproj (1.15.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.2.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.8.4)
+  cocoapods!
   cocoapods-generate!
+  xcodeproj!
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
This will provide the following improvements to the development workflow:
1. `bundle exec pod gen` can be run with no arguments, and `Development.podspec` will automatically be selected.
2. Sample apps will now include their respective unit tests in their scheme, so `CMD-U` can be used to run tests in Xcode for each sample app
3. Config variables can now be used in scheme environment variables (ex. `$(SRCROOT)`)

![Screen Shot 2020-02-14 at 5 30 21 PM](https://user-images.githubusercontent.com/2281949/74579576-56c5c100-4f50-11ea-86db-256ee4541d6f.png)

