### PR TITLE
Fix type parameter for expectWorker accepting Worker instance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+## Version 0.23.3
+
+### Kotlin
+
+ * Fix type parameter for expectWorker accepting Worker instance. (#969)
+
+### Swift
+
+ * Kotlin-only release, no changes.
+
 ## Version 0.23.2
 
 ### Kotlin

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -265,9 +265,9 @@ interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
 /* ktlint-disable parameter-list-wrapping */
 fun <PropsT, StateT, OutputT : Any, RenderingT>
     RenderTester<PropsT, StateT, OutputT, RenderingT>.expectWorker(
-  doesSameWorkAs: Worker<OutputT>,
+  doesSameWorkAs: Worker<*>,
   key: String = "",
-  output: EmittedOutput<OutputT>? = null
+  output: EmittedOutput<Any?>? = null
 ): RenderTester<PropsT, StateT, OutputT, RenderingT> = expectWorker(
 /* ktlint-enable parameter-list-wrapping */
     matchesWhen = { it.doesSameWorkAs(doesSameWorkAs) },


### PR DESCRIPTION
The worker type should be unbounded, _not_ the same as the _Workflow's_ output type.