### PR TITLE
Rename ContainerHints to ViewEnvironment to match Swift.

### DIFF
--- a/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/ReactorAsWorkflowIntegrationTest.kt
+++ b/kotlin/legacy/legacy-workflow-core/src/test/java/com/squareup/workflow/legacy/ReactorAsWorkflowIntegrationTest.kt
@@ -32,8 +32,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.junit.Test
-import kotlin.coroutines.suspendCoroutine
 import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse

--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/BackButtonScreen.kt
@@ -55,7 +55,7 @@ data class BackButtonScreen<W : Any>(
             .also { view ->
               val wrappedUpdater = view.getShowRendering<Any>()!!
 
-              view.bindShowRendering(initialRendering, initialHints) { rendering, hints ->
+              view.bindShowRendering(initialRendering, initialHints) { rendering, environment ->
                 if (!rendering.override) {
                   // Place our handler before invoking the wrapped updater, so that
                   // its later calls to view.backPressedHandler will take precedence
@@ -63,7 +63,7 @@ data class BackButtonScreen<W : Any>(
                   view.backPressedHandler = rendering.onBackPressed
                 }
 
-                wrappedUpdater.invoke(rendering.wrapped, hints)
+                wrappedUpdater.invoke(rendering.wrapped, environment)
 
                 if (rendering.override) {
                   // Place our handler after invoking the wrapped updater, so that ours

--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/masterdetail/MasterDetailConfig.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/masterdetail/MasterDetailConfig.kt
@@ -15,10 +15,10 @@
  */
 package com.squareup.sample.container.masterdetail
 
-import com.squareup.workflow.ui.ContainerHintKey
+import com.squareup.workflow.ui.ViewEnvironmentKey
 
 /**
- * [com.squareup.workflow.ui.ContainerHints] value that informs views
+ * [com.squareup.workflow.ui.ViewEnvironment] value that informs views
  * whether they're children of a [MasterDetailContainer], and if so
  * in what configuration.
  */
@@ -43,7 +43,7 @@ enum class MasterDetailConfig {
    */
   Single;
 
-  companion object : ContainerHintKey<MasterDetailConfig>(MasterDetailConfig::class) {
+  companion object : ViewEnvironmentKey<MasterDetailConfig>(MasterDetailConfig::class) {
     override val default = None
   }
 }

--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/masterdetail/MasterDetailContainer.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/masterdetail/MasterDetailContainer.kt
@@ -22,9 +22,9 @@ import com.squareup.sample.container.R
 import com.squareup.sample.container.masterdetail.MasterDetailConfig.Detail
 import com.squareup.sample.container.masterdetail.MasterDetailConfig.Master
 import com.squareup.sample.container.masterdetail.MasterDetailConfig.Single
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.WorkflowViewStub
 import com.squareup.workflow.ui.backstack.BackStackScreen
 
@@ -52,29 +52,29 @@ class MasterDetailContainer(view: View) : LayoutRunner<MasterDetailScreen> {
 
   override fun showRendering(
     rendering: MasterDetailScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
-    if (singleStub == null) renderSplitView(rendering, containerHints)
-    else renderSingleView(rendering, containerHints, singleStub)
+    if (singleStub == null) renderSplitView(rendering, viewEnvironment)
+    else renderSingleView(rendering, viewEnvironment, singleStub)
   }
 
   private fun renderSplitView(
     rendering: MasterDetailScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     if (rendering.detailRendering == null && rendering.selectDefault != null) {
       rendering.selectDefault!!.invoke()
     } else {
       masterStub!!.update(
           rendering.masterRendering,
-          containerHints + (MasterDetailConfig to Master)
+          viewEnvironment + (MasterDetailConfig to Master)
       )
       rendering.detailRendering
           ?.let { detail ->
             detailStub!!.actual.visibility = VISIBLE
             detailStub.update(
                 detail,
-                containerHints + (MasterDetailConfig to Detail)
+                viewEnvironment + (MasterDetailConfig to Detail)
             )
           }
           ?: run {
@@ -85,14 +85,14 @@ class MasterDetailContainer(view: View) : LayoutRunner<MasterDetailScreen> {
 
   private fun renderSingleView(
     rendering: MasterDetailScreen,
-    containerHints: ContainerHints,
+    viewEnvironment: ViewEnvironment,
     stub: WorkflowViewStub
   ) {
     val combined: BackStackScreen<*> = rendering.detailRendering
         ?.let { rendering.masterRendering + it }
         ?: rendering.masterRendering
 
-    stub.update(combined, containerHints + (MasterDetailConfig to Single))
+    stub.update(combined, viewEnvironment + (MasterDetailConfig to Single))
   }
 
   companion object : ViewBinding<MasterDetailScreen> by LayoutRunner.Binding(

--- a/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
+++ b/kotlin/samples/containers/android/src/main/java/com/squareup/sample/container/panel/ScrimContainer.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package com.squareup.sample.container.panel
+
 import android.animation.ValueAnimator
 import android.content.Context
 import android.util.AttributeSet
@@ -105,7 +106,7 @@ class ScrimContainer @JvmOverloads constructor(
 
   companion object : ViewBinding<ScrimContainerScreen<*>> by BuilderBinding(
       type = ScrimContainerScreen::class,
-      viewConstructor = { initialRendering, initialContainerHints, contextForNewView, _ ->
+      viewConstructor = { initialRendering, initialViewEnvironment, contextForNewView, _ ->
         val stub = WorkflowViewStub(contextForNewView)
 
         ScrimContainer(contextForNewView)
@@ -113,8 +114,10 @@ class ScrimContainer @JvmOverloads constructor(
               layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
               addView(stub)
 
-              bindShowRendering(initialRendering, initialContainerHints) { rendering, hints ->
-                stub.update(rendering.wrapped, hints)
+              bindShowRendering(
+                  initialRendering, initialViewEnvironment
+              ) { rendering, environment ->
+                stub.update(rendering.wrapped, environment)
                 isDimmed = rendering.dimmed
               }
             }

--- a/kotlin/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListLayoutRunner.kt
+++ b/kotlin/samples/containers/app-poetry/src/main/java/com/squareup/sample/poetryapp/PoemListLayoutRunner.kt
@@ -25,10 +25,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.squareup.sample.container.masterdetail.MasterDetailConfig
 import com.squareup.sample.container.masterdetail.MasterDetailConfig.Master
 import com.squareup.sample.container.poetryapp.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 
 class PoemListLayoutRunner(view: View) : LayoutRunner<PoemListRendering> {
   init {
@@ -46,10 +46,10 @@ class PoemListLayoutRunner(view: View) : LayoutRunner<PoemListRendering> {
 
   override fun showRendering(
     rendering: PoemListRendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     adapter.rendering = rendering
-    adapter.hints = containerHints
+    adapter.environment = viewEnvironment
     adapter.notifyDataSetChanged()
     if (recyclerView.adapter == null) recyclerView.adapter = adapter
 
@@ -60,13 +60,13 @@ class PoemListLayoutRunner(view: View) : LayoutRunner<PoemListRendering> {
 
   private class Adapter : RecyclerView.Adapter<ViewHolder>() {
     lateinit var rendering: PoemListRendering
-    lateinit var hints: ContainerHints
+    lateinit var environment: ViewEnvironment
 
     override fun onCreateViewHolder(
       parent: ViewGroup,
       viewType: Int
     ): ViewHolder {
-      val selectable = hints[MasterDetailConfig] == Master
+      val selectable = environment[MasterDetailConfig] == Master
       val layoutId = if (selectable) {
         R.layout.list_row_selectable
       } else {

--- a/kotlin/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonLayoutRunner.kt
+++ b/kotlin/samples/containers/hello-back-button/src/main/java/com/squareup/sample/hellobackbutton/HelloBackButtonLayoutRunner.kt
@@ -17,13 +17,13 @@ package com.squareup.sample.hellobackbutton
 
 import android.view.View
 import android.widget.TextView
+import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.Rendering
 import com.squareup.sample.hellobackbutton.R.id
 import com.squareup.sample.hellobackbutton.R.layout
-import com.squareup.sample.hellobackbutton.HelloBackButtonWorkflow.Rendering
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 
 class HelloBackButtonLayoutRunner(view: View) : LayoutRunner<Rendering> {
@@ -31,7 +31,7 @@ class HelloBackButtonLayoutRunner(view: View) : LayoutRunner<Rendering> {
 
   override fun showRendering(
     rendering: Rendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     messageView.text = rendering.message
     messageView.setOnClickListener { rendering.onClick() }

--- a/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaLayoutRunner.kt
+++ b/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaLayoutRunner.kt
@@ -26,9 +26,9 @@ import androidx.appcompat.widget.Toolbar
 import com.squareup.sample.container.masterdetail.MasterDetailConfig
 import com.squareup.sample.container.masterdetail.MasterDetailConfig.Detail
 import com.squareup.sample.container.poetry.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 import com.squareup.workflow.ui.backstack.BackStackConfig
 import com.squareup.workflow.ui.backstack.BackStackConfig.None
@@ -47,9 +47,9 @@ class StanzaLayoutRunner(private val view: View) : LayoutRunner<StanzaRendering>
 
   override fun showRendering(
     rendering: StanzaRendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
-    if (containerHints[MasterDetailConfig] == Detail) {
+    if (viewEnvironment[MasterDetailConfig] == Detail) {
       toolbar.title = "Stanza ${rendering.stanzaNumber}"
       toolbar.subtitle = null
     } else {
@@ -81,14 +81,14 @@ class StanzaLayoutRunner(private val view: View) : LayoutRunner<StanzaRendering>
           goBack.visibility = View.INVISIBLE
         }
 
-    if (containerHints[MasterDetailConfig] != Detail && containerHints[BackStackConfig] != None) {
+    if (viewEnvironment[MasterDetailConfig] != Detail && viewEnvironment[BackStackConfig] != None) {
       toolbar.setNavigationOnClickListener { rendering.onGoUp.invoke() }
     } else {
       toolbar.navigationIcon = null
     }
 
     view.backPressedHandler = rendering.onGoBack
-        ?: rendering.onGoUp.takeIf { containerHints[MasterDetailConfig] != Detail }
+        ?: rendering.onGoUp.takeIf { viewEnvironment[MasterDetailConfig] != Detail }
   }
 
   private fun TextView.setTabulatedText(lines: List<String>) {

--- a/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListLayoutRunner.kt
+++ b/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaListLayoutRunner.kt
@@ -25,10 +25,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.squareup.sample.container.masterdetail.MasterDetailConfig
 import com.squareup.sample.container.masterdetail.MasterDetailConfig.Master
 import com.squareup.sample.container.poetry.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 import com.squareup.workflow.ui.backstack.BackStackConfig
 import com.squareup.workflow.ui.backstack.BackStackConfig.Other
@@ -42,16 +42,16 @@ class StanzaListLayoutRunner(view: View) : LayoutRunner<StanzaListRendering> {
 
   override fun showRendering(
     rendering: StanzaListRendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     adapter.rendering = rendering
-    adapter.hints = containerHints
+    adapter.environment = viewEnvironment
     adapter.notifyDataSetChanged()
     if (recyclerView.adapter == null) recyclerView.adapter = adapter
     toolbar.title = rendering.title
     toolbar.subtitle = rendering.subtitle
 
-    if (containerHints[BackStackConfig] == Other) {
+    if (viewEnvironment[BackStackConfig] == Other) {
       toolbar.setNavigationOnClickListener { rendering.onExit() }
       toolbar.backPressedHandler = rendering.onExit
     } else {
@@ -66,13 +66,13 @@ class StanzaListLayoutRunner(view: View) : LayoutRunner<StanzaListRendering> {
 
   private class Adapter : RecyclerView.Adapter<ViewHolder>() {
     lateinit var rendering: StanzaListRendering
-    lateinit var hints: ContainerHints
+    lateinit var environment: ViewEnvironment
 
     override fun onCreateViewHolder(
       parent: ViewGroup,
       viewType: Int
     ): ViewHolder {
-      val selectable = hints[MasterDetailConfig] == Master
+      val selectable = environment[MasterDetailConfig] == Master
       val layoutId = if (selectable) {
         R.layout.list_row_selectable
       } else {

--- a/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
+++ b/kotlin/samples/containers/poetry/src/main/java/com/squareup/sample/poetry/StanzaWorkflow.kt
@@ -17,8 +17,8 @@ package com.squareup.sample.poetry
 
 import com.squareup.sample.poetry.StanzaWorkflow.Output
 import com.squareup.sample.poetry.StanzaWorkflow.Output.CloseStanzas
-import com.squareup.sample.poetry.StanzaWorkflow.Output.ShowPreviousStanza
 import com.squareup.sample.poetry.StanzaWorkflow.Output.ShowNextStanza
+import com.squareup.sample.poetry.StanzaWorkflow.Output.ShowPreviousStanza
 import com.squareup.sample.poetry.StanzaWorkflow.Props
 import com.squareup.sample.poetry.model.Poem
 import com.squareup.workflow.RenderContext

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/BoardsListLayoutRunner.kt
@@ -24,10 +24,10 @@ import com.squareup.cycler.Recycler
 import com.squareup.cycler.toDataSource
 import com.squareup.sample.dungeon.DungeonAppWorkflow.DisplayBoardsListScreen
 import com.squareup.sample.dungeon.board.Board
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.WorkflowViewStub
 
 /**
@@ -39,14 +39,14 @@ import com.squareup.workflow.ui.WorkflowViewStub
 class BoardsListLayoutRunner(rootView: View) : LayoutRunner<DisplayBoardsListScreen> {
 
   /**
-   * Used to associate a single [ContainerHints] and [DisplayBoardsListScreen.onBoardSelected]
+   * Used to associate a single [ViewEnvironment] and [DisplayBoardsListScreen.onBoardSelected]
    * event handler with every item of a [DisplayBoardsListScreen].
    *
    * @see toDataSource
    */
   private data class BoardItem(
     val board: Board,
-    val containerHints: ContainerHints,
+    val viewEnvironment: ViewEnvironment,
     val onClicked: () -> Unit
   )
 
@@ -66,7 +66,7 @@ class BoardsListLayoutRunner(rootView: View) : LayoutRunner<DisplayBoardsListScr
             val boardPreviewView: WorkflowViewStub = view.findViewById(R.id.board_preview)
 
             boardNameView.text = item.board.metadata.name
-            boardPreviewView.update(item.board, item.containerHints)
+            boardPreviewView.update(item.board, item.viewEnvironment)
             card.setOnClickListener { item.onClicked() }
           }
         }
@@ -75,28 +75,28 @@ class BoardsListLayoutRunner(rootView: View) : LayoutRunner<DisplayBoardsListScr
 
   override fun showRendering(
     rendering: DisplayBoardsListScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     // Associate the containerHints and event handler to each item because it needs to be used when
     // binding the RecyclerView item above.
     // Recycler is configured with a DataSource, which effectively (and often in practice) a simple
     // wrapper around a List.
-    recycler.data = rendering.toDataSource(containerHints)
+    recycler.data = rendering.toDataSource(viewEnvironment)
   }
 
   /**
    * Converts this [DisplayBoardsListScreen] into a [DataSource] by lazily wrapping it in a
-   * [BoardItem] to associate it with the [ContainerHints] and selection event handler from the
+   * [BoardItem] to associate it with the [ViewEnvironment] and selection event handler from the
    * rendering.
    */
   private fun DisplayBoardsListScreen.toDataSource(
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ): DataSource<BoardItem> = object : DataSource<BoardItem> {
     override val size: Int get() = boards.size
 
     override fun get(i: Int): BoardItem = BoardItem(
         board = boards[i],
-        containerHints = containerHints,
+        viewEnvironment = viewEnvironment,
         onClicked = { onBoardSelected(i) }
     )
   }

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameLayoutRunner.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/GameLayoutRunner.kt
@@ -24,10 +24,10 @@ import com.squareup.sample.dungeon.Direction.LEFT
 import com.squareup.sample.dungeon.Direction.RIGHT
 import com.squareup.sample.dungeon.Direction.UP
 import com.squareup.sample.dungeon.GameWorkflow.GameRendering
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.WorkflowViewStub
 
 /**
@@ -53,9 +53,9 @@ class GameLayoutRunner(view: View) : LayoutRunner<GameRendering> {
 
   override fun showRendering(
     rendering: GameRendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
-    boardView.update(rendering.board, containerHints)
+    boardView.update(rendering.board, viewEnvironment)
     this.rendering = rendering
 
     // Disable the views if we don't have an event handler, e.g. when the game has finished.

--- a/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/LoadingBinding.kt
+++ b/kotlin/samples/dungeon/app/src/main/java/com/squareup/sample/dungeon/LoadingBinding.kt
@@ -18,10 +18,10 @@ package com.squareup.sample.dungeon
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.StringRes
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 
 /**
  * Factory function for [ViewBinding]s that show a full-screen loading indicator with some text
@@ -51,7 +51,7 @@ internal class LoadingLayoutRunner<RenderingT : Any>(
 
   override fun showRendering(
     rendering: RenderingT,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     // No-op.
   }

--- a/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineLayoutRunner.kt
+++ b/kotlin/samples/dungeon/timemachine-shakeable/src/main/java/com/squareup/sample/timemachine/shakeable/ShakeableTimeMachineLayoutRunner.kt
@@ -22,10 +22,10 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.Group
 import androidx.transition.TransitionManager
 import com.squareup.sample.timemachine.shakeable.internal.GlassFrameLayout
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.WorkflowViewStub
 import com.squareup.workflow.ui.backPressedHandler
 import kotlin.time.Duration
@@ -55,7 +55,7 @@ class ShakeableTimeMachineLayoutRunner(
 
   override fun showRendering(
     rendering: ShakeableTimeMachineRendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     // Only handle back presses explicitly if in playback mode.
     view.backPressedHandler = rendering.onResumeRecording.takeUnless { rendering.recording }
@@ -94,7 +94,7 @@ class ShakeableTimeMachineLayoutRunner(
     }
 
     // Show the child screen.
-    childStub.update(rendering.rendering, containerHints)
+    childStub.update(rendering.rendering, viewEnvironment)
   }
 
   private fun Duration.toProgressInt(): Int = toLongMilliseconds().toInt()

--- a/kotlin/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
+++ b/kotlin/samples/dungeon/timemachine/src/main/java/com/squareup/sample/timemachine/RecorderWorkflow.kt
@@ -22,9 +22,9 @@ import com.squareup.sample.timemachine.RecorderWorkflow.Recording
 import com.squareup.workflow.RenderContext
 import com.squareup.workflow.Snapshot
 import com.squareup.workflow.StatefulWorkflow
-import kotlin.time.TimeMark
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
+import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
 /**

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloFragmentLayoutRunner.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloFragmentLayoutRunner.kt
@@ -18,10 +18,10 @@ package com.squareup.sample.helloworkflowfragment
 import android.annotation.SuppressLint
 import android.view.View
 import android.widget.TextView
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 
 class HelloFragmentLayoutRunner(view: View) : LayoutRunner<HelloWorkflow.Rendering> {
   private val messageView = view.findViewById<TextView>(R.id.hello_message)
@@ -29,7 +29,7 @@ class HelloFragmentLayoutRunner(view: View) : LayoutRunner<HelloWorkflow.Renderi
   @SuppressLint("SetTextI18n")
   override fun showRendering(
     rendering: HelloWorkflow.Rendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     messageView.text = rendering.message + " Fragment!"
     messageView.setOnClickListener { rendering.onClick() }

--- a/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
+++ b/kotlin/samples/hello-workflow-fragment/src/main/java/com/squareup/sample/helloworkflowfragment/HelloWorkflowFragment.kt
@@ -16,13 +16,13 @@
 package com.squareup.sample.helloworkflowfragment
 
 import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
-import com.squareup.workflow.ui.ContainerHints
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowFragment
 import com.squareup.workflow.ui.WorkflowRunner
 
 class HelloWorkflowFragment : WorkflowFragment<Unit, Nothing>() {
-  override val containerHints = ContainerHints(ViewRegistry(HelloFragmentLayoutRunner))
+  override val viewEnvironment = ViewEnvironment(ViewRegistry(HelloFragmentLayoutRunner))
 
   override fun onCreateWorkflow(): WorkflowRunner.Config<Unit, Nothing> {
     return WorkflowRunner.Config(

--- a/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloLayoutRunner.kt
+++ b/kotlin/samples/hello-workflow/src/main/java/com/squareup/sample/helloworkflow/HelloLayoutRunner.kt
@@ -17,17 +17,17 @@ package com.squareup.sample.helloworkflow
 
 import android.view.View
 import android.widget.TextView
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 
 class HelloLayoutRunner(view: View) : LayoutRunner<HelloWorkflow.Rendering> {
   private val messageView: TextView = view.findViewById(R.id.hello_message)
 
   override fun showRendering(
     rendering: HelloWorkflow.Rendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     messageView.text = rendering.message
     messageView.setOnClickListener { rendering.onClick() }

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/BaseScreenLayoutRunner.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/BaseScreenLayoutRunner.kt
@@ -21,10 +21,10 @@ import com.squareup.sample.recyclerview.AppWorkflow.BaseScreen
 import com.squareup.sample.recyclerview.editablelistworkflow.ListDiffMode
 import com.squareup.sample.recyclerview.editablelistworkflow.ListDiffMode.Asynchronous
 import com.squareup.sample.recyclerview.editablelistworkflow.ListDiffMode.Synchronous
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.WorkflowViewStub
 
 /**
@@ -42,11 +42,11 @@ class BaseScreenLayoutRunner(view: View) : LayoutRunner<BaseScreen> {
 
   override fun showRendering(
     rendering: BaseScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
-    val syncHints = containerHints + (ListDiffMode to Synchronous)
-    val asyncHints = containerHints + (ListDiffMode to Asynchronous)
-    noDiffListStub.update(rendering.listRendering, containerHints)
+    val syncHints = viewEnvironment + (ListDiffMode to Synchronous)
+    val asyncHints = viewEnvironment + (ListDiffMode to Asynchronous)
+    noDiffListStub.update(rendering.listRendering, viewEnvironment)
     syncListStub.update(rendering.listRendering, syncHints)
     asyncListStub.update(rendering.listRendering, asyncHints)
     addRowButton.setOnClickListener { rendering.onAddRowTapped() }

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/ChooseRowTypeViewBinding.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/ChooseRowTypeViewBinding.kt
@@ -25,8 +25,8 @@ import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.Button
 import android.widget.LinearLayout
 import com.squareup.sample.recyclerview.AppWorkflow.ChooseRowTypeScreen
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.bindShowRendering
 import kotlin.reflect.KClass
 
@@ -38,7 +38,7 @@ object ChooseRowTypeViewBinding : ViewBinding<ChooseRowTypeScreen> {
 
   override fun buildView(
     initialRendering: ChooseRowTypeScreen,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup?
   ): View {
@@ -48,7 +48,7 @@ object ChooseRowTypeViewBinding : ViewBinding<ChooseRowTypeScreen> {
 
     val inflater = LayoutInflater.from(contextForNewView)
 
-    list.bindShowRendering(initialRendering, initialContainerHints) { rendering, _ ->
+    list.bindShowRendering(initialRendering, initialViewEnvironment) { rendering, _ ->
       list.removeAllViews()
       rendering.options.forEachIndexed { index, option ->
         val row = inflater.inflate(R.layout.new_row_type_item, list, false) as Button

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListLayoutRunner.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/EditableListLayoutRunner.kt
@@ -22,10 +22,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.squareup.sample.recyclerview.R
 import com.squareup.sample.recyclerview.R.id
 import com.squareup.sample.recyclerview.editablelistworkflow.EditableListWorkflow.Rendering
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 
 class EditableListLayoutRunner(view: View) : LayoutRunner<Rendering> {
   private val adapter = EditableListAdapter()
@@ -41,9 +41,9 @@ class EditableListLayoutRunner(view: View) : LayoutRunner<Rendering> {
 
   override fun showRendering(
     rendering: Rendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
-    adapter.updateRendering(rendering, containerHints[ListDiffMode])
+    adapter.updateRendering(rendering, viewEnvironment[ListDiffMode])
   }
 
   companion object : ViewBinding<Rendering> by bind(

--- a/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/ListDiffMode.kt
+++ b/kotlin/samples/recyclerview/src/main/java/com/squareup/sample/recyclerview/editablelistworkflow/ListDiffMode.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.sample.recyclerview.editablelistworkflow
 
-import com.squareup.workflow.ui.ContainerHintKey
+import com.squareup.workflow.ui.ViewEnvironmentKey
 
 /**
  * Tells [EditableListAdapter]s how to calculate and notify updates.
@@ -26,7 +26,7 @@ enum class ListDiffMode {
   Synchronous,
   Asynchronous;
 
-  companion object : ContainerHintKey<ListDiffMode>(ListDiffMode::class) {
+  companion object : ViewEnvironmentKey<ListDiffMode>(ListDiffMode::class) {
     override val default get() = None
   }
 }

--- a/kotlin/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
+++ b/kotlin/samples/tictactoe/app/src/androidTest/java/com/squareup/sample/TicTacToeEspressoTest.kt
@@ -39,8 +39,8 @@ import com.squareup.sample.gameworkflow.Player
 import com.squareup.sample.gameworkflow.symbol
 import com.squareup.sample.mainactivity.MainActivity
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow.ui.ContainerHints
-import com.squareup.workflow.ui.hints
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.environment
 import com.squareup.workflow.ui.getRendering
 import org.junit.After
 import org.junit.Before
@@ -83,7 +83,7 @@ class TicTacToeEspressoTest {
 
     onView(withId(R.id.start_game)).perform(click())
 
-    val hints = AtomicReference<ContainerHints>()
+    val environment = AtomicReference<ViewEnvironment>()
 
     // Why should I learn how to write a matcher when I can just grab the activity
     // and work with it directly?
@@ -92,9 +92,9 @@ class TicTacToeEspressoTest {
       val parent = button.parent as View
       val rendering = parent.getRendering<GamePlayScreen>()!!
       assertThat(rendering.gameState.playing).isSameInstanceAs(Player.X)
-      val firstHints = parent.hints
+      val firstHints = parent.environment
       assertThat(firstHints).isNotNull()
-      hints.set(firstHints)
+      environment.set(firstHints)
 
       // Make a move.
       rendering.onClick(0, 0)
@@ -115,7 +115,7 @@ class TicTacToeEspressoTest {
       val parent = button.parent as View
       val rendering = parent.getRendering<GamePlayScreen>()!!
       assertThat(rendering.gameState.playing).isSameInstanceAs(Player.O)
-      assertThat(parent.hints).isEqualTo(hints.get())
+      assertThat(parent.environment).isEqualTo(environment.get())
     }
   }
 

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/authworkflow/AuthorizingLayoutRunner.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/authworkflow/AuthorizingLayoutRunner.kt
@@ -18,17 +18,17 @@ package com.squareup.sample.authworkflow
 import android.view.View
 import android.widget.TextView
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 
 internal class AuthorizingLayoutRunner(view: View) : LayoutRunner<AuthorizingScreen> {
   private val messageView: TextView = view.findViewById(R.id.authorizing_message)
 
   override fun showRendering(
     rendering: AuthorizingScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     messageView.text = rendering.message
   }

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/authworkflow/LoginLayoutRunner.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/authworkflow/LoginLayoutRunner.kt
@@ -20,10 +20,10 @@ import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 
 internal class LoginLayoutRunner(val view: View) : LayoutRunner<LoginScreen> {
@@ -34,7 +34,7 @@ internal class LoginLayoutRunner(val view: View) : LayoutRunner<LoginScreen> {
 
   override fun showRendering(
     rendering: LoginScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     error.text = rendering.errorMessage
 

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/authworkflow/SecondFactorLayoutRunner.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/authworkflow/SecondFactorLayoutRunner.kt
@@ -21,10 +21,10 @@ import android.widget.EditText
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 
 internal class SecondFactorLayoutRunner(
@@ -37,7 +37,7 @@ internal class SecondFactorLayoutRunner(
 
   override fun showRendering(
     rendering: SecondFactorScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     view.backPressedHandler = { rendering.onCancel() }
     toolbar.setNavigationOnClickListener { rendering.onCancel() }

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GameOverLayoutRunner.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GameOverLayoutRunner.kt
@@ -26,10 +26,10 @@ import com.squareup.sample.gameworkflow.SyncState.SAVED
 import com.squareup.sample.gameworkflow.SyncState.SAVE_FAILED
 import com.squareup.sample.gameworkflow.SyncState.SAVING
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 
 internal class GameOverLayoutRunner(private val view: View) : LayoutRunner<GameOverScreen> {
@@ -48,7 +48,7 @@ internal class GameOverLayoutRunner(private val view: View) : LayoutRunner<GameO
 
   override fun showRendering(
     rendering: GameOverScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     exitItem.setOnMenuItemClickListener {
       rendering.onPlayAgain()

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GamePlayLayoutRunner.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/GamePlayLayoutRunner.kt
@@ -19,10 +19,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.Toolbar
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 
 internal class GamePlayLayoutRunner(private val view: View) : LayoutRunner<GamePlayScreen> {
@@ -31,7 +31,7 @@ internal class GamePlayLayoutRunner(private val view: View) : LayoutRunner<GameP
 
   override fun showRendering(
     rendering: GamePlayScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     renderBanner(rendering.gameState, rendering.playerInfo)
     rendering.gameState.board.render(boardView)

--- a/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/NewGameLayoutRunner.kt
+++ b/kotlin/samples/tictactoe/app/src/main/java/com/squareup/sample/gameworkflow/NewGameLayoutRunner.kt
@@ -19,10 +19,10 @@ import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import com.squareup.sample.tictactoe.R
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 
 internal class NewGameLayoutRunner(private val view: View) : LayoutRunner<NewGameScreen> {
@@ -33,7 +33,7 @@ internal class NewGameLayoutRunner(private val view: View) : LayoutRunner<NewGam
 
   override fun showRendering(
     rendering: NewGameScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     if (playerX.text.isBlank()) playerX.setText(rendering.defaultNameX)
     if (playerO.text.isBlank()) playerO.setText(rendering.defaultNameO)

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/ItemListView.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/ItemListView.kt
@@ -15,13 +15,13 @@
  */
 package com.squareup.sample.mainactivity
 
-import androidx.annotation.IdRes
 import android.text.style.StrikethroughSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.LinearLayout
+import androidx.annotation.IdRes
 import com.squareup.sample.todo.R
 
 class ItemListView private constructor(private val itemContainer: LinearLayout) {

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoEditorLayoutRunner.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoEditorLayoutRunner.kt
@@ -20,10 +20,10 @@ import android.widget.EditText
 import androidx.appcompat.widget.Toolbar
 import com.squareup.sample.todo.R
 import com.squareup.sample.todo.TodoRendering
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.backPressedHandler
 import com.squareup.workflow.ui.backstack.BackStackConfig
 import com.squareup.workflow.ui.backstack.BackStackConfig.Other
@@ -49,13 +49,13 @@ internal class TodoEditorLayoutRunner(private val view: View) : LayoutRunner<Tod
 
   override fun showRendering(
     rendering: TodoRendering,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     toolbar.title = rendering.list.title
     titleText.text.replace(0, titleText.text.length, rendering.list.title)
     itemContainer.setRows(rendering.list.rows.map { Pair(it.done, it.text) })
 
-    if (containerHints[BackStackConfig] == Other) {
+    if (viewEnvironment[BackStackConfig] == Other) {
       toolbar.setNavigationOnClickListener { rendering.onGoBackClicked() }
       view.backPressedHandler = { rendering.onGoBackClicked() }
     } else {

--- a/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoListsLayoutRunner.kt
+++ b/kotlin/samples/todo-android/app/src/main/java/com/squareup/sample/mainactivity/TodoListsLayoutRunner.kt
@@ -24,10 +24,10 @@ import com.squareup.sample.container.masterdetail.MasterDetailConfig.Master
 import com.squareup.sample.todo.R
 import com.squareup.sample.todo.TodoList
 import com.squareup.sample.todo.TodoListsScreen
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.LayoutRunner
 import com.squareup.workflow.ui.LayoutRunner.Companion.bind
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 
 internal class TodoListsLayoutRunner(view: View) : LayoutRunner<TodoListsScreen> {
   private val inflater = LayoutInflater.from(view.context)
@@ -35,14 +35,14 @@ internal class TodoListsLayoutRunner(view: View) : LayoutRunner<TodoListsScreen>
 
   override fun showRendering(
     rendering: TodoListsScreen,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
     for ((index, list) in rendering.lists.withIndex()) {
       addRow(
           index,
           list,
-          selectable = containerHints[MasterDetailConfig] == Master,
-          selected = index == rendering.selection && containerHints[MasterDetailConfig] == Master
+          selectable = viewEnvironment[MasterDetailConfig] == Master,
+          selected = index == rendering.selection && viewEnvironment[MasterDetailConfig] == Master
       ) { rendering.onRowClicked(index) }
     }
     pruneDeadRowsFrom(rendering.lists.size)

--- a/kotlin/trace-encoder/src/test/java/com/squareup/tracing/TraceEncoderTest.kt
+++ b/kotlin/trace-encoder/src/test/java/com/squareup/tracing/TraceEncoderTest.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.runBlocking
 import okio.Buffer
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.TimeMark
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
+import kotlin.time.TimeMark
 import kotlin.time.microseconds
 
 @OptIn(ExperimentalTime::class)

--- a/kotlin/workflow-tracing/src/test/java/com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListenerTest.kt
+++ b/kotlin/workflow-tracing/src/test/java/com/squareup/workflow/diagnostic/tracing/TracingDiagnosticListenerTest.kt
@@ -39,9 +39,9 @@ import okio.buffer
 import okio.source
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.TimeMark
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
+import kotlin.time.TimeMark
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TracingDiagnosticListenerTest {

--- a/kotlin/workflow-ui/backstack-android/api/backstack-android.api
+++ b/kotlin/workflow-ui/backstack-android/api/backstack-android.api
@@ -7,7 +7,7 @@ public final class com/squareup/workflow/ui/backstack/BackStackConfig : java/lan
 	public static fun values ()[Lcom/squareup/workflow/ui/backstack/BackStackConfig;
 }
 
-public final class com/squareup/workflow/ui/backstack/BackStackConfig$Companion : com/squareup/workflow/ui/ContainerHintKey {
+public final class com/squareup/workflow/ui/backstack/BackStackConfig$Companion : com/squareup/workflow/ui/ViewEnvironmentKey {
 	public fun getDefault ()Lcom/squareup/workflow/ui/backstack/BackStackConfig;
 	public synthetic fun getDefault ()Ljava/lang/Object;
 }
@@ -25,8 +25,8 @@ public class com/squareup/workflow/ui/backstack/BackStackContainer : android/wid
 }
 
 public final class com/squareup/workflow/ui/backstack/BackStackContainer$Companion : com/squareup/workflow/ui/ViewBinding {
-	public fun buildView (Lcom/squareup/workflow/ui/backstack/BackStackScreen;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
-	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun buildView (Lcom/squareup/workflow/ui/backstack/BackStackScreen;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 

--- a/kotlin/workflow-ui/backstack-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackConfig.kt
+++ b/kotlin/workflow-ui/backstack-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackConfig.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.workflow.ui.backstack
 
-import com.squareup.workflow.ui.ContainerHintKey
+import com.squareup.workflow.ui.ViewEnvironmentKey
 import com.squareup.workflow.ui.backstack.BackStackConfig.First
 import com.squareup.workflow.ui.backstack.BackStackConfig.Other
 
@@ -41,7 +41,7 @@ enum class BackStackConfig {
    */
   Other;
 
-  companion object : ContainerHintKey<BackStackConfig>(BackStackConfig::class) {
+  companion object : ViewEnvironmentKey<BackStackConfig>(BackStackConfig::class) {
     override val default = None
   }
 }

--- a/kotlin/workflow-ui/backstack-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
+++ b/kotlin/workflow-ui/backstack-android/src/main/java/com/squareup/workflow/ui/backstack/BackStackContainer.kt
@@ -29,9 +29,9 @@ import androidx.transition.Slide
 import androidx.transition.TransitionManager
 import androidx.transition.TransitionSet
 import com.squareup.workflow.ui.BuilderBinding
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.Named
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.backstack.BackStackConfig.First
 import com.squareup.workflow.ui.backstack.BackStackConfig.Other
@@ -58,10 +58,10 @@ open class BackStackContainer @JvmOverloads constructor(
 
   private fun update(
     newRendering: BackStackScreen<*>,
-    newContainerHints: ContainerHints
+    newViewEnvironment: ViewEnvironment
   ) {
     val config = if (newRendering.backStack.isEmpty()) First else Other
-    val hints = newContainerHints + (BackStackConfig to config)
+    val environment = newViewEnvironment + (BackStackConfig to config)
 
     val named: BackStackScreen<Named<*>> = newRendering
         // ViewStateCache requires that everything be Named.
@@ -75,11 +75,11 @@ open class BackStackContainer @JvmOverloads constructor(
         ?.takeIf { it.canShowRendering(named.top) }
         ?.let {
           viewStateCache.prune(named.frames)
-          it.showRendering(named.top, hints)
+          it.showRendering(named.top, environment)
           return
         }
 
-    val newView = hints[ViewRegistry].buildView(named.top, hints, this)
+    val newView = environment[ViewRegistry].buildView(named.top, environment, this)
     viewStateCache.update(named.backStack, oldViewMaybe, newView)
 
     val popped = currentRendering?.backStack?.any { compatible(it, named.top) } == true

--- a/kotlin/workflow-ui/core-android/api/core-android.api
+++ b/kotlin/workflow-ui/core-android/api/core-android.api
@@ -15,36 +15,18 @@ public final class com/squareup/workflow/ui/BuildConfig {
 
 public final class com/squareup/workflow/ui/BuilderBinding : com/squareup/workflow/ui/ViewBinding {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function4;)V
-	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
-}
-
-public abstract class com/squareup/workflow/ui/ContainerHintKey {
-	public fun <init> (Lkotlin/reflect/KClass;)V
-	public final fun equals (Ljava/lang/Object;)Z
-	public abstract fun getDefault ()Ljava/lang/Object;
-	public final fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/squareup/workflow/ui/ContainerHints {
-	public fun <init> (Lcom/squareup/workflow/ui/ViewRegistry;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun get (Lcom/squareup/workflow/ui/ContainerHintKey;)Ljava/lang/Object;
-	public fun hashCode ()I
-	public final fun plus (Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/ContainerHints;
-	public final fun plus (Lkotlin/Pair;)Lcom/squareup/workflow/ui/ContainerHints;
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/squareup/workflow/ui/LayoutRunner {
 	public static final field Companion Lcom/squareup/workflow/ui/LayoutRunner$Companion;
-	public abstract fun showRendering (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)V
+	public abstract fun showRendering (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)V
 }
 
 public final class com/squareup/workflow/ui/LayoutRunner$Binding : com/squareup/workflow/ui/ViewBinding {
 	public fun <init> (Lkotlin/reflect/KClass;ILkotlin/jvm/functions/Function1;)V
-	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 
@@ -56,14 +38,14 @@ public final class com/squareup/workflow/ui/LifecyclesKt {
 }
 
 public final class com/squareup/workflow/ui/ShowRenderingTag {
-	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;)V
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
 	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun component2 ()Lcom/squareup/workflow/ui/ViewEnvironment;
 	public final fun component3 ()Lkotlin/jvm/functions/Function2;
-	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/ui/ShowRenderingTag;
-	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/ShowRenderingTag;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/squareup/workflow/ui/ShowRenderingTag;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/ui/ShowRenderingTag;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/ShowRenderingTag;Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcom/squareup/workflow/ui/ShowRenderingTag;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getHints ()Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun getEnvironment ()Lcom/squareup/workflow/ui/ViewEnvironment;
 	public final fun getShowRendering ()Lkotlin/jvm/functions/Function2;
 	public final fun getShowing ()Ljava/lang/Object;
 	public fun hashCode ()I
@@ -71,51 +53,69 @@ public final class com/squareup/workflow/ui/ShowRenderingTag {
 }
 
 public abstract interface class com/squareup/workflow/ui/ViewBinding {
-	public abstract fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public abstract fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public abstract fun getType ()Lkotlin/reflect/KClass;
 }
 
 public final class com/squareup/workflow/ui/ViewBinding$DefaultImpls {
-	public static synthetic fun buildView$default (Lcom/squareup/workflow/ui/ViewBinding;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
+	public static synthetic fun buildView$default (Lcom/squareup/workflow/ui/ViewBinding;Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
+}
+
+public final class com/squareup/workflow/ui/ViewEnvironment {
+	public fun <init> (Lcom/squareup/workflow/ui/ViewRegistry;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (Lcom/squareup/workflow/ui/ViewEnvironmentKey;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun plus (Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/ViewEnvironment;
+	public final fun plus (Lkotlin/Pair;)Lcom/squareup/workflow/ui/ViewEnvironment;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/squareup/workflow/ui/ViewEnvironmentKey {
+	public fun <init> (Lkotlin/reflect/KClass;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public abstract fun getDefault ()Ljava/lang/Object;
+	public final fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/squareup/workflow/ui/ViewRegistry {
 	public static final field Companion Lcom/squareup/workflow/ui/ViewRegistry$Companion;
-	public abstract fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public abstract fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public abstract fun getKeys ()Ljava/util/Set;
 }
 
-public final class com/squareup/workflow/ui/ViewRegistry$Companion : com/squareup/workflow/ui/ContainerHintKey {
+public final class com/squareup/workflow/ui/ViewRegistry$Companion : com/squareup/workflow/ui/ViewEnvironmentKey {
 	public fun getDefault ()Lcom/squareup/workflow/ui/ViewRegistry;
 	public synthetic fun getDefault ()Ljava/lang/Object;
 }
 
 public final class com/squareup/workflow/ui/ViewRegistry$DefaultImpls {
-	public static synthetic fun buildView$default (Lcom/squareup/workflow/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
+	public static synthetic fun buildView$default (Lcom/squareup/workflow/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;ILjava/lang/Object;)Landroid/view/View;
 }
 
 public final class com/squareup/workflow/ui/ViewRegistryKt {
 	public static final fun ViewRegistry ()Lcom/squareup/workflow/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow/ui/ViewBinding;)Lcom/squareup/workflow/ui/ViewRegistry;
 	public static final fun ViewRegistry ([Lcom/squareup/workflow/ui/ViewRegistry;)Lcom/squareup/workflow/ui/ViewRegistry;
-	public static final fun buildView (Lcom/squareup/workflow/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/view/ViewGroup;)Landroid/view/View;
+	public static final fun buildView (Lcom/squareup/workflow/ui/ViewRegistry;Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/view/ViewGroup;)Landroid/view/View;
 	public static final fun plus (Lcom/squareup/workflow/ui/ViewRegistry;Lcom/squareup/workflow/ui/ViewBinding;)Lcom/squareup/workflow/ui/ViewRegistry;
 	public static final fun plus (Lcom/squareup/workflow/ui/ViewRegistry;Lcom/squareup/workflow/ui/ViewRegistry;)Lcom/squareup/workflow/ui/ViewRegistry;
 }
 
 public final class com/squareup/workflow/ui/ViewShowRenderingKt {
-	public static final fun bindShowRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function2;)V
+	public static final fun bindShowRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)V
 	public static final fun canShowRendering (Landroid/view/View;Ljava/lang/Object;)Z
-	public static final fun getHints (Landroid/view/View;)Lcom/squareup/workflow/ui/ContainerHints;
+	public static final fun getEnvironment (Landroid/view/View;)Lcom/squareup/workflow/ui/ViewEnvironment;
 	public static final fun getRendering (Landroid/view/View;)Ljava/lang/Object;
 	public static final fun getShowRendering (Landroid/view/View;)Lkotlin/jvm/functions/Function2;
-	public static final fun showRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)V
+	public static final fun showRendering (Landroid/view/View;Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)V
 }
 
 public abstract class com/squareup/workflow/ui/WorkflowFragment : androidx/fragment/app/Fragment {
 	public fun <init> ()V
-	protected abstract fun getContainerHints ()Lcom/squareup/workflow/ui/ContainerHints;
 	protected final fun getRunner ()Lcom/squareup/workflow/ui/WorkflowRunner;
+	protected abstract fun getViewEnvironment ()Lcom/squareup/workflow/ui/ViewEnvironment;
 	public fun onActivityCreated (Landroid/os/Bundle;)V
 	public synthetic fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
 	public final fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Lcom/squareup/workflow/ui/WorkflowLayout;
@@ -125,7 +125,7 @@ public abstract class com/squareup/workflow/ui/WorkflowFragment : androidx/fragm
 public final class com/squareup/workflow/ui/WorkflowLayout : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun start (Lio/reactivex/Observable;Lcom/squareup/workflow/ui/ContainerHints;)V
+	public final fun start (Lio/reactivex/Observable;Lcom/squareup/workflow/ui/ViewEnvironment;)V
 	public final fun start (Lio/reactivex/Observable;Lcom/squareup/workflow/ui/ViewRegistry;)V
 }
 
@@ -153,8 +153,8 @@ public final class com/squareup/workflow/ui/WorkflowRunner$Config {
 }
 
 public final class com/squareup/workflow/ui/WorkflowRunnerKt {
-	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/ui/WorkflowRunner;
-	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ContainerHints;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/ui/WorkflowRunner;
+	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ViewEnvironment;Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/ui/WorkflowRunner;
+	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ViewEnvironment;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/ui/WorkflowRunner;
 	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ViewRegistry;Lkotlin/jvm/functions/Function0;)Lcom/squareup/workflow/ui/WorkflowRunner;
 	public static final fun setContentWorkflow (Landroidx/fragment/app/FragmentActivity;Lcom/squareup/workflow/ui/ViewRegistry;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)Lcom/squareup/workflow/ui/WorkflowRunner;
 }
@@ -167,6 +167,6 @@ public final class com/squareup/workflow/ui/WorkflowViewStub : android/view/View
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getActual ()Landroid/view/View;
 	public final fun setActual (Landroid/view/View;)V
-	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Landroid/view/View;
+	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Landroid/view/View;
 }
 

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/BindingViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/BindingViewRegistry.kt
@@ -40,7 +40,7 @@ internal class BindingViewRegistry private constructor(
 
   override fun <RenderingT : Any> buildView(
     initialRendering: RenderingT,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup?
   ): View {
@@ -48,7 +48,7 @@ internal class BindingViewRegistry private constructor(
     return (bindings[initialRendering::class] as? ViewBinding<RenderingT>)
         ?.buildView(
             initialRendering,
-            initialContainerHints,
+            initialViewEnvironment,
             contextForNewView,
             container
         )

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/BuilderBinding.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/BuilderBinding.kt
@@ -55,15 +55,15 @@ class BuilderBinding<RenderingT : Any>(
   override val type: KClass<RenderingT>,
   private val viewConstructor: (
     initialRendering: RenderingT,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup?
   ) -> View
 ) : ViewBinding<RenderingT> {
   override fun buildView(
     initialRendering: RenderingT,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup?
-  ): View = viewConstructor(initialRendering, initialContainerHints, contextForNewView, container)
+  ): View = viewConstructor(initialRendering, initialViewEnvironment, contextForNewView, container)
 }

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/CompositeViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/CompositeViewRegistry.kt
@@ -44,7 +44,7 @@ internal class CompositeViewRegistry private constructor(
 
   override fun <RenderingT : Any> buildView(
     initialRendering: RenderingT,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup?
   ): View {
@@ -53,7 +53,7 @@ internal class CompositeViewRegistry private constructor(
             "A ${ViewBinding::class.java.name} should have been registered " +
                 "to display $initialRendering."
         )
-    return registry.buildView(initialRendering, initialContainerHints, contextForNewView, container)
+    return registry.buildView(initialRendering, initialViewEnvironment, contextForNewView, container)
   }
 
   companion object {

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/LayoutRunner.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/LayoutRunner.kt
@@ -55,7 +55,7 @@ import kotlin.reflect.KClass
 interface LayoutRunner<RenderingT : Any> {
   fun showRendering(
     rendering: RenderingT,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   )
 
   class Binding<RenderingT : Any>(
@@ -65,7 +65,7 @@ interface LayoutRunner<RenderingT : Any> {
   ) : ViewBinding<RenderingT> {
     override fun buildView(
       initialRendering: RenderingT,
-      initialContainerHints: ContainerHints,
+      initialViewEnvironment: ViewEnvironment,
       contextForNewView: Context,
       container: ViewGroup?
     ): View {
@@ -75,7 +75,7 @@ interface LayoutRunner<RenderingT : Any> {
           .apply {
             bindShowRendering(
                 initialRendering,
-                initialContainerHints,
+                initialViewEnvironment,
                 runnerConstructor.invoke(this)::showRendering
             )
           }
@@ -102,7 +102,7 @@ interface LayoutRunner<RenderingT : Any> {
       object : LayoutRunner<RenderingT> {
         override fun showRendering(
           rendering: RenderingT,
-          containerHints: ContainerHints
+          viewEnvironment: ViewEnvironment
         ) = Unit
       }
     }

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/NamedBinding.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/NamedBinding.kt
@@ -35,8 +35,8 @@ by BuilderBinding(
 
             val wrappedUpdater = view.getShowRendering<Any>()!!
 
-            view.bindShowRendering(initialRendering, initialHints) { rendering, hints ->
-              wrappedUpdater.invoke(rendering.wrapped, hints)
+            view.bindShowRendering(initialRendering, initialHints) { rendering, environment ->
+              wrappedUpdater.invoke(rendering.wrapped, environment)
             }
           }
     }

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewBinding.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewBinding.kt
@@ -36,7 +36,7 @@ interface ViewBinding<RenderingT : Any> {
    */
   fun buildView(
     initialRendering: RenderingT,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup? = null
   ): View

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewEnvironment.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewEnvironment.kt
@@ -17,41 +17,48 @@ package com.squareup.workflow.ui
 
 import kotlin.reflect.KClass
 
+@Suppress("unused")
+@Deprecated(
+    "Renamed to ViewEnvironment.",
+    replaceWith = ReplaceWith("ViewEnvironment", "com.squareup.workflow.ui.ViewEnvironment")
+)
+typealias ContainerHints = ViewEnvironment
+
 /**
  * Immutable, append-only map of values that a parent view can pass down to
  * its children via [View.showRendering][android.view.View.showRendering] et al.
  * Allows container views to give descendants information about the context in which
  * they're drawing.
  *
- * Every [ContainerHints] includes a [ViewRegistry]. This allows container views to
+ * Every [ViewEnvironment] includes a [ViewRegistry]. This allows container views to
  * make recursive [ViewRegistry.buildView] calls to build child views to show nested renderings.
  */
-class ContainerHints private constructor(
-  private val map: Map<ContainerHintKey<*>, Any>
+class ViewEnvironment private constructor(
+  private val map: Map<ViewEnvironmentKey<*>, Any>
 ) {
   constructor(registry: ViewRegistry) :
-      this(mapOf<ContainerHintKey<*>, Any>(ViewRegistry to registry))
+      this(mapOf<ViewEnvironmentKey<*>, Any>(ViewRegistry to registry))
 
   @Suppress("UNCHECKED_CAST")
-  operator fun <T : Any> get(key: ContainerHintKey<T>): T = map[key] as? T ?: key.default
+  operator fun <T : Any> get(key: ViewEnvironmentKey<T>): T = map[key] as? T ?: key.default
 
-  operator fun <T : Any> plus(pair: Pair<ContainerHintKey<T>, T>): ContainerHints =
-    ContainerHints(map + pair)
+  operator fun <T : Any> plus(pair: Pair<ViewEnvironmentKey<T>, T>): ViewEnvironment =
+    ViewEnvironment(map + pair)
 
-  operator fun plus(other: ContainerHints): ContainerHints = ContainerHints(map + other.map)
+  operator fun plus(other: ViewEnvironment): ViewEnvironment = ViewEnvironment(map + other.map)
 
-  override fun toString() = "ContainerHints($map)"
+  override fun toString() = "ViewEnvironment($map)"
 
-  override fun equals(other: Any?) = (other as? ContainerHints)?.let { it.map == map } ?: false
+  override fun equals(other: Any?) = (other as? ViewEnvironment)?.let { it.map == map } ?: false
 
   override fun hashCode() = map.hashCode()
 }
 
 /**
- * Defines a value that can be provided by a [ContainerHints] map, specifying its [type]
+ * Defines a value that can be provided by a [ViewEnvironment] map, specifying its [type]
  * and [default] value.
  */
-abstract class ContainerHintKey<T : Any>(
+abstract class ViewEnvironmentKey<T : Any>(
   private val type: KClass<T>
 ) {
   abstract val default: T
@@ -59,12 +66,12 @@ abstract class ContainerHintKey<T : Any>(
   final override fun equals(other: Any?) = when {
     this === other -> true
     other != null && this::class != other::class -> false
-    else -> type == (other as ContainerHintKey<*>).type
+    else -> type == (other as ViewEnvironmentKey<*>).type
   }
 
   final override fun hashCode() = type.hashCode()
 
   override fun toString(): String {
-    return "ContainerHintKey($type)-${super.toString()}"
+    return "ViewEnvironmentKey($type)-${super.toString()}"
   }
 }

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewRegistry.kt
@@ -79,12 +79,12 @@ interface ViewRegistry {
    */
   fun <RenderingT : Any> buildView(
     initialRendering: RenderingT,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup? = null
   ): View
 
-  companion object : ContainerHintKey<ViewRegistry>(ViewRegistry::class) {
+  companion object : ViewEnvironmentKey<ViewRegistry>(ViewRegistry::class) {
     override val default: ViewRegistry
       get() = error("There should always be a ViewRegistry hint, this is bug in Workflow.")
   }
@@ -117,9 +117,9 @@ fun ViewRegistry(): ViewRegistry = BindingViewRegistry()
  */
 fun <RenderingT : Any> ViewRegistry.buildView(
   initialRendering: RenderingT,
-  initialContainerHints: ContainerHints,
+  initialViewEnvironment: ViewEnvironment,
   container: ViewGroup
-): View = buildView(initialRendering, initialContainerHints, container.context, container)
+): View = buildView(initialRendering, initialViewEnvironment, container.context, container)
 
 operator fun ViewRegistry.plus(binding: ViewBinding<*>): ViewRegistry = this + ViewRegistry(binding)
 

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewShowRendering.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/ViewShowRendering.kt
@@ -21,7 +21,7 @@ import android.view.View
  * Function attached to a view created by [ViewRegistry], to allow it
  * to respond to [View.showRendering].
  */
-typealias ViewShowRendering<RenderingT> = (@UnsafeVariance RenderingT, ContainerHints) -> Unit
+typealias ViewShowRendering<RenderingT> = (@UnsafeVariance RenderingT, ViewEnvironment) -> Unit
 
 /**
 ` * View tag that holds the function to make the view show instances of [RenderingT], and
@@ -32,7 +32,7 @@ typealias ViewShowRendering<RenderingT> = (@UnsafeVariance RenderingT, Container
  */
 data class ShowRenderingTag<out RenderingT : Any>(
   val showing: RenderingT,
-  val hints: ContainerHints,
+  val environment: ViewEnvironment,
   val showRendering: ViewShowRendering<RenderingT>
 )
 
@@ -47,14 +47,14 @@ data class ShowRenderingTag<out RenderingT : Any>(
  */
 fun <RenderingT : Any> View.bindShowRendering(
   initialRendering: RenderingT,
-  initialContainerHints: ContainerHints,
+  initialViewEnvironment: ViewEnvironment,
   showRendering: ViewShowRendering<RenderingT>
 ) {
   setTag(
       R.id.view_show_rendering_function,
-      ShowRenderingTag(initialRendering, initialContainerHints, showRendering)
+      ShowRenderingTag(initialRendering, initialViewEnvironment, showRendering)
   )
-  showRendering.invoke(initialRendering, initialContainerHints)
+  showRendering.invoke(initialRendering, initialViewEnvironment)
 }
 
 /**
@@ -80,7 +80,7 @@ fun View.canShowRendering(rendering: Any): Boolean {
  */
 fun <RenderingT : Any> View.showRendering(
   rendering: RenderingT,
-  containerHints: ContainerHints
+  viewEnvironment: ViewEnvironment
 ) {
   showRenderingTag
       ?.let { tag ->
@@ -90,7 +90,7 @@ fun <RenderingT : Any> View.showRendering(
               "Consider using ${WorkflowViewStub::class.java.simpleName} to display arbitrary types."
         }
 
-        bindShowRendering(rendering, containerHints, tag.showRendering)
+        bindShowRendering(rendering, viewEnvironment, tag.showRendering)
       }
       ?: error(
           "Expected $this to have a showRendering function to show $rendering. " +
@@ -114,10 +114,10 @@ fun <RenderingT : Any> View.getRendering(): RenderingT? {
 }
 
 /**
- * Returns the most recent [ContainerHints] that apply to this view, or null if [bindShowRendering]
+ * Returns the most recent [ViewEnvironment] that apply to this view, or null if [bindShowRendering]
  * has never been called.
  */
-val View.hints: ContainerHints? get() = showRenderingTag?.hints
+val View.environment: ViewEnvironment? get() = showRenderingTag?.environment
 
 /**
  * Returns the function set by the most recent call to [bindShowRendering], or null

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowFragment.kt
@@ -60,7 +60,7 @@ abstract class WorkflowFragment<PropsT, OutputT : Any> : Fragment() {
   /**
    * Provides the [ViewRegistry] used to display workflow renderings.
    */
-  protected abstract val containerHints: ContainerHints
+  protected abstract val viewEnvironment: ViewEnvironment
 
   /**
    * Called from [onActivityCreated], so it should be safe for implementations
@@ -87,6 +87,6 @@ abstract class WorkflowFragment<PropsT, OutputT : Any> : Fragment() {
 
     _runner = WorkflowRunner.startWorkflow(this, ::onCreateWorkflow)
 
-    (view as WorkflowLayout).start(runner.renderings, containerHints)
+    (view as WorkflowLayout).start(runner.renderings, viewEnvironment)
   }
 }

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowLayout.kt
@@ -52,30 +52,30 @@ class WorkflowLayout(
     renderings: Observable<out Any>,
     registry: ViewRegistry
   ) {
-    start(renderings, ContainerHints(registry))
+    start(renderings, ViewEnvironment(registry))
   }
 
   /**
-   * Subscribes to [renderings], and uses the [ViewRegistry] in the given [hints] to
+   * Subscribes to [renderings], and uses the [ViewRegistry] in the given [environment] to
    * [build a new view][ViewRegistry.buildView] each time a new type of rendering is received,
    * making that view the only child of this one.
    */
   fun start(
     renderings: Observable<out Any>,
-    hints: ContainerHints
+    environment: ViewEnvironment
   ) {
-    val hintsWithDefaults = hints.withDefaultViewBindings()
+    val hintsWithDefaults = environment.withDefaultViewBindings()
     takeWhileAttached(renderings) { show(it, hintsWithDefaults) }
   }
 
-  private fun ContainerHints.withDefaultViewBindings(): ContainerHints =
+  private fun ViewEnvironment.withDefaultViewBindings(): ViewEnvironment =
     this + (ViewRegistry to (this[ViewRegistry] + defaultViewBindings))
 
   private fun show(
     newRendering: Any,
-    hints: ContainerHints
+    environment: ViewEnvironment
   ) {
-    showing.update(newRendering, hints)
+    showing.update(newRendering, environment)
     restoredChildState?.let { restoredState ->
       restoredChildState = null
       showing.actual.restoreHierarchyState(restoredState)

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowRunner.kt
@@ -140,7 +140,7 @@ interface WorkflowRunner<out OutputT : Any> {
  * It creates a [WorkflowRunner] for this activity, if one doesn't already exist, and
  * sets a view driven by that model as the content view.
  *
- * @param containerHints provides the [ViewRegistry] used to display workflow renderings.
+ * @param viewEnvironment provides the [ViewRegistry] used to display workflow renderings.
  *
  * @param configure function defining the root workflow and its environment. Called only
  * once per [lifecycle][FragmentActivity.getLifecycle], and always called from the UI thread.
@@ -151,14 +151,14 @@ interface WorkflowRunner<out OutputT : Any> {
  * only while the activity is active, and always called from the UI thread.
  */
 fun <PropsT, OutputT : Any> FragmentActivity.setContentWorkflow(
-  containerHints: ContainerHints,
+  viewEnvironment: ViewEnvironment,
   configure: () -> Config<PropsT, OutputT>,
   onResult: (OutputT) -> Unit
 ): WorkflowRunner<OutputT> {
   val runner = WorkflowRunner.startWorkflow(this, configure)
   val layout = WorkflowLayout(this@setContentWorkflow).apply {
     id = R.id.workflow_layout
-    start(runner.renderings, containerHints)
+    start(runner.renderings, viewEnvironment)
   }
 
   runner.result.toFlowable()
@@ -189,7 +189,7 @@ fun <PropsT, OutputT : Any> FragmentActivity.setContentWorkflow(
   registry: ViewRegistry,
   configure: () -> Config<PropsT, OutputT>,
   onResult: (OutputT) -> Unit
-): WorkflowRunner<OutputT> = setContentWorkflow(ContainerHints(registry), configure, onResult)
+): WorkflowRunner<OutputT> = setContentWorkflow(ViewEnvironment(registry), configure, onResult)
 
 /**
  * For workflows that produce no output, call this method from [FragmentActivity.onCreate]
@@ -197,15 +197,15 @@ fun <PropsT, OutputT : Any> FragmentActivity.setContentWorkflow(
  * It creates a [WorkflowRunner] for this activity, if one doesn't already exist, and
  * sets a view driven by that model as the content view.
  *
- * @param containerHints provides the [ViewRegistry] used to display workflow renderings.
+ * @param viewEnvironment provides the [ViewRegistry] used to display workflow renderings.
  *
  * @param configure function defining the root workflow and its environment. Called only
  * once per [lifecycle][FragmentActivity.getLifecycle], and always called from the UI thread.
  */
 fun <PropsT> FragmentActivity.setContentWorkflow(
-  containerHints: ContainerHints,
+  viewEnvironment: ViewEnvironment,
   configure: () -> Config<PropsT, Nothing>
-): WorkflowRunner<Nothing> = setContentWorkflow(containerHints, configure) {}
+): WorkflowRunner<Nothing> = setContentWorkflow(viewEnvironment, configure) {}
 
 /**
  * For workflows that produce no output, call this method from [FragmentActivity.onCreate]
@@ -221,4 +221,4 @@ fun <PropsT> FragmentActivity.setContentWorkflow(
 fun <PropsT> FragmentActivity.setContentWorkflow(
   registry: ViewRegistry,
   configure: () -> Config<PropsT, Nothing>
-): WorkflowRunner<Nothing> = setContentWorkflow(ContainerHints(registry), configure) {}
+): WorkflowRunner<Nothing> = setContentWorkflow(ViewEnvironment(registry), configure) {}

--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/WorkflowViewStub.kt
@@ -46,9 +46,9 @@ import android.view.ViewGroup
  *
  *       override fun showRendering(
  *          rendering: YourRendering,
- *          containerHints: ContainerHints
+ *          viewEnvironment: ViewEnvironment
  *       ) {
- *         child.update(rendering.childRendering, containerHints)
+ *         child.update(rendering.childRendering, viewEnvironment)
  *       }
  *     }
  * ```
@@ -83,18 +83,18 @@ class WorkflowViewStub @JvmOverloads constructor(
    */
   fun update(
     rendering: Any,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ): View {
     actual.takeIf { it.canShowRendering(rendering) }
         ?.let {
-          it.showRendering(rendering, containerHints)
+          it.showRendering(rendering, viewEnvironment)
           return it
         }
 
     return when (val parent = actual.parent) {
-      is ViewGroup -> containerHints[ViewRegistry].buildView(rendering, containerHints, parent)
+      is ViewGroup -> viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, parent)
           .also { buildNewViewAndReplaceOldView(parent, it) }
-      else -> containerHints[ViewRegistry].buildView(rendering, containerHints, actual.context)
+      else -> viewEnvironment[ViewRegistry].buildView(rendering, viewEnvironment, actual.context)
     }.also { actual = it }
   }
 

--- a/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/CompositeViewRegistryTest.kt
+++ b/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/CompositeViewRegistryTest.kt
@@ -106,7 +106,7 @@ class CompositeViewRegistryTest {
 
     override fun <RenderingT : Any> buildView(
       initialRendering: RenderingT,
-      initialContainerHints: ContainerHints,
+      initialViewEnvironment: ViewEnvironment,
       contextForNewView: Context,
       container: ViewGroup?
     ): View = bindings.getValue(initialRendering::class)

--- a/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/TestBinding.kt
+++ b/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/TestBinding.kt
@@ -23,13 +23,13 @@ import kotlin.reflect.KClass
 import kotlin.test.fail
 
 fun <R : Any> ViewRegistry.buildView(rendering: R): View =
-  buildView(rendering, ContainerHints(this), mock())
+  buildView(rendering, ViewEnvironment(this), mock())
 
 class TestBinding<R : Any>(override val type: KClass<R>) :
     ViewBinding<R> {
   override fun buildView(
     initialRendering: R,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup?
   ): View {

--- a/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/ViewEnvironmentTest.kt
+++ b/kotlin/workflow-ui/core-android/src/test/java/com/squareup/workflow/ui/ViewEnvironmentTest.kt
@@ -18,12 +18,12 @@ package com.squareup.workflow.ui
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-class ContainerHintsTest {
-  private object StringHint : ContainerHintKey<String>(String::class) {
+class ViewEnvironmentTest {
+  private object StringHint : ViewEnvironmentKey<String>(String::class) {
     override val default = ""
   }
 
-  private object OtherStringHint : ContainerHintKey<String>(String::class) {
+  private object OtherStringHint : ViewEnvironmentKey<String>(String::class) {
     override val default = ""
   }
 
@@ -31,24 +31,24 @@ class ContainerHintsTest {
     val int: Int = -1,
     val string: String = ""
   ) {
-    companion object : ContainerHintKey<DataHint>(DataHint::class) {
+    companion object : ViewEnvironmentKey<DataHint>(DataHint::class) {
       override val default = DataHint()
     }
   }
 
-  private val emptyHints = ContainerHints(ViewRegistry())
+  private val emptyHints = ViewEnvironment(ViewRegistry())
 
   @Test fun defaults() {
     assertThat(emptyHints[DataHint]).isEqualTo(DataHint())
   }
 
   @Test fun put() {
-    val hints = emptyHints +
+    val environment = emptyHints +
         (StringHint to "fnord") +
         (DataHint to DataHint(42, "foo"))
 
-    assertThat(hints[StringHint]).isEqualTo("fnord")
-    assertThat(hints[DataHint]).isEqualTo(DataHint(42, "foo"))
+    assertThat(environment[StringHint]).isEqualTo("fnord")
+    assertThat(environment[DataHint]).isEqualTo(DataHint(42, "foo"))
   }
 
   @Test fun `map equality`() {
@@ -84,19 +84,19 @@ class ContainerHintsTest {
   }
 
   @Test fun override() {
-    val hints = emptyHints +
+    val environment = emptyHints +
         (StringHint to "able") +
         (StringHint to "baker")
 
-    assertThat(hints[StringHint]).isEqualTo("baker")
+    assertThat(environment[StringHint]).isEqualTo("baker")
   }
 
   @Test fun `keys of the same type`() {
-    val hints = emptyHints +
+    val environment = emptyHints +
         (StringHint to "able") +
         (OtherStringHint to "baker")
 
-    assertThat(hints[StringHint]).isEqualTo("able")
-    assertThat(hints[OtherStringHint]).isEqualTo("baker")
+    assertThat(environment[StringHint]).isEqualTo("able")
+    assertThat(environment[OtherStringHint]).isEqualTo("baker")
   }
 }

--- a/kotlin/workflow-ui/core-compose/api/core-compose.api
+++ b/kotlin/workflow-ui/core-compose/api/core-compose.api
@@ -1,6 +1,6 @@
 public final class com/squareup/workflow/ui/compose/ComposeViewBinding : com/squareup/workflow/ui/ViewBinding {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function2;)V
-	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 

--- a/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewBinding.kt
+++ b/kotlin/workflow-ui/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewBinding.kt
@@ -24,8 +24,8 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.Composable
 import androidx.ui.core.setContent
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.bindShowRendering
 import kotlin.reflect.KClass
 
@@ -54,20 +54,20 @@ import kotlin.reflect.KClass
  * ```
  */
 inline fun <reified RenderingT : Any> bindCompose(
-  noinline showRendering: @Composable() (RenderingT, ContainerHints) -> Unit
-): ViewBinding<RenderingT> = ComposeViewBinding(RenderingT::class) { rendering, hints ->
-  showRendering(rendering, hints)
+  noinline showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
+): ViewBinding<RenderingT> = ComposeViewBinding(RenderingT::class) { rendering, environment ->
+  showRendering(rendering, environment)
 }
 
 @PublishedApi
 internal class ComposeViewBinding<RenderingT : Any>(
   override val type: KClass<RenderingT>,
-  private val showRendering: @Composable() (RenderingT, ContainerHints) -> Unit
+  private val showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
 ) : ViewBinding<RenderingT> {
 
   override fun buildView(
     initialRendering: RenderingT,
-    initialContainerHints: ContainerHints,
+    initialViewEnvironment: ViewEnvironment,
     contextForNewView: Context,
     container: ViewGroup?
   ): View {
@@ -76,10 +76,10 @@ internal class ComposeViewBinding<RenderingT : Any>(
     val composeContainer = FrameLayout(contextForNewView)
     composeContainer.bindShowRendering(
         initialRendering,
-        initialContainerHints
-    ) { rendering, hints ->
+        initialViewEnvironment
+    ) { rendering, environment ->
       composeContainer.setContent {
-        showRendering(rendering, hints)
+        showRendering(rendering, environment)
       }
     }
     return composeContainer

--- a/kotlin/workflow-ui/modal-android/api/modal-android.api
+++ b/kotlin/workflow-ui/modal-android/api/modal-android.api
@@ -6,12 +6,12 @@ public final class com/squareup/workflow/ui/modal/AlertContainer : com/squareup/
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;III)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	public synthetic fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
 }
 
 public final class com/squareup/workflow/ui/modal/AlertContainer$Companion : com/squareup/workflow/ui/ViewBinding {
-	public fun buildView (Lcom/squareup/workflow/ui/modal/AlertContainerScreen;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
-	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun buildView (Lcom/squareup/workflow/ui/modal/AlertContainerScreen;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public final fun customThemeBinding (I)Lcom/squareup/workflow/ui/ViewBinding;
 	public static synthetic fun customThemeBinding$default (Lcom/squareup/workflow/ui/modal/AlertContainer$Companion;IILjava/lang/Object;)Lcom/squareup/workflow/ui/ViewBinding;
 	public fun getType ()Lkotlin/reflect/KClass;
@@ -32,27 +32,27 @@ public abstract class com/squareup/workflow/ui/modal/ModalContainer : android/wi
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected abstract fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	protected abstract fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
 	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
-	protected final fun update (Lcom/squareup/workflow/ui/modal/HasModals;Lcom/squareup/workflow/ui/ContainerHints;)V
+	protected final fun update (Lcom/squareup/workflow/ui/modal/HasModals;Lcom/squareup/workflow/ui/ViewEnvironment;)V
 	protected abstract fun updateDialog (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;)V
 }
 
 protected final class com/squareup/workflow/ui/modal/ModalContainer$DialogRef {
-	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;)V
-	public synthetic fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Lcom/squareup/workflow/ui/ContainerHints;
+	public final fun component2 ()Lcom/squareup/workflow/ui/ViewEnvironment;
 	public final fun component3 ()Landroid/app/Dialog;
 	public final fun component4 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
-	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/app/Dialog;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	public final fun copy (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	public static synthetic fun copy$default (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/app/Dialog;Ljava/lang/Object;ILjava/lang/Object;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getContainerHints ()Lcom/squareup/workflow/ui/ContainerHints;
 	public final fun getDialog ()Landroid/app/Dialog;
 	public final fun getExtra ()Ljava/lang/Object;
 	public final fun getModalRendering ()Ljava/lang/Object;
+	public final fun getViewEnvironment ()Lcom/squareup/workflow/ui/ViewEnvironment;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -64,15 +64,15 @@ public class com/squareup/workflow/ui/modal/ModalViewContainer : com/squareup/wo
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected final fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
+	protected final fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
 	public fun buildDialogForView (Landroid/view/View;)Landroid/app/Dialog;
 	protected fun updateDialog (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;)V
 }
 
 public final class com/squareup/workflow/ui/modal/ModalViewContainer$Binding : com/squareup/workflow/ui/ViewBinding {
 	public fun <init> (ILkotlin/reflect/KClass;)V
-	public fun buildView (Lcom/squareup/workflow/ui/modal/HasModals;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
-	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ContainerHints;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public fun buildView (Lcom/squareup/workflow/ui/modal/HasModals;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
+	public synthetic fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 

--- a/kotlin/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/AlertContainer.kt
+++ b/kotlin/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/AlertContainer.kt
@@ -24,8 +24,8 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AlertDialog
 import com.squareup.workflow.ui.BuilderBinding
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.bindShowRendering
 import com.squareup.workflow.ui.modal.AlertScreen.Button
 import com.squareup.workflow.ui.modal.AlertScreen.Button.NEGATIVE
@@ -47,11 +47,11 @@ class AlertContainer @JvmOverloads constructor(
 
   override fun buildDialog(
     initialModalRendering: AlertScreen,
-    initialContainerHints: ContainerHints
+    initialViewEnvironment: ViewEnvironment
   ): DialogRef<AlertScreen> {
     val dialog = AlertDialog.Builder(context, dialogThemeResId)
         .create()
-    val ref = DialogRef(initialModalRendering, initialContainerHints, dialog)
+    val ref = DialogRef(initialModalRendering, initialViewEnvironment, dialog)
     updateDialog(ref)
     return ref
   }

--- a/kotlin/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/ModalContainer.kt
+++ b/kotlin/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/ModalContainer.kt
@@ -30,8 +30,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.Named
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.WorkflowViewStub
 import com.squareup.workflow.ui.compatible
 import com.squareup.workflow.ui.lifecycleOrNull
@@ -56,17 +56,17 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
 
   protected fun update(
     newScreen: HasModals<*, ModalRenderingT>,
-    containerHints: ContainerHints
+    viewEnvironment: ViewEnvironment
   ) {
-    baseView.update(newScreen.beneathModals, containerHints)
+    baseView.update(newScreen.beneathModals, viewEnvironment)
 
     val newDialogs = mutableListOf<DialogRef<ModalRenderingT>>()
     for ((i, modal) in newScreen.modals.withIndex()) {
       newDialogs += if (i < dialogs.size && compatible(dialogs[i].modalRendering, modal)) {
-        dialogs[i].copy(modalRendering = modal, containerHints = containerHints)
+        dialogs[i].copy(modalRendering = modal, viewEnvironment = viewEnvironment)
             .also { updateDialog(it) }
       } else {
-        buildDialog(modal, containerHints).apply {
+        buildDialog(modal, viewEnvironment).apply {
           dialog.show()
           // Android makes a lot of logcat noise if it has to close the window for us. :/
           // https://github.com/square/workflow/issues/51
@@ -85,7 +85,7 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
    */
   protected abstract fun buildDialog(
     initialModalRendering: ModalRenderingT,
-    initialContainerHints: ContainerHints
+    initialViewEnvironment: ViewEnvironment
   ): DialogRef<ModalRenderingT>
 
   protected abstract fun updateDialog(dialogRef: DialogRef<ModalRenderingT>)
@@ -139,7 +139,7 @@ abstract class ModalContainer<ModalRenderingT : Any> @JvmOverloads constructor(
    */
   protected data class DialogRef<ModalRenderingT : Any>(
     val modalRendering: ModalRenderingT,
-    val containerHints: ContainerHints,
+    val viewEnvironment: ViewEnvironment,
     val dialog: Dialog,
     val extra: Any? = null
   ) {

--- a/kotlin/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/ModalViewContainer.kt
+++ b/kotlin/workflow-ui/modal-android/src/main/java/com/squareup/workflow/ui/modal/ModalViewContainer.kt
@@ -26,8 +26,8 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import androidx.annotation.IdRes
 import com.squareup.workflow.ui.BuilderBinding
-import com.squareup.workflow.ui.ContainerHints
 import com.squareup.workflow.ui.ViewBinding
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.backPressedHandler
 import com.squareup.workflow.ui.bindShowRendering
@@ -73,10 +73,10 @@ open class ModalViewContainer @JvmOverloads constructor(
 
   final override fun buildDialog(
     initialModalRendering: Any,
-    initialContainerHints: ContainerHints
+    initialViewEnvironment: ViewEnvironment
   ): DialogRef<Any> {
-    val view = initialContainerHints[ViewRegistry]
-        .buildView(initialModalRendering, initialContainerHints, this)
+    val view = initialViewEnvironment[ViewRegistry]
+        .buildView(initialModalRendering, initialViewEnvironment, this)
         .apply {
           // If the modal's root view has no backPressedHandler, add a no-op one to
           // ensure that the `onBackPressed` call below will not leak up to handlers
@@ -108,12 +108,12 @@ open class ModalViewContainer @JvmOverloads constructor(
           }
         }
         .run {
-          DialogRef(initialModalRendering, initialContainerHints, this, view)
+          DialogRef(initialModalRendering, initialViewEnvironment, this, view)
         }
   }
 
   override fun updateDialog(dialogRef: DialogRef<Any>) {
-    with(dialogRef) { (extra as View).showRendering(modalRendering, containerHints) }
+    with(dialogRef) { (extra as View).showRendering(modalRendering, viewEnvironment) }
   }
 
   @PublishedApi


### PR DESCRIPTION
Closes #1000.

Keeps `ContainerHints` around as a deprecated type alias with replacement action.