### PR TITLE
Update binary-compatibility-validator plugin to 0.2.1.

### DIFF
--- a/kotlin/.buildscript/binary-validation.gradle
+++ b/kotlin/.buildscript/binary-validation.gradle
@@ -25,24 +25,8 @@
 apply plugin: 'binary-compatibility-validator'
 
 apiValidation {
+  // Ignore all sample projects, since they're not part of our API.
   // Only leaf project name is valid configuration, and every project must be individually ignored.
   // See https://github.com/Kotlin/binary-compatibility-validator/issues/3
-  // Please keep this list sorted alphabetically.
-  ignoredProjects += [
-      "android",
-      "app",
-      "app-poetry",
-      "app-raven",
-      "common",
-      "hello-back-button",
-      "hello-terminal-app",
-      "hello-workflow",
-      "hello-workflow-fragment",
-      "poetry",
-      "recyclerview",
-      "terminal-workflow",
-      "timemachine",
-      "timemachine-shakeable",
-      "todo-terminal-app",
-  ]
+  ignoredProjects += project('samples').subprojects.collect { it.name }
 }

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -82,7 +82,7 @@ buildscript {
       'timber': "com.jakewharton.timber:timber:4.7.1",
 
       'kotlin': [
-          'binaryCompatibilityValidatorPlugin': "org.jetbrains.kotlinx:binary-compatibility-validator:0.1.1",
+          'binaryCompatibilityValidatorPlugin': "org.jetbrains.kotlinx:binary-compatibility-validator:0.2.1",
           'gradlePlugin': "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61",
           'stdLib': [
               'common': "org.jetbrains.kotlin:kotlin-stdlib-common",

--- a/kotlin/legacy/legacy-workflow-core/api/legacy-workflow-core.api
+++ b/kotlin/legacy/legacy-workflow-core/api/legacy-workflow-core.api
@@ -132,13 +132,9 @@ public final class com/squareup/workflow/legacy/WorkflowPool {
 	public static final field Companion Lcom/squareup/workflow/legacy/WorkflowPool$Companion;
 	public fun <init> ()V
 	public final fun abandonAll ()V
-	public final synthetic fun abandonWorker (Lcom/squareup/workflow/legacy/Worker;Ljava/lang/String;)V
-	public static synthetic fun abandonWorker$default (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/String;ILjava/lang/Object;)V
 	public final fun abandonWorkflow (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)V
 	public final fun abandonWorkflow (Lcom/squareup/workflow/legacy/WorkflowPool$Id;)V
 	public final fun awaitWorkerResult (Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lcom/squareup/workflow/legacy/WorkflowPool$Type;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final synthetic fun awaitWorkerResult (Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun awaitWorkerResult$default (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun awaitWorkflowUpdate (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getPeekWorkflowsCount ()I
 	public final fun input (Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)Lcom/squareup/workflow/legacy/WorkflowInput;
@@ -146,10 +142,6 @@ public final class com/squareup/workflow/legacy/WorkflowPool {
 }
 
 public final class com/squareup/workflow/legacy/WorkflowPool$Companion {
-	public final synthetic fun handle (Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
-	public final synthetic fun handle (Lkotlin/reflect/KClass;Ljava/lang/String;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
-	public static synthetic fun handle$default (Lcom/squareup/workflow/legacy/WorkflowPool$Companion;Lkotlin/reflect/KClass;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
-	public static synthetic fun handle$default (Lcom/squareup/workflow/legacy/WorkflowPool$Companion;Lkotlin/reflect/KClass;Ljava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/legacy/WorkflowPool$Handle;
 }
 
 public final class com/squareup/workflow/legacy/WorkflowPool$Handle {
@@ -187,12 +179,7 @@ public final class com/squareup/workflow/legacy/WorkflowPool$Type {
 }
 
 public final class com/squareup/workflow/legacy/WorkflowPoolKt {
-	public static final synthetic fun getWorkflowType (Lcom/squareup/workflow/legacy/WorkflowPool$Launcher;)Lcom/squareup/workflow/legacy/WorkflowPool$Type;
-	public static final synthetic fun getWorkflowType (Lkotlin/reflect/KClass;)Lcom/squareup/workflow/legacy/WorkflowPool$Type;
-	public static final synthetic fun register (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/WorkflowPool$Launcher;)V
-	public static final synthetic fun workerResult (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;)Lkotlinx/coroutines/Deferred;
 	public static final fun workerResult (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lcom/squareup/workflow/legacy/WorkflowPool$Type;)Lkotlinx/coroutines/Deferred;
-	public static synthetic fun workerResult$default (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lkotlinx/coroutines/Deferred;
 	public static final fun workflowUpdate (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/WorkflowPool$Handle;)Lkotlinx/coroutines/Deferred;
 }
 

--- a/kotlin/legacy/legacy-workflow-rx2/api/legacy-workflow-rx2.api
+++ b/kotlin/legacy/legacy-workflow-rx2/api/legacy-workflow-rx2.api
@@ -8,11 +8,8 @@ public final class com/squareup/workflow/legacy/rx2/EventChannelKt {
 
 public final class com/squareup/workflow/legacy/rx2/EventSelectBuilder {
 	public final fun addEventCase (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public final synthetic fun onEvent (Lkotlin/jvm/functions/Function1;)V
 	public final fun onSuccess (Lio/reactivex/Single;Lkotlin/jvm/functions/Function1;)V
 	public final fun onSuspending (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public final synthetic fun onWorkerResult (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun onWorkerResult$default (Lcom/squareup/workflow/legacy/rx2/EventSelectBuilder;Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/Worker;Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun onWorkflowUpdate (Lcom/squareup/workflow/legacy/WorkflowPool;Lcom/squareup/workflow/legacy/WorkflowPool$Handle;Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/kotlin/workflow-core/api/workflow-core.api
+++ b/kotlin/workflow-core/api/workflow-core.api
@@ -82,11 +82,9 @@ public final class com/squareup/workflow/SnapshotKt {
 	public static final fun parse (Lokio/ByteString;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static final fun readBooleanFromInt (Lokio/BufferedSource;)Z
 	public static final fun readByteStringWithLength (Lokio/BufferedSource;)Lokio/ByteString;
-	public static final synthetic fun readEnumByOrdinal (Lokio/BufferedSource;)Ljava/lang/Enum;
 	public static final fun readFloat (Lokio/BufferedSource;)F
 	public static final fun readList (Lokio/BufferedSource;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static final fun readNullable (Lokio/BufferedSource;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final synthetic fun readOptionalEnumByOrdinal (Lokio/BufferedSource;)Ljava/lang/Enum;
 	public static final fun readOptionalUtf8WithLength (Lokio/BufferedSource;)Ljava/lang/String;
 	public static final fun readUtf8WithLength (Lokio/BufferedSource;)Ljava/lang/String;
 	public static final fun writeBooleanAsInt (Lokio/BufferedSink;Z)Lokio/BufferedSink;
@@ -156,11 +154,8 @@ public abstract interface class com/squareup/workflow/Worker {
 }
 
 public final class com/squareup/workflow/Worker$Companion {
-	public final synthetic fun create (Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/Worker;
 	public final fun createSideEffect (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
 	public final fun finished ()Lcom/squareup/workflow/Worker;
-	public final synthetic fun from (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
-	public final synthetic fun fromNullable (Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
 	public final fun timer (JLjava/lang/String;)Lcom/squareup/workflow/Worker;
 	public static synthetic fun timer$default (Lcom/squareup/workflow/Worker$Companion;JLjava/lang/String;ILjava/lang/Object;)Lcom/squareup/workflow/Worker;
 }
@@ -170,11 +165,6 @@ public final class com/squareup/workflow/Worker$DefaultImpls {
 }
 
 public final class com/squareup/workflow/WorkerKt {
-	public static final synthetic fun asWorker (Lkotlinx/coroutines/Deferred;)Lcom/squareup/workflow/Worker;
-	public static final synthetic fun asWorker (Lkotlinx/coroutines/channels/BroadcastChannel;)Lcom/squareup/workflow/Worker;
-	public static final synthetic fun asWorker (Lkotlinx/coroutines/channels/ReceiveChannel;Z)Lcom/squareup/workflow/Worker;
-	public static final synthetic fun asWorker (Lkotlinx/coroutines/flow/Flow;)Lcom/squareup/workflow/Worker;
-	public static synthetic fun asWorker$default (Lkotlinx/coroutines/channels/ReceiveChannel;ZILjava/lang/Object;)Lcom/squareup/workflow/Worker;
 	public static final fun transform (Lcom/squareup/workflow/Worker;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/Worker;
 }
 

--- a/kotlin/workflow-rx2/api/workflow-rx2.api
+++ b/kotlin/workflow-rx2/api/workflow-rx2.api
@@ -7,9 +7,5 @@ public abstract class com/squareup/workflow/rx2/PublisherWorker : com/squareup/w
 
 public final class com/squareup/workflow/rx2/RxWorkersKt {
 	public static final fun asWorker (Lio/reactivex/Completable;)Lcom/squareup/workflow/Worker;
-	public static final synthetic fun asWorker (Lio/reactivex/Maybe;)Lcom/squareup/workflow/Worker;
-	public static final synthetic fun asWorker (Lio/reactivex/Observable;)Lcom/squareup/workflow/Worker;
-	public static final synthetic fun asWorker (Lio/reactivex/Single;)Lcom/squareup/workflow/Worker;
-	public static final synthetic fun asWorker (Lorg/reactivestreams/Publisher;)Lcom/squareup/workflow/Worker;
 }
 

--- a/kotlin/workflow-testing/api/workflow-testing.api
+++ b/kotlin/workflow-testing/api/workflow-testing.api
@@ -41,10 +41,6 @@ public final class com/squareup/workflow/testing/WorkerSink : com/squareup/workf
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/squareup/workflow/testing/WorkerSinkKt {
-	public static final synthetic fun WorkerSink (Ljava/lang/String;)Lcom/squareup/workflow/testing/WorkerSink;
-}
-
 public abstract interface class com/squareup/workflow/testing/WorkerTester {
 	public abstract fun assertFinished (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun assertNoOutput ()V

--- a/kotlin/workflow-ui/backstack-android/api/backstack-android.api
+++ b/kotlin/workflow-ui/backstack-android/api/backstack-android.api
@@ -1,0 +1,74 @@
+public final class com/squareup/workflow/ui/backstack/BackStackConfig : java/lang/Enum {
+	public static final field Companion Lcom/squareup/workflow/ui/backstack/BackStackConfig$Companion;
+	public static final field First Lcom/squareup/workflow/ui/backstack/BackStackConfig;
+	public static final field None Lcom/squareup/workflow/ui/backstack/BackStackConfig;
+	public static final field Other Lcom/squareup/workflow/ui/backstack/BackStackConfig;
+	public static fun valueOf (Ljava/lang/String;)Lcom/squareup/workflow/ui/backstack/BackStackConfig;
+	public static fun values ()[Lcom/squareup/workflow/ui/backstack/BackStackConfig;
+}
+
+public final class com/squareup/workflow/ui/backstack/BackStackConfig$Companion : com/squareup/workflow/ui/ContainerHintKey {
+	public fun getDefault ()Lcom/squareup/workflow/ui/backstack/BackStackConfig;
+	public synthetic fun getDefault ()Ljava/lang/Object;
+}
+
+public class com/squareup/workflow/ui/backstack/BackStackContainer : android/widget/FrameLayout {
+	public static final field Companion Lcom/squareup/workflow/ui/backstack/BackStackContainer$Companion;
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
+	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
+	protected fun performTransition (Landroid/view/View;Landroid/view/View;Z)V
+}
+
+public final class com/squareup/workflow/ui/backstack/BackStackContainer$Companion : com/squareup/workflow/ui/ViewBinding {
+	public fun buildView (Lcom/squareup/workflow/ui/backstack/BackStackScreen;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow/ui/backstack/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/squareup/workflow/ui/backstack/ViewStateCache : android/os/Parcelable {
+	public static final field CREATOR Lcom/squareup/workflow/ui/backstack/ViewStateCache$CREATOR;
+	public fun <init> ()V
+	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun describeContents ()I
+	public final fun prune (Ljava/util/Collection;)V
+	public final fun restore (Lcom/squareup/workflow/ui/backstack/ViewStateCache;)V
+	public final fun update (Ljava/util/Collection;Landroid/view/View;Landroid/view/View;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/squareup/workflow/ui/backstack/ViewStateCache$CREATOR : android/os/Parcelable$Creator {
+	public fun createFromParcel (Landroid/os/Parcel;)Lcom/squareup/workflow/ui/backstack/ViewStateCache;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public fun newArray (I)[Lcom/squareup/workflow/ui/backstack/ViewStateCache;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/ui/backstack/ViewStateCache$SavedState : android/view/View$BaseSavedState {
+	public static final field CREATOR Lcom/squareup/workflow/ui/backstack/ViewStateCache$SavedState$CREATOR;
+	public fun <init> (Landroid/os/Parcel;)V
+	public fun <init> (Landroid/os/Parcelable;Lcom/squareup/workflow/ui/backstack/ViewStateCache;)V
+	public final fun getViewStateCache ()Lcom/squareup/workflow/ui/backstack/ViewStateCache;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/squareup/workflow/ui/backstack/ViewStateCache$SavedState$CREATOR : android/os/Parcelable$Creator {
+	public fun createFromParcel (Landroid/os/Parcel;)Lcom/squareup/workflow/ui/backstack/ViewStateCache$SavedState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public fun newArray (I)[Lcom/squareup/workflow/ui/backstack/ViewStateCache$SavedState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+

--- a/kotlin/workflow-ui/core-android/api/core-android.api
+++ b/kotlin/workflow-ui/core-android/api/core-android.api
@@ -1,0 +1,172 @@
+public final class com/squareup/workflow/ui/BackPressHandlerKt {
+	public static final fun getBackPressedHandler (Landroid/view/View;)Lkotlin/jvm/functions/Function0;
+	public static final fun onBackPressedDispatcherOwnerOrNull (Landroid/content/Context;)Landroidx/activity/OnBackPressedDispatcherOwner;
+	public static final fun setBackPressedHandler (Landroid/view/View;Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class com/squareup/workflow/ui/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/squareup/workflow/ui/BuilderBinding : com/squareup/workflow/ui/ViewBinding {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function4;)V
+	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public abstract class com/squareup/workflow/ui/ContainerHintKey {
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public abstract fun getDefault ()Ljava/lang/Object;
+	public final fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/squareup/workflow/ui/ContainerHints {
+	public fun <init> (Lcom/squareup/workflow/ui/ViewRegistry;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (Lcom/squareup/workflow/ui/ContainerHintKey;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun plus (Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun plus (Lkotlin/Pair;)Lcom/squareup/workflow/ui/ContainerHints;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/squareup/workflow/ui/LayoutRunner {
+	public static final field Companion Lcom/squareup/workflow/ui/LayoutRunner$Companion;
+	public abstract fun showRendering (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)V
+}
+
+public final class com/squareup/workflow/ui/LayoutRunner$Binding : com/squareup/workflow/ui/ViewBinding {
+	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function1;)V
+	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow/ui/LayoutRunner$Companion {
+}
+
+public final class com/squareup/workflow/ui/LifecyclesKt {
+	public static final fun lifecycleOrNull (Landroid/content/Context;)Landroidx/lifecycle/Lifecycle;
+}
+
+public final class com/squareup/workflow/ui/ShowRenderingTag {
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun component3 ()Lkotlin/jvm/functions/Function2;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/ui/ShowRenderingTag;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/ShowRenderingTag;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/squareup/workflow/ui/ShowRenderingTag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHints ()Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun getShowRendering ()Lkotlin/jvm/functions/Function2;
+	public final fun getShowing ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/squareup/workflow/ui/ViewBinding {
+	public abstract fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public abstract fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow/ui/ViewBinding$DefaultImpls {
+	public static synthetic fun buildView$default (Lcom/squareup/workflow/ui/ViewBinding;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
+}
+
+public abstract interface class com/squareup/workflow/ui/ViewRegistry {
+	public static final field Companion Lcom/squareup/workflow/ui/ViewRegistry$Companion;
+	public abstract fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public abstract fun getKeys ()Ljava/util/Set;
+}
+
+public final class com/squareup/workflow/ui/ViewRegistry$Companion : com/squareup/workflow/ui/ContainerHintKey {
+	public fun getDefault ()Lcom/squareup/workflow/ui/ViewRegistry;
+	public synthetic fun getDefault ()Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/ui/ViewRegistry$DefaultImpls {
+	public static synthetic fun buildView$default (Lcom/squareup/workflow/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
+}
+
+public final class com/squareup/workflow/ui/ViewRegistryKt {
+	public static final fun ViewRegistry ()Lcom/squareup/workflow/ui/ViewRegistry;
+	public static final fun ViewRegistry ([Lcom/squareup/workflow/ui/ViewBinding;)Lcom/squareup/workflow/ui/ViewRegistry;
+	public static final fun ViewRegistry ([Lcom/squareup/workflow/ui/ViewRegistry;)Lcom/squareup/workflow/ui/ViewRegistry;
+	public static final fun buildView (Lcom/squareup/workflow/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/view/ViewGroup;)Landroid/view/View;
+	public static final fun plus (Lcom/squareup/workflow/ui/ViewRegistry;Lcom/squareup/workflow/ui/ViewBinding;)Lcom/squareup/workflow/ui/ViewRegistry;
+	public static final fun plus (Lcom/squareup/workflow/ui/ViewRegistry;Lcom/squareup/workflow/ui/ViewRegistry;)Lcom/squareup/workflow/ui/ViewRegistry;
+}
+
+public final class com/squareup/workflow/ui/ViewShowRenderingKt {
+	public static final fun bindShowRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;)V
+	public static final fun canShowRendering (Landroid/view/View;Ljava/lang/Object;)Z
+	public static final fun getHints (Landroid/view/View;)Lcom/squareup/workflow/ui/ContainerHints;
+	public static final fun getRendering (Landroid/view/View;)Ljava/lang/Object;
+	public static final fun getShowRendering (Landroid/view/View;)Lkotlin/jvm/functions/Function2;
+	public static final fun showRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)V
+}
+
+public abstract class com/squareup/workflow/ui/WorkflowFragment : androidx/fragment/app/Fragment {
+	public fun <init> ()V
+	protected abstract fun getContainerHints ()Lcom/squareup/workflow/ui/ContainerHints;
+	protected final fun getRunner ()Lcom/squareup/workflow/ui/WorkflowRunner;
+	public fun onActivityCreated (Landroid/os/Bundle;)V
+	public synthetic fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
+	public final fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Lcom/squareup/workflow/ui/WorkflowLayout;
+	protected abstract fun onCreateWorkflow ()Lcom/squareup/workflow/ui/WorkflowRunner$Config;
+}
+
+public final class com/squareup/workflow/ui/WorkflowLayout : android/widget/FrameLayout {
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun start (Lio/reactivex/Observable;Lcom/squareup/workflow/ui/ContainerHints;)V
+	public final fun start (Lio/reactivex/Observable;Lcom/squareup/workflow/ui/ViewRegistry;)V
+}
+
+public abstract interface class com/squareup/workflow/ui/WorkflowRunner {
+	public static final field Companion Lcom/squareup/workflow/ui/WorkflowRunner$Companion;
+	public abstract fun getRenderings ()Lio/reactivex/Observable;
+	public abstract fun getResult ()Lio/reactivex/Maybe;
+}
+
+public final class com/squareup/workflow/ui/WorkflowRunner$Companion {
+	public final fun Config (Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)Lcom/squareup/workflow/ui/WorkflowRunner$Config;
+	public static synthetic fun Config$default (Lcom/squareup/workflow/ui/WorkflowRunner$Companion;Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;ILjava/lang/Object;)Lcom/squareup/workflow/ui/WorkflowRunner$Config;
+	public final fun startWorkflow (Landroidx/fragment/app/Fragment;Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/ui/WorkflowRunner;
+	public final fun startWorkflow (Landroidx/fragment/app/FragmentActivity;Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/ui/WorkflowRunner;
+}
+
+public final class com/squareup/workflow/ui/WorkflowRunner$Config {
+	public fun <init> (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)V
+	public synthetic fun <init> (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/squareup/workflow/Workflow;Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;)V
+	public final fun getDiagnosticListener ()Lcom/squareup/workflow/diagnostic/WorkflowDiagnosticListener;
+	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
+	public final fun getProps ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getWorkflow ()Lcom/squareup/workflow/Workflow;
+}
+
+public final class com/squareup/workflow/ui/WorkflowRunnerKt {
+	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/ui/WorkflowRunner;
+	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/ui/WorkflowRunner;
+	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ViewRegistry;Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/ui/WorkflowRunner;
+	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ViewRegistry;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/ui/WorkflowRunner;
+}
+
+public final class com/squareup/workflow/ui/WorkflowViewStub : android/view/View {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getActual ()Landroid/view/View;
+	public final fun setActual (Landroid/view/View;)V
+	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Landroid/view/View;
+}
+

--- a/kotlin/workflow-ui/core-compose/api/core-compose.api
+++ b/kotlin/workflow-ui/core-compose/api/core-compose.api
@@ -1,0 +1,15 @@
+public final class com/squareup/workflow/ui/compose/ComposeViewBinding : com/squareup/workflow/ui/ViewBinding {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;)V
+	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow/ui/core/compose/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+

--- a/kotlin/workflow-ui/modal-android/api/modal-android.api
+++ b/kotlin/workflow-ui/modal-android/api/modal-android.api
@@ -1,0 +1,81 @@
+public final class com/squareup/workflow/ui/modal/AlertContainer : com/squareup/workflow/ui/modal/ModalContainer {
+	public static final field Companion Lcom/squareup/workflow/ui/modal/AlertContainer$Companion;
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;III)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+}
+
+public final class com/squareup/workflow/ui/modal/AlertContainer$Companion : com/squareup/workflow/ui/ViewBinding {
+	public fun buildView (Lcom/squareup/workflow/ui/modal/AlertContainerScreen;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public final fun customThemeBinding (I)Lcom/squareup/workflow/ui/ViewBinding;
+	public static synthetic fun customThemeBinding$default (Lcom/squareup/workflow/ui/modal/AlertContainer$Companion;IILjava/lang/Object;)Lcom/squareup/workflow/ui/ViewBinding;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow/ui/modal/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field VERSION_CODE I
+	public static final field VERSION_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public abstract class com/squareup/workflow/ui/modal/ModalContainer : android/widget/FrameLayout {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected abstract fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
+	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
+	protected final fun update (Lcom/squareup/workflow/ui/modal/HasModals;Lcom/squareup/workflow/ui/ContainerHints;)V
+	protected abstract fun updateDialog (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;)V
+}
+
+protected final class com/squareup/workflow/ui/modal/ModalContainer$DialogRef {
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun component3 ()Landroid/app/Dialog;
+	public final fun component4 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContainerHints ()Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun getDialog ()Landroid/app/Dialog;
+	public final fun getExtra ()Ljava/lang/Object;
+	public final fun getModalRendering ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class com/squareup/workflow/ui/modal/ModalViewContainer : com/squareup/workflow/ui/modal/ModalContainer {
+	public static final field Companion Lcom/squareup/workflow/ui/modal/ModalViewContainer$Companion;
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected final fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	public fun buildDialogForView (Landroid/view/View;)Landroid/app/Dialog;
+	protected fun updateDialog (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;)V
+}
+
+public final class com/squareup/workflow/ui/modal/ModalViewContainer$Binding : com/squareup/workflow/ui/ViewBinding {
+	public fun <init> (ILkotlin/reflect/KClass;)V
+	public fun buildView (Lcom/squareup/workflow/ui/modal/HasModals;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public final class com/squareup/workflow/ui/modal/ModalViewContainer$Companion {
+}
+


### PR DESCRIPTION
[Here's the release notes](https://github.com/Kotlin/binary-compatibility-validator/releases/tag/0.2.0) (interesting changes are all in 0.2.0, but latest version is actually 0.2.1).

Highlights:
 - Android support!
 - `inline reified` functions are no longer considered as public ABI

The plugin configuration now automatically ignores any projects in the `samples` directory,
instead of listing them explicitly.