### PR TITLE
Increase CI timeout for Kotlin assemble job

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - '!gh-pages'
     paths:
       # Rebuild when workflow configs change.
       - .github/workflows/kotlin.yml
@@ -59,7 +58,7 @@ jobs:
     name: Check
     needs: assemble
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       # Run all checks, even if some fail.
       fail-fast: false


### PR DESCRIPTION
Some assemble runs take ~8 minutes, which, when added to the durations of the other steps in the job, exceeds the timeout.

Also removes the `'!gh-pages'` from the push branch list, since `master` doesn't use globs it's good enough.