### PR TITLE
Add a Github Workflow to automatically publish the doc site when release tags are pushed.

### DIFF
--- a/.github/workflows/deploy-doc-site.yml
+++ b/.github/workflows/deploy-doc-site.yml
@@ -1,0 +1,82 @@
+name: Deploy documentation site
+
+on:
+  push:
+    tags: [ v* ]
+  pull_request:
+    # Run this workflow as a dry run when it's edited, so we can test it.
+    paths: .github/workflows/deploy-doc-site.yml
+
+jobs:
+  deploy:
+    runs-on: macOS-latest
+    env:
+      # Default to deploying the current REF. If this is a pull request run, that ref will be invalid
+      # (local-only merge commit), so we'll override it with the GITHUB_HEAD_REF below.
+      DEPLOY_REF: ${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      # Gradle caches (keys must match those defined in kotlin.yml)
+      # Don't use the gradle wrapper cache, since there's only one job we're downloading the whole wrapper once either way.
+      - name: Cache gradle artifacts
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ github.sha }}
+          restore-keys: |
+            gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-
+
+      # Swift caches (keys must match those defined in swift.yml)
+      - name: Load gem cache
+        uses: actions/cache@v1
+        with:
+          path: .bundle
+          key: gems-${{ hashFiles('Gemfile.lock') }}
+
+      - name: Set up Swift environment
+        run: |
+          # Set global bundle path so it gets used by build_swift_docs.sh running in the nested repo as well.
+          bundle config --global path "$(pwd)/.bundle"
+          bundle check || bundle install
+          # Don't need to run pod gen, the website script does that itself.
+          brew install sourcedocs
+          sudo xcode-select -s /Applications/Xcode_11.3.1.app
+
+      # Docs dependencies
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+
+      # This environment variable step should be run after all 3rd-party actions to ensure nothing
+      # else accidentally overrides any of our special variables.
+      - name: 'If pull request: enable dry run and configure deploy ref'
+        if: github.event_name == 'pull_request'
+        run: |
+          # When building pull requests, we shouldn't actually deploy, just do a dry run to make
+          # sure all the dependencies are set up correctly.
+          echo "::set-env name=DRY_RUN::true"
+          # GITHUB_REF is a local-only merge commit, so we need to explicitly deploy the PR's branch.
+          echo "::set-env name=DEPLOY_REF::$GITHUB_HEAD_REF"
+
+      - name: Debug info
+        run: |
+          echo event_name=${{ github.event_name }}
+          echo GITHUB_REF=$GITHUB_REF
+          echo GITHUB_HEAD_REF=$GITHUB_HEAD_REF
+          echo DEPLOY_REF=$DEPLOY_REF
+          echo DRY_RUN=$DRY_RUN
+          git remote -v
+
+      ## Main steps
+      - name: Build and deploy website
+        env:
+          WORKFLOW_GOOGLE_ANALYTICS_KEY: ${{ secrets.WORKFLOW_GOOGLE_ANALYTICS_KEY }}
+          GIT_USERNAME: ${{ github.actor }}
+          GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: ./deploy_website.sh $DEPLOY_REF

--- a/.github/workflows/validate-documentation.yml
+++ b/.github/workflows/validate-documentation.yml
@@ -1,24 +1,13 @@
 name: Build and validate documentation site
 
 on:
-  push:
-    branches:
-      - master
-      - '!gh-pages'
+  pull_request:
     paths:
       # Rebuild when workflow configs change.
       - .github/workflows/validate-documentation.yml
       # Or when documentation code changes.
