### PR TITLE
Revert "Enable AndroidX test orchestrator to try to reduce flakiness."

### DIFF
--- a/kotlin/.buildscript/android-ui-tests.gradle
+++ b/kotlin/.buildscript/android-ui-tests.gradle
@@ -1,21 +1,10 @@
 android {
   defaultConfig {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-    // The following argument makes the Android Test Orchestrator run its
-    // "pm clear" command after each test invocation. This command ensures
-    // that the app's state is completely cleared between tests.
-    testInstrumentationRunnerArguments clearPackageData: 'true'
-  }
-
-  testOptions {
-    execution 'ANDROIDX_TEST_ORCHESTRATOR'
   }
 }
 
 dependencies {
-  androidTestUtil 'androidx.test:orchestrator:1.2.0'
-
   androidTestImplementation deps.test.androidx.espresso.core
   androidTestImplementation deps.test.androidx.junitExt
 }


### PR DESCRIPTION
This reverts commit 18e4dcfdfa110289a077b7ca9a55b1caeb07d89d.

Tests are still super flaky, so no reason to use the orchestrator, since it
increases the time each test takes to run.