### PR TITLE
Add Swift tutorial code to the Development podspec

### DIFF
--- a/.gen_config.yml
+++ b/.gen_config.yml
@@ -2,6 +2,14 @@ local_sources:
   - .
   - swift/Samples/SplitScreenContainer
   - swift/Samples/BackStackContainer
+  - swift/Samples/Tutorial/Frameworks/TutorialViews
+  - swift/Samples/Tutorial/Frameworks/TutorialBase
+  - swift/Samples/Tutorial/Frameworks/Tutorial1Complete
+  - swift/Samples/Tutorial/Frameworks/Tutorial2Complete
+  - swift/Samples/Tutorial/Frameworks/Tutorial3Complete
+  - swift/Samples/Tutorial/Frameworks/Tutorial4Complete
+  - swift/Samples/Tutorial/Frameworks/Tutorial5Complete
+  - swift/
 platforms:
   - ios
 podspec_paths:

--- a/Development.podspec
+++ b/Development.podspec
@@ -89,6 +89,32 @@ Pod::Spec.new do |s|
     }
   end
 
+  s.app_spec 'Tutorial' do |app_spec|
+    app_spec.dependency 'BackStackContainer'
+    app_spec.dependency 'TutorialViews'
+    app_spec.dependency 'TutorialBase'
+    app_spec.dependency 'Tutorial1'
+    app_spec.dependency 'Tutorial2'
+    app_spec.dependency 'Tutorial3'
+    app_spec.dependency 'Tutorial4'
+    app_spec.dependency 'Tutorial5'
+    app_spec.source_files = 'swift/Samples/Tutorial/AppHost/Sources/*.swift'
+
+    app_spec.scheme = {
+      environment_variables: snapshot_test_env
+    }
+  end
+
+  s.test_spec 'Tutorial5Tests' do |test_spec|
+    test_spec.dependency 'BackStackContainer'
+    test_spec.dependency 'TutorialBase'
+    test_spec.dependency 'Tutorial5'
+    test_spec.dependency 'WorkflowTesting'
+    test_spec.requires_app_host = true
+    test_spec.source_files = 'swift/Samples/Tutorial/Frameworks/TutorialBase/Tests/**/*.swift'
+    test_spec.framework = 'XCTest'
+  end
+
   s.test_spec 'WorkflowTests' do |test_spec|
     test_spec.requires_app_host = true
     test_spec.source_files = 'swift/Workflow/Tests/**/*.swift'


### PR DESCRIPTION
I missed the Tutorials when doing ViewEnvironment stuff because they weren’t in the development project. This adds them to that.