### PR TITLE
Enable AndroidX test orchestrator to try to reduce flakiness.

### DIFF
--- a/kotlin/.buildscript/android-ui-tests.gradle
+++ b/kotlin/.buildscript/android-ui-tests.gradle
@@ -1,0 +1,10 @@
+android {
+  defaultConfig {
+    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+  }
+}
+
+dependencies {
+  androidTestImplementation deps.test.androidx.espresso.core
+  androidTestImplementation deps.test.androidx.junitExt
+}

--- a/kotlin/.buildscript/android-ui-tests.gradle
+++ b/kotlin/.buildscript/android-ui-tests.gradle
@@ -1,10 +1,21 @@
 android {
   defaultConfig {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+    // The following argument makes the Android Test Orchestrator run its
+    // "pm clear" command after each test invocation. This command ensures
+    // that the app's state is completely cleared between tests.
+    testInstrumentationRunnerArguments clearPackageData: 'true'
+  }
+
+  testOptions {
+    execution 'ANDROIDX_TEST_ORCHESTRATOR'
   }
 }
 
 dependencies {
+  androidTestUtil 'androidx.test:orchestrator:1.2.0'
+
   androidTestImplementation deps.test.androidx.espresso.core
   androidTestImplementation deps.test.androidx.junitExt
 }

--- a/kotlin/samples/containers/app-poetry/build.gradle
+++ b/kotlin/samples/containers/app-poetry/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -25,8 +26,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   testOptions {
@@ -45,7 +44,4 @@ dependencies {
   implementation deps.androidx.recyclerview
   implementation deps.rxjava2.rxjava2
   implementation deps.timber
-
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
 }

--- a/kotlin/samples/containers/app-raven/build.gradle
+++ b/kotlin/samples/containers/app-raven/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -25,8 +26,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 }
 
@@ -40,7 +39,4 @@ dependencies {
   implementation deps.androidx.appcompat
   implementation deps.rxjava2.rxjava2
   implementation deps.timber
-
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
 }

--- a/kotlin/samples/containers/hello-back-button/build.gradle
+++ b/kotlin/samples/containers/hello-back-button/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -25,8 +26,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 }
 
@@ -38,7 +37,4 @@ dependencies {
 
   implementation deps.androidx.appcompat
   implementation deps.rxjava2.rxjava2
-
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
 }

--- a/kotlin/samples/dungeon/app/build.gradle
+++ b/kotlin/samples/dungeon/app/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -26,8 +27,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "com.squareup.sample.dungeon.DungeonTestRunner"
   }
 
   testOptions {
@@ -65,7 +64,5 @@ dependencies {
   testImplementation deps.test.junit
   testImplementation deps.test.truth
 
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
   androidTestImplementation deps.test.androidx.uiautomator
 }

--- a/kotlin/samples/hello-compose-binding/build.gradle
+++ b/kotlin/samples/hello-compose-binding/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -25,8 +26,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   // See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940
@@ -51,6 +50,5 @@ dependencies {
   implementation deps.rxjava2.rxjava2
 
   androidTestImplementation deps.compose.test
-  androidTestImplementation deps.test.androidx.junitExt
   androidTestImplementation deps.test.junit
 }

--- a/kotlin/samples/hello-workflow-fragment/build.gradle
+++ b/kotlin/samples/hello-workflow-fragment/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -25,8 +26,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 }
 
@@ -37,7 +36,4 @@ dependencies {
 
   implementation deps.androidx.appcompat
   implementation deps.rxjava2.rxjava2
-
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
 }

--- a/kotlin/samples/hello-workflow/build.gradle
+++ b/kotlin/samples/hello-workflow/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -25,8 +26,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 }
 
@@ -37,7 +36,4 @@ dependencies {
 
   implementation deps.androidx.appcompat
   implementation deps.rxjava2.rxjava2
-
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
 }

--- a/kotlin/samples/recyclerview/build.gradle
+++ b/kotlin/samples/recyclerview/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -25,8 +26,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 }
 
@@ -41,7 +40,4 @@ dependencies {
   implementation deps.kotlin.coroutines.core
   implementation deps.rxjava2.rxjava2
   implementation deps.timber
-
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
 }

--- a/kotlin/samples/tictactoe/app/build.gradle
+++ b/kotlin/samples/tictactoe/app/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -26,8 +27,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   testOptions.unitTests.includeAndroidResources = true
@@ -50,9 +49,7 @@ dependencies {
   implementation deps.test.androidx.espresso.idlingResource
   implementation deps.timber
 
-  androidTestImplementation deps.test.androidx.espresso.core
   androidTestImplementation deps.test.androidx.espresso.intents
-  androidTestImplementation deps.test.androidx.junitExt
   androidTestImplementation deps.test.androidx.runner
   androidTestImplementation deps.test.androidx.truthExt
   androidTestImplementation deps.test.junit

--- a/kotlin/samples/todo-android/app/build.gradle
+++ b/kotlin/samples/todo-android/app/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android rootProject.ext.defaultAndroidConfig
+apply from: rootProject.file('.buildscript/android-ui-tests.gradle')
 
 android {
   defaultConfig {
@@ -26,8 +27,6 @@ android {
     targetSdkVersion versions.targetSdk
     versionCode 1
     versionName "1.0.0"
-
-    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 
   testOptions {
@@ -55,7 +54,5 @@ dependencies {
   testImplementation deps.test.junit
   testImplementation deps.test.truth
 
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
   androidTestImplementation deps.test.androidx.uiautomator
 }


### PR DESCRIPTION
2 commits:
1. Factor out Android UI test gradle config into a separate file.
2. Enable AndroidX test orchestrator to try to reduce flakiness.

Note this was originally attempted in #912, but we never got it working.