### PR TITLE
Fix build.gradle to use renamed compiler flag -Xopt-in

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -197,7 +197,7 @@ subprojects {
 
       // Don't panic, all this does is allow us to use the @Experimental meta-annotation.
       // to define our own experiments.
-      freeCompilerArgs += "-Xuse-experimental=kotlin.Experimental"
+      freeCompilerArgs += "-Xopt-in=kotlin.Experimental"
     }
   }
 


### PR DESCRIPTION
Missed this in the original 1.3.70 PR, #993.