-      - docs/**
-      - ./**.md
-      - mkdocs.yml
-      - lint_docs.sh
-      - .markdownlint.rb
-  pull_request:
-    paths:
-      - .github/workflows/validate-documentation.yml
-      - docs/**
-      - ./**.md
+      - 'docs/**'
+      - '**.md'
       - mkdocs.yml
       - lint_docs.sh
       - .markdownlint.rb

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -99,6 +99,9 @@ consists of three parts:
    [Sourcedocs](https://github.com/eneko/SourceDocs) and then included in the statically-generated
    website.
 
+**Note: The documentation site is automatically built and deployed whenever a version tag is pushed.
+You only need these steps if you want to work on the site locally.**
+
 ### Setting up the site generators
 
 If you've already done this, you can skip to _Deploying the website to production_ below.
@@ -167,6 +170,9 @@ mkdocs serve
 ```
 
 ### Deploying the website to production
+
+**Note: The documentation site is automatically built and deployed by a Github Workflow whenever a
+version tag is pushed. You only need these steps if you want to publish the site manually.**
 
 Before deploying the website for real, you need to export our Google Analytics key in an environment
 variable so that it will get added to the HTML. Get the key from one of the project maintainers,

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -26,47 +26,84 @@
 # See .buildscript/build_swift_docs.sh for setup info.
 #
 # Usage deploy_website.sh SHA_OR_REF_TO_DEPLOY
+# Set the DRY_RUN flag to any non-null value to skip the actual deploy.
+# A custom username/password can be used to authenticate to the git repo by setting
+# the GIT_USERNAME and GIT_PASSWORD environment variables.
 
-set -ex
-
-# Get the actual SHA, even if a ref was passed.
-SHA=$(git rev-parse $1)
-REPO="git@github.com:square/workflow.git"
-DIR=mkdocs-clone
-# Need to use the absolute path for these.
-SWIFT_API_DIR="$(pwd)/$DIR/docs/swift/api"
-SWIFT_DOCS_SCRIPT="$(pwd)/.buildscript/build_swift_docs.sh"
-
-# Delete any existing temporary website clone.
-rm -rf $DIR
+# Automatically exit the script on error.
+set -e
 
 if [ -z "$WORKFLOW_GOOGLE_ANALYTICS_KEY" ]; then
     echo "Must set WORKFLOW_GOOGLE_ANALYTICS_KEY to deploy." >&2
     exit 1
 fi
 
-# Clone the current repo into temp folder.
-git clone $REPO $DIR
+# This is only necessary if the remote configured by checkout doesnt automatically have
+# push access. Verify it's actually required before merging.
+GIT_CREDENTIALS=git
+# Accept username/password overrides from environment variables for Github Actions.
+if [ -n "$GIT_USERNAME" -a -n "$GIT_PASSWORD" ]; then
+	echo "Authenticating as $GIT_USERNAME."
+	GIT_CREDENTIALS="$GIT_USERNAME:$GIT_PASSWORD"
+else
+	echo "Authenticating as current user."
+fi
+
+DEPLOY_REF=$1
+if [ -z "$DEPLOY_REF" ]; then
+	echo "Must pass ref to deploy as first argument." >&2
+	exit 1
+fi
+# Try to cut any extra refs/ prefix off the ref. Needed for Github Actions, which passes
+# something like refs/tags/vX.Y.Z, which is not accepted by git clone.
+# Note that for pull requests, because Github does a shallow clone, the ref we get won't exist
+# and this will fail, but that's ok because in that case the ref is already cloneable.
+# In that case, rev-parse will still print the argument to stdout, but we don't care about
+# the error message or non-zero exit code.
+set +e
+DEPLOY_REF=$(git rev-parse --abbrev-ref $DEPLOY_REF 2>/dev/null)
+set -e
+
+DIR=mkdocs-clone
+SWIFT_DOCS_SCRIPT="$(pwd)/.buildscript/build_swift_docs.sh"
+REPO="https://${GIT_CREDENTIALS}@github.com/square/workflow.git"
+
+# Delete any existing temporary website clone.
+echo "Removing ${DIR}…"
+rm -rf $DIR
+
+# Clone the repo into temp folder if we need to deploy a different ref.
+# This lets us run the scripts from this working copy even if docs are being built
+# for a different ref.
+echo "Shallow-cloning ${DEPLOY_REF}…"
+git clone --depth 1 --branch $DEPLOY_REF $REPO $DIR
 
 # Move working directory into temp folder.
 pushd $DIR
-git checkout $SHA
+
+# Need to use the absolute path for these.
+SWIFT_API_DIR="$(pwd)/docs/swift/api"
+echo "SWIFT_API_DIR=$SWIFT_API_DIR"
 
 # Generate the Kotlin API docs.
-(cd kotlin && ./gradlew assemble && ./gradlew dokka)
+echo "Building Kotlin docs…"
+( cd kotlin && ./gradlew assemble --quiet && ./gradlew dokka --quiet )
 
 # Generate the Swift API docs.
+echo "Building Swift docs…"
 $SWIFT_DOCS_SCRIPT $SWIFT_API_DIR
 
-# Build the site
-mkdocs gh-deploy
-# Remove Dokka markdown.
-git clean -fdx
-git checkout gh-pages
-
 # Push the new files up to GitHub.
-git push origin gh-pages:gh-pages
+if [ -n "$DRY_RUN" ]; then
+	echo "DRY_RUN enabled, building mkdocs but skipping gh-deploy and push…"
+	mkdocs build
+else
+	echo "Running mkdocs gh-deploy --force…"
+	# Build the site and force-push to the gh-pages branch.
+	mkdocs gh-deploy --force
+fi
 
 # Delete our temp folder.
+echo "Deploy finished, cleaning up…"
 popd
 rm -rf $DIR


### PR DESCRIPTION
This workflow is run whenever a release tag is pushed (starts with `v` prefix), or when
a pull request is made that modifies the workflow, so the changes can be validated. In
the latter case, the `deploy_website.sh` script is run in dry mode so the docs are built
but not actually deployed. This workflow re-uses the gradle artifact and bundle caches
from the Kotlin and Swift workflows, respectively.

This requires a few changes to the `deploy_website.sh` script:
 - Use HTTPS instead of SSH to clone.
 - Allow custom username/password to be passed in via environment variables,
   so the GH Workflow can authenticate using its token.
 - Enable dry runs by setting the `DRY_RUN` environment variable, so pull requests that
   modify this workflow definition can still run the build steps in CI to validate them
   without actually publishing the doc site.
 - Shallow clone only the actual ref that is going to be deployed from.
 - Try to resolve the deploy ref with best-effort, but fallback to the raw value if it
   can't be resolved. Github does a shallow clone of the repo, so when building a pull
   request, the head ref won't actually be present in the worker's repo, so we just
   assume it will resolve when cloning fresh.
 - Build Kotlin source quietly.
 - Turn off auto-logging (`set -x`) since the git command might have a password in it
   that we don't want to expose.

This change also updates the `RELEASING` file to mention that the doc site is now built
and deployed automatically.