### PR TITLE
Require Signals to get wrapped in a Worker

### DIFF
--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -185,7 +185,7 @@ extension DemoWorkflow {
             subscribeTitle = "Subscribe"
         case .subscribing:
             // Subscribe to the timer signal, simulating the title being tapped.
-            context.awaitResult(for: SignalWorker(key: "Timer", signal: state.signal.signal)) { _ -> Action in
+            context.awaitResult(for: state.signal.signal.asWorker(key: "Timer")) { _ -> Action in
                 return .titleButtonTapped
             }
             subscribeTitle = "Stop"

--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -185,7 +185,7 @@ extension DemoWorkflow {
             subscribeTitle = "Subscribe"
         case .subscribing:
             // Subscribe to the timer signal, simulating the title being tapped.
-            context.awaitResult(for: SignalWorker(signal: state.signal.signal)) { _ -> Action in
+            context.awaitResult(for: SignalWorker(key: "Timer", signal: state.signal.signal)) { _ -> Action in
                 return .titleButtonTapped
             }
             subscribeTitle = "Stop"

--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -185,9 +185,9 @@ extension DemoWorkflow {
             subscribeTitle = "Subscribe"
         case .subscribing:
             // Subscribe to the timer signal, simulating the title being tapped.
-            context.subscribe(signal: state.signal.signal.map({ _ -> Action in
+            context.awaitResult(for: SignalWorker(signal: state.signal.signal)) { _ -> Action in
                 return .titleButtonTapped
-            }))
+            }
             subscribeTitle = "Stop"
         }
 

--- a/swift/Workflow/Sources/RenderContext.swift
+++ b/swift/Workflow/Sources/RenderContext.swift
@@ -71,10 +71,6 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         fatalError()
     }
 
-    public func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, WorkflowType == Action.WorkflowType {
-        fatalError()
-    }
-
     public func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
         fatalError()
     }
@@ -108,12 +104,6 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
             return implementation.makeSink(of: actionType)
         }
 
-        override func subscribe<Action>(signal: Signal<Action, Never>) where WorkflowType == Action.WorkflowType, Action : WorkflowAction {
-            assertStillValid()
-            return implementation.subscribe(signal: signal)
-        }
-
-
         override func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
             assertStillValid()
             implementation.awaitResult(for: worker, outputMap: outputMap)
@@ -134,8 +124,6 @@ internal protocol RenderContextType: class {
     func render<Child, Action>(workflow: Child, key: String, outputMap: @escaping (Child.Output) -> Action) -> Child.Rendering where Child: Workflow, Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
     func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where Action: WorkflowAction, Action.WorkflowType == WorkflowType
-
-    func subscribe<Action>(signal: Signal<Action, Never>) where Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
     

--- a/swift/Workflow/Sources/SignalWorker.swift
+++ b/swift/Workflow/Sources/SignalWorker.swift
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ReactiveSwift
+
+/// A `Worker` that wraps a `Signal`
+public struct SignalWorker<Key: Equatable, Value>: Worker {
+    let key: Key
+    let signal: Signal<Value, Never>
+
+    public init(key: Key, signal: Signal<Value, Never>) {
+        self.key = key
+        self.signal = signal
+    }
+
+    public func run() -> SignalProducer<Value, Never> {
+        return SignalProducer(signal)
+    }
+
+    public func isEquivalent(to otherWorker: SignalWorker) -> Bool {
+        return key == otherWorker.key
+    }
+}
+
+extension Signal where Error == Never {
+    public func asWorker<Key: Equatable>(key: Key) -> SignalWorker<Key, Value> {
+        return SignalWorker(key: key, signal: self)
+    }
+}

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -36,9 +36,6 @@ extension WorkflowNode {
         /// The current array of workers
         private (set) internal var childWorkers: [AnyChildWorker] = []
 
-        /// Subscriptions from the outside world.
-        private var subscriptions: Subscriptions = Subscriptions(eventSources: [], eventPipe: EventPipe())
-
         init() {}
 
         /// Performs an update pass using the given closure.
@@ -67,8 +64,6 @@ extension WorkflowNode {
             /// as a result of this call to `render`.
             self.childWorkflows = context.usedChildWorkflows
             self.childWorkers = context.usedChildWorkers
-            /// Merge all of the signals together from the subscriptions.
-            self.subscriptions = Subscriptions(eventSources: context.eventSources, eventPipe: EventPipe())
 
             /// Captured the reusable sinks from this render pass.
             self.previousSinks = context.sinkStore.usedSinks
@@ -76,7 +71,6 @@ extension WorkflowNode {
             /// Capture all the pipes to be enabled after render completes.
             self.eventPipes = context.eventPipes
             self.eventPipes.append(contentsOf: context.sinkStore.eventPipes)
-            self.eventPipes.append(self.subscriptions.eventPipe)
 
             /// Set all event pipes to `pending`.
             self.eventPipes.forEach { $0.setPending() }
@@ -157,8 +151,6 @@ extension WorkflowNode.SubtreeManager {
 
         private let originalChildWorkers: [AnyChildWorker]
         private (set) internal var usedChildWorkers: [AnyChildWorker]
-
-        private (set) internal var eventSources: [Signal<AnyWorkflowAction<WorkflowType>, Never>] = []
 
         internal init(previousSinks: [ObjectIdentifier:AnyReusableSink], originalChildWorkflows: [ChildKey:AnyChildWorkflow], originalChildWorkers: [AnyChildWorker]) {
             self.eventPipes = []
@@ -463,31 +455,6 @@ extension WorkflowNode.SubtreeManager {
 
     }
 
-}
-
-
-// MARK: - Subscriptions
-
-extension WorkflowNode.SubtreeManager {
-    fileprivate final class Subscriptions {
-        private var (lifetime, token) = Lifetime.make()
-        private (set) internal var eventPipe: EventPipe
-
-        init(eventSources: [Signal<AnyWorkflowAction<WorkflowType>, Never>], eventPipe: EventPipe) {
-            self.eventPipe = eventPipe
-
-            Signal
-                .merge(eventSources)
-                .map({ action -> Output in
-                    return Output.update(action, source: .external)
-                })
-                .observe(on: QueueScheduler.workflowExecution)
-                .take(during: lifetime)
-                .observeValues({ output in
-                    eventPipe.handle(event: output)
-                })
-        }
-    }
 }
 
 

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -228,10 +228,6 @@ extension WorkflowNode.SubtreeManager {
             return sink
         }
 
-        func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, WorkflowType == Action.WorkflowType {
-            eventSources.append(signal.map { AnyWorkflowAction($0) })
-        }
-
         func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
 
             let outputMap = { AnyWorkflowAction(outputMap($0)) }

--- a/swift/Workflow/Sources/Worker.swift
+++ b/swift/Workflow/Sources/Worker.swift
@@ -63,3 +63,9 @@ public struct SignalWorker<Key: Equatable, Value>: Worker {
         return key == otherWorker.key
     }
 }
+
+extension Signal where Error == Never {
+    public func asWorker<Key: Equatable>(key: Key) -> SignalWorker<Key, Value> {
+        return SignalWorker(key: key, signal: self)
+    }
+}

--- a/swift/Workflow/Sources/Worker.swift
+++ b/swift/Workflow/Sources/Worker.swift
@@ -46,10 +46,12 @@ extension Worker where Self: Equatable {
 }
 
 /// A Worker that wraps a `Signal`
-public struct SignalWorker<Value>: Worker {
+public struct SignalWorker<Key: Equatable, Value>: Worker {
+    let key: Key
     let signal: Signal<Value, Never>
 
-    public init(signal: Signal<Value, Never>) {
+    public init(key: Key, signal: Signal<Value, Never>) {
+        self.key = key
         self.signal = signal
     }
 
@@ -58,6 +60,6 @@ public struct SignalWorker<Value>: Worker {
     }
 
     public func isEquivalent(to otherWorker: SignalWorker) -> Bool {
-        return true
+        return key == otherWorker.key
     }
 }

--- a/swift/Workflow/Sources/Worker.swift
+++ b/swift/Workflow/Sources/Worker.swift
@@ -44,28 +44,3 @@ extension Worker where Self: Equatable {
     }
 
 }
-
-/// A Worker that wraps a `Signal`
-public struct SignalWorker<Key: Equatable, Value>: Worker {
-    let key: Key
-    let signal: Signal<Value, Never>
-
-    public init(key: Key, signal: Signal<Value, Never>) {
-        self.key = key
-        self.signal = signal
-    }
-
-    public func run() -> SignalProducer<Value, Never> {
-        return SignalProducer(signal)
-    }
-
-    public func isEquivalent(to otherWorker: SignalWorker) -> Bool {
-        return key == otherWorker.key
-    }
-}
-
-extension Signal where Error == Never {
-    public func asWorker<Key: Equatable>(key: Key) -> SignalWorker<Key, Value> {
-        return SignalWorker(key: key, signal: self)
-    }
-}

--- a/swift/Workflow/Sources/Worker.swift
+++ b/swift/Workflow/Sources/Worker.swift
@@ -44,3 +44,20 @@ extension Worker where Self: Equatable {
     }
 
 }
+
+/// A Worker that wraps a `Signal`
+public struct SignalWorker<Value>: Worker {
+    let signal: Signal<Value, Never>
+
+    public init(signal: Signal<Value, Never>) {
+        self.signal = signal
+    }
+
+    public func run() -> SignalProducer<Value, Never> {
+        return SignalProducer(signal)
+    }
+
+    public func isEquivalent(to otherWorker: SignalWorker) -> Bool {
+        return true
+    }
+}

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -300,6 +300,43 @@ final class ConcurrencyTests: XCTestCase {
         disposable?.dispose()
     }
 
+    func test_allSubscriptionActionsAreApplied() {
+        let signal1 = TestSignal()
+        let signal2 = TestSignal()
+        let host = WorkflowHost(
+            workflow: TestWorkflow(
+                running: .doubleSubscribing(secondSignal: signal2),
+                signal: signal1
+            )
+        )
+
+        let renderingExpectation = XCTestExpectation()
+        let outputExpectation = XCTestExpectation()
+        let outDisposable = host.output.signal.observeValues { output in
+            outputExpectation.fulfill()
+        }
+
+        let disposable = host.rendering.signal.observeValues { rendering in
+            renderingExpectation.fulfill()
+        }
+
+        let screen = host.rendering.value
+
+        XCTAssertEqual(0, screen.count)
+
+        signal1.send(value: 1)
+        signal2.send(value: 2)
+
+        XCTAssertEqual(0, host.rendering.value.count)
+
+        wait(for: [renderingExpectation, outputExpectation], timeout: 1.0)
+
+        XCTAssertEqual(101, host.rendering.value.count)
+
+        disposable?.dispose()
+        outDisposable?.dispose()
+    }
+
     // Workers are subscribed on a different scheduler than the UI scheduler,
     // which means that if they fire immediately, the action will be received after
     // `render` has completed.
@@ -548,6 +585,7 @@ final class ConcurrencyTests: XCTestCase {
         enum Running {
             case idle
             case signal
+            case doubleSubscribing(secondSignal: TestSignal)
             case worker
         }
         var signal: TestSignal
@@ -573,12 +611,16 @@ final class ConcurrencyTests: XCTestCase {
             typealias WorkflowType = TestWorkflow
 
             case update
+            case secondUpdate
 
             func apply(toState state: inout State) -> Output? {
                 switch self {
                 case .update:
                     state.count += 1
                     return .emit
+                case .secondUpdate:
+                    state.count += 100
+                    return nil
                 }
             }
         }
@@ -591,6 +633,14 @@ final class ConcurrencyTests: XCTestCase {
             case .idle:
                 break
             case .signal:
+                context.awaitResult(for: SignalWorker(key: "signal1", signal: signal.signal)) { _ -> Action in
+                    return .update
+                }
+
+            case .doubleSubscribing(secondSignal: let signal2):
+                context.awaitResult(for: SignalWorker(key: "signal2", signal: signal2.signal)) { _ -> Action in
+                    return .secondUpdate
+                }
                 context.awaitResult(for: SignalWorker(key: "signal1", signal: signal.signal)) { _ -> Action in
                     return .update
                 }

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -633,15 +633,15 @@ final class ConcurrencyTests: XCTestCase {
             case .idle:
                 break
             case .signal:
-                context.awaitResult(for: SignalWorker(key: "signal1", signal: signal.signal)) { _ -> Action in
+                context.awaitResult(for: signal.signal.asWorker(key: "signal1")) { _ -> Action in
                     return .update
                 }
 
             case .doubleSubscribing(secondSignal: let signal2):
-                context.awaitResult(for: SignalWorker(key: "signal2", signal: signal2.signal)) { _ -> Action in
+                context.awaitResult(for: signal2.signal.asWorker(key: "signal2")) { _ -> Action in
                     return .secondUpdate
                 }
-                context.awaitResult(for: SignalWorker(key: "signal1", signal: signal.signal)) { _ -> Action in
+                context.awaitResult(for: signal.signal.asWorker(key: "signal1")) { _ -> Action in
                     return .update
                 }
 

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -591,7 +591,7 @@ final class ConcurrencyTests: XCTestCase {
             case .idle:
                 break
             case .signal:
-                context.awaitResult(for: SignalWorker(signal: signal.signal)) { _ -> Action in
+                context.awaitResult(for: SignalWorker(key: "signal1", signal: signal.signal)) { _ -> Action in
                     return .update
                 }
 

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -591,9 +591,9 @@ final class ConcurrencyTests: XCTestCase {
             case .idle:
                 break
             case .signal:
-                context.subscribe(signal: signal.signal.map({ _ -> Action in
+                context.awaitResult(for: SignalWorker(signal: signal.signal)) { _ -> Action in
                     return .update
-                }))
+                }
 
             case .worker:
                 context.awaitResult(for: TestWorker())

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -241,7 +241,7 @@ final class SubtreeManagerTests: XCTestCase {
 
             func render(state: SubscribingWorkflow.State, context: RenderContext<SubscribingWorkflow>) -> Bool {
                 if let signal = signal {
-                    context.awaitResult(for: SignalWorker(signal: signal)) { _ -> AnyWorkflowAction<SubscribingWorkflow> in
+                    context.awaitResult(for: SignalWorker(key: "signal", signal: signal)) { _ -> AnyWorkflowAction<SubscribingWorkflow> in
                         return AnyWorkflowAction.noAction
                     }
                     return true

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -241,7 +241,7 @@ final class SubtreeManagerTests: XCTestCase {
 
             func render(state: SubscribingWorkflow.State, context: RenderContext<SubscribingWorkflow>) -> Bool {
                 if let signal = signal {
-                    context.awaitResult(for: SignalWorker(key: "signal", signal: signal)) { _ -> AnyWorkflowAction<SubscribingWorkflow> in
+                    context.awaitResult(for: signal.asWorker(key: "signal")) { _ -> AnyWorkflowAction<SubscribingWorkflow> in
                         return AnyWorkflowAction.noAction
                     }
                     return true

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -241,9 +241,9 @@ final class SubtreeManagerTests: XCTestCase {
 
             func render(state: SubscribingWorkflow.State, context: RenderContext<SubscribingWorkflow>) -> Bool {
                 if let signal = signal {
-                    context.subscribe(signal: signal.map({ _ -> AnyWorkflowAction<SubscribingWorkflow> in
+                    context.awaitResult(for: SignalWorker(signal: signal)) { _ -> AnyWorkflowAction<SubscribingWorkflow> in
                         return AnyWorkflowAction.noAction
-                    }))
+                    }
                     return true
                 } else {
                     return false

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -270,9 +270,13 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         let sink = Sink<Action> { action in
             observer.send(value: AnyWorkflowAction(action))
         }
-        awaitResult(for: signal.asWorker(key: "\(actionType)")) { output in
-            return output
-        }
+
+        signal
+            .take(during: lifetime)
+            .observeValues { [weak self] action in
+                self?.apply(action: action)
+            }
+
         return sink
     }
 

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -274,14 +274,6 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         return sink
     }
 
-    func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
-        signal
-            .take(during: lifetime)
-            .observeValues { [weak self] action in
-                self?.apply(action: action)
-            }
-    }
-
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
 
         guard let workerIndex = expectations.expectedWorkers.firstIndex(where: { (expectedWorker) -> Bool in

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -270,7 +270,9 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         let sink = Sink<Action> { action in
             observer.send(value: AnyWorkflowAction(action))
         }
-        subscribe(signal: signal)
+        awaitResult(for: signal.asWorker(key: "\(actionType)")) { output in
+            return output
+        }
         return sink
     }
 

--- a/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -115,13 +115,12 @@ fileprivate struct MockWorkflow: Workflow {
     }
 
     func render(state: State, context: RenderContext<MockWorkflow>) -> TestScreen {
-
-        context.subscribe(signal: subscription.map { output in
+        context.awaitResult(for: subscription.asWorker(key: "signal")) { output in
             return AnyWorkflowAction { state in
                 state = output
                 return output
             }
-        })
+        }
 
         return TestScreen(string: "\(state)")
     }


### PR DESCRIPTION
This _should_ address #402. The aesthetics of the `SignalWorker` are very much open for feedback. We could also leave `context.subscribe` in place and create the worker in the infrastructure layer instead.