### PR TITLE
Move dependency declarations to buildSrc.

### DIFF
--- a/kotlin/.buildscript/android-ui-tests.gradle
+++ b/kotlin/.buildscript/android-ui-tests.gradle
@@ -5,6 +5,6 @@ android {
 }
 
 dependencies {
-  androidTestImplementation deps.test.androidx.espresso.core
-  androidTestImplementation deps.test.androidx.junitExt
+  androidTestImplementation Dep.get("test.androidx.espresso.core")
+  androidTestImplementation Dep.get("test.androidx.junitExt")
 }

--- a/kotlin/.buildscript/configure-compose.gradle
+++ b/kotlin/.buildscript/configure-compose.gradle
@@ -19,6 +19,6 @@ android {
     compose true
   }
   composeOptions {
-    kotlinCompilerExtensionVersion versions.compose
+    kotlinCompilerExtensionVersion Versions.compose
   }
 }

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -14,15 +14,8 @@
  * limitations under the License.
  */
 buildscript {
-  ext.versions = [
-      'targetSdk': 29,
-      'compose': '0.1.0-dev07',
-      'coroutines': '1.3.4',
-      'kotlin': '1.3.71',
-  ]
-
   rootProject.ext.defaultAndroidConfig = {
-    compileSdkVersion versions.targetSdk
+    compileSdkVersion Versions.targetSdk
     buildToolsVersion '29.0.2'
 
     compileOptions {
@@ -32,7 +25,7 @@ buildscript {
 
     defaultConfig {
       minSdkVersion 21
-      targetSdkVersion versions.targetSdk
+      targetSdkVersion Versions.targetSdk
       versionCode 1
       versionName "1.0"
     }
@@ -48,122 +41,16 @@ buildscript {
     }
   }
 
-  ext.deps = [
-      'android_gradle_plugin': "com.android.tools.build:gradle:4.0.0-beta03",
-
-      'androidx': [
-          'activity': "androidx.activity:activity:1.1.0",
-          'annotations': "androidx.annotation:annotation:1.1.0",
-          'appcompat': "androidx.appcompat:appcompat:1.1.0",
-          'constraint_layout': "androidx.constraintlayout:constraintlayout:1.1.3",
-          'fragment': "androidx.fragment:fragment:1.2.3",
-          'gridlayout': "androidx.gridlayout:gridlayout:1.0.0",
-          'lifecycle': [
-              'reactivestreams': "androidx.lifecycle:lifecycle-reactivestreams-ktx:2.2.0",
-          ],
-          // Note that we're not using the actual androidx material dep yet, it's still alpha.
-          'material': "com.google.android.material:material:1.1.0",
-          'recyclerview': "androidx.recyclerview:recyclerview:1.1.0",
-          // Note that we are *not* using lifecycle-viewmodel-savedstate, which at this
-          // writing is still in beta and still fixing bad bugs. Probably we'll never bother to,
-          // it doesn't really add value for us.
-          'savedstate': "androidx.savedstate:savedstate:1.0.0",
-          'transition': "androidx.transition:transition:1.3.1",
-          'viewbinding': "androidx.databinding:viewbinding:3.6.2",
-      ],
-
-      'compose': [
-          'foundation': "androidx.ui:ui-foundation:${versions.compose}",
-          'layout': "androidx.ui:ui-layout:${versions.compose}",
-          'material': "androidx.ui:ui-material:${versions.compose}",
-          'test': "androidx.ui:ui-test:${versions.compose}",
-          'tooling': "androidx.ui:ui-tooling:${versions.compose}",
-      ],
-
-      'cycler': "com.squareup.cycler:cycler:0.1.3",
-      // Required for Dungeon Crawler sample.
-      'desugar_jdk_libs': "com.android.tools:desugar_jdk_libs:1.0.5",
-      'moshi': "com.squareup.moshi:moshi:1.9.2",
-      'rxandroid2': "io.reactivex.rxjava2:rxandroid:2.1.1",
-      'timber': "com.jakewharton.timber:timber:4.7.1",
-
-      'kotlin': [
-          'binaryCompatibilityValidatorPlugin': "org.jetbrains.kotlinx:binary-compatibility-validator:0.2.3",
-          'gradlePlugin': "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
-          'stdLib': [
-              'common': "org.jetbrains.kotlin:kotlin-stdlib-common",
-              'jdk8': "org.jetbrains.kotlin:kotlin-stdlib-jdk8",
-              'jdk7': "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
-              'jdk6': "org.jetbrains.kotlin:kotlin-stdlib"
-          ],
-          'coroutines': [
-              'android': "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}",
-              'core': "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}",
-              'rx2': "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${versions.coroutines}",
-              'test': "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.coroutines}"
-          ],
-          'moshi': "com.squareup.moshi:moshi-kotlin:1.9.2",
-          'reflect': "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}",
-          'serialization': [
-              'gradlePlugin': "org.jetbrains.kotlin:kotlin-serialization:${versions.kotlin}",
-              'runtime': "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0-1.3.70-eap-134",
-              'kaml': "com.charleskorn.kaml:kaml:0.16.1",
-          ],
-          'test': [
-              'common': "org.jetbrains.kotlin:kotlin-test-common",
-              'annotations': "org.jetbrains.kotlin:kotlin-test-annotations-common",
-              'jdk': "org.jetbrains.kotlin:kotlin-test-junit",
-              'mockito': "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
-          ]
-      ],
-      'dokka': "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0",
-      'jmh': [
-          'gradlePlugin': "me.champeau.gradle:jmh-gradle-plugin:0.5.0",
-          'core': "org.openjdk.jmh:jmh-core:1.23",
-          'generator': "org.openjdk.jmh:jmh-generator-annprocess:1.23",
-      ],
-      'mavenPublish': "com.vanniktech:gradle-maven-publish-plugin:0.11.1",
-      'ktlint': "org.jlleitschuh.gradle:ktlint-gradle:9.2.0",
-      'lanterna': "com.googlecode.lanterna:lanterna:3.0.2",
-      'detekt': "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1",
-      'okio': "com.squareup.okio:okio:2.5.0",
-      'rxjava2': [
-          'rxjava2': "io.reactivex.rxjava2:rxjava:2.2.19",
-          'extensions': "com.github.akarnokd:rxjava2-extensions:0.20.10"
-      ],
-      'annotations': [
-          'intellij': "org.jetbrains:annotations:19.0.0",
-      ],
-      'test': [
-          'androidx': [
-              'espresso': [
-                  'contrib': "androidx.test.espresso:espresso-contrib:3.2.0",
-                  'core': "androidx.test.espresso:espresso-core:3.2.0",
-                  'idlingResource': "androidx.test.espresso:espresso-idling-resource:3.2.0",
-                  'intents': "androidx.test.espresso:espresso-intents:3.2.0",
-              ],
-              'junitExt': "androidx.test.ext:junit:1.1.1",
-              'runner': "androidx.test:runner:1.2.0",
-              'truthExt': "androidx.test.ext:truth:1.2.0",
-              'uiautomator': "androidx.test.uiautomator:uiautomator:2.2.0",
-          ],
-          'hamcrestCore': "org.hamcrest:hamcrest-core:2.2",
-          'junit': "junit:junit:4.13",
-          'mockito': "org.mockito:mockito-core:3.3.3",
-          'truth': "com.google.truth:truth:1.0.1",
-      ]
-  ]
-
   dependencies {
-    classpath deps.android_gradle_plugin
-    classpath deps.detekt
-    classpath deps.dokka
-    classpath deps.jmh.gradlePlugin
-    classpath deps.kotlin.binaryCompatibilityValidatorPlugin
-    classpath deps.kotlin.gradlePlugin
-    classpath deps.kotlin.serialization.gradlePlugin
-    classpath deps.ktlint
-    classpath deps.mavenPublish
+    classpath Dep.get("android_gradle_plugin")
+    classpath Dep.get("detekt")
+    classpath Dep.get("dokka")
+    classpath Dep.get("jmh.gradlePlugin")
+    classpath Dep.get("kotlin.binaryCompatibilityValidatorPlugin")
+    classpath Dep.get("kotlin.gradlePlugin")
+    classpath Dep.get("kotlin.serialization.gradlePlugin")
+    classpath Dep.get("ktlint")
+    classpath Dep.get("mavenPublish")
   }
 
   repositories {
@@ -190,7 +77,7 @@ subprojects {
     project.configurations.configureEach {
       // There could be transitive dependencies in tests with a lower version. This could cause
       // problems with a newer Kotlin version that we use.
-      resolutionStrategy.force deps.kotlin.reflect
+      resolutionStrategy.force Dep.get("kotlin.reflect")
     }
   }
 

--- a/kotlin/buildSrc/build.gradle.kts
+++ b/kotlin/buildSrc/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+  `kotlin-dsl`
+}
+
+repositories {
+  mavenCentral()
+}
+
+kotlinDslPluginOptions {
+  experimentalWarning.set(false)
+}

--- a/kotlin/buildSrc/src/main/java/Dependencies.kt
+++ b/kotlin/buildSrc/src/main/java/Dependencies.kt
@@ -1,0 +1,161 @@
+@file:JvmName("Dep")
+
+import java.util.Locale.US
+import kotlin.reflect.full.declaredMembers
+
+object Versions {
+  const val compose = "0.1.0-dev07"
+  const val coroutines = "1.3.4"
+  const val kotlin = "1.3.71"
+  const val targetSdk = 29
+}
+
+/** Temporary hack to make [Dependencies] accessible from Groovy scripts. */
+fun get(path: String) = Dependencies.resolveObject(
+    path.toLowerCase(US)
+        .split(".")
+)
+
+private tailrec fun Any.resolveObject(pathParts: List<String>): String {
+  require(pathParts.isNotEmpty())
+  val klass = this::class
+
+  if (pathParts.size == 1) {
+    @Suppress("UNCHECKED_CAST")
+    val member = klass.declaredMembers.single { it.name.toLowerCase(US) == pathParts.single() }
+    return member.call() as String
+  }
+
+  val nestedKlasses = klass.nestedClasses
+  val selectedKlass = nestedKlasses.single { it.simpleName!!.toLowerCase(US) == pathParts.first() }
+  return selectedKlass.objectInstance!!.resolveObject(pathParts.subList(1, pathParts.size))
+}
+
+@Suppress("unused")
+object Dependencies {
+  const val android_gradle_plugin = "com.android.tools.build:gradle:4.0.0-beta03"
+
+  object AndroidX {
+    const val activity = "androidx.activity:activity:1.1.0"
+    const val annotations = "androidx.annotation:annotation:1.1.0"
+    const val appcompat = "androidx.appcompat:appcompat:1.1.0"
+    const val constraint_layout = "androidx.constraintlayout:constraintlayout:1.1.3"
+    const val fragment = "androidx.fragment:fragment:1.2.3"
+    const val gridlayout = "androidx.gridlayout:gridlayout:1.0.0"
+
+    object Lifecycle {
+      const val reactivestreams = "androidx.lifecycle:lifecycle-reactivestreams-ktx:2.2.0"
+    }
+
+    // Note that we're not using the actual androidx material dep yet, it's still alpha.
+    const val material = "com.google.android.material:material:1.1.0"
+    const val recyclerview = "androidx.recyclerview:recyclerview:1.1.0"
+
+    // Note that we are *not* using lifecycle-viewmodel-savedstate, which at this
+    // writing is still in beta and still fixing bad bugs. Probably we'll never bother to,
+    // it doesn't really add value for us.
+    const val savedstate = "androidx.savedstate:savedstate:1.0.0"
+    const val transition = "androidx.transition:transition:1.3.1"
+    const val viewbinding = "androidx.databinding:viewbinding:3.6.2"
+  }
+
+  object Compose {
+    const val foundation = "androidx.ui:ui-foundation:${Versions.compose}"
+    const val layout = "androidx.ui:ui-layout:${Versions.compose}"
+    const val material = "androidx.ui:ui-material:${Versions.compose}"
+    const val test = "androidx.ui:ui-test:${Versions.compose}"
+    const val tooling = "androidx.ui:ui-tooling:${Versions.compose}"
+  }
+
+  const val cycler = "com.squareup.cycler:cycler:0.1.3"
+
+  // Required for Dungeon Crawler sample.
+  const val desugar_jdk_libs = "com.android.tools:desugar_jdk_libs:1.0.5"
+  const val moshi = "com.squareup.moshi:moshi:1.9.2"
+  const val rxandroid2 = "io.reactivex.rxjava2:rxandroid:2.1.1"
+  const val timber = "com.jakewharton.timber:timber:4.7.1"
+
+  object Kotlin {
+    const val binaryCompatibilityValidatorPlugin =
+      "org.jetbrains.kotlinx:binary-compatibility-validator:0.2.3"
+    const val gradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
+
+    object Stdlib {
+      const val common = "org.jetbrains.kotlin:kotlin-stdlib-common"
+      const val jdk8 = "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+      const val jdk7 = "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
+      const val jdk6 = "org.jetbrains.kotlin:kotlin-stdlib"
+    }
+
+    object Coroutines {
+      const val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
+      const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
+      const val rx2 = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:${Versions.coroutines}"
+
+      const val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"
+    }
+
+    const val moshi = "com.squareup.moshi:moshi-kotlin:1.9.2"
+    const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
+
+    object Serialization {
+      const val gradlePlugin = "org.jetbrains.kotlin:kotlin-serialization:${Versions.kotlin}"
+      const val runtime =
+        "org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0-1.3.70-eap-134"
+      const val kaml = "com.charleskorn.kaml:kaml:0.16.1"
+    }
+
+    object Test {
+      const val common = "org.jetbrains.kotlin:kotlin-test-common"
+      const val annotations = "org.jetbrains.kotlin:kotlin-test-annotations-common"
+      const val jdk = "org.jetbrains.kotlin:kotlin-test-junit"
+
+      const val mockito = "com.nhaarman:mockito-kotlin-kt1.1:1.6.0"
+    }
+  }
+
+  const val dokka = "org.jetbrains.dokka:dokka-gradle-plugin:0.10.0"
+
+  object Jmh {
+    const val gradlePlugin = "me.champeau.gradle:jmh-gradle-plugin:0.5.0"
+    const val core = "org.openjdk.jmh:jmh-core:1.23"
+    const val generator = "org.openjdk.jmh:jmh-generator-annprocess:1.23"
+  }
+
+  const val mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.11.1"
+  const val ktlint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.0"
+  const val lanterna = "com.googlecode.lanterna:lanterna:3.0.2"
+  const val detekt = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1"
+  const val okio = "com.squareup.okio:okio:2.5.0"
+
+  object RxJava2 {
+    const val rxjava2 = "io.reactivex.rxjava2:rxjava:2.2.19"
+
+    const val extensions = "com.github.akarnokd:rxjava2-extensions:0.20.10"
+  }
+
+  object Annotations {
+    const val intellij = "org.jetbrains:annotations:19.0.0"
+  }
+
+  object Test {
+    object AndroidX {
+      object Espresso {
+        const val contrib = "androidx.test.espresso:espresso-contrib:3.2.0"
+        const val core = "androidx.test.espresso:espresso-core:3.2.0"
+        const val idlingResource = "androidx.test.espresso:espresso-idling-resource:3.2.0"
+        const val intents = "androidx.test.espresso:espresso-intents:3.2.0"
+      }
+
+      const val junitExt = "androidx.test.ext:junit:1.1.1"
+      const val runner = "androidx.test:runner:1.2.0"
+      const val truthExt = "androidx.test.ext:truth:1.2.0"
+      const val uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
+    }
+
+    const val hamcrestCore = "org.hamcrest:hamcrest-core:2.2"
+    const val junit = "junit:junit:4.13"
+    const val mockito = "org.mockito:mockito-core:3.3.3"
+    const val truth = "com.google.truth:truth:1.0.1"
+  }
+}

--- a/kotlin/internal-testing-utils/build.gradle
+++ b/kotlin/internal-testing-utils/build.gradle
@@ -21,9 +21,9 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  implementation deps.kotlin.stdLib.jdk8
+  implementation Dep.get("kotlin.stdLib.jdk8")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
 }

--- a/kotlin/legacy/legacy-workflow-core/build.gradle
+++ b/kotlin/legacy/legacy-workflow-core/build.gradle
@@ -22,10 +22,10 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("annotations.intellij")
 
-  api deps.kotlin.stdLib.jdk6
-  api deps.kotlin.coroutines.core
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("kotlin.coroutines.core")
 
-  testImplementation deps.kotlin.test.jdk
+  testImplementation Dep.get("kotlin.test.jdk")
 }

--- a/kotlin/legacy/legacy-workflow-rx2/build.gradle
+++ b/kotlin/legacy/legacy-workflow-rx2/build.gradle
@@ -22,25 +22,25 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-  compileOnly deps.androidx.annotations
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("androidx.annotations")
+  compileOnly Dep.get("annotations.intellij")
 
   api project(':legacy:legacy-workflow-core')
   // For Snapshot.
   api project(':workflow-core')
-  api deps.kotlin.stdLib.jdk6
-  api deps.kotlin.coroutines.core
-  api deps.okio
-  api deps.rxjava2.rxjava2
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("kotlin.coroutines.core")
+  api Dep.get("okio")
+  api Dep.get("rxjava2.rxjava2")
 
-  implementation deps.kotlin.coroutines.rx2
+  implementation Dep.get("kotlin.coroutines.rx2")
 
   testImplementation project(':internal-testing-utils')
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.kotlin.test.mockito
-  testImplementation deps.test.hamcrestCore
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.test.mockito
-  testImplementation deps.rxjava2.extensions
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("kotlin.test.mockito")
+  testImplementation Dep.get("test.hamcrestCore")
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("test.mockito")
+  testImplementation Dep.get("rxjava2.extensions")
 }

--- a/kotlin/samples/containers/android/build.gradle
+++ b/kotlin/samples/containers/android/build.gradle
@@ -27,19 +27,19 @@ dependencies {
   api project(':workflow-ui:modal-android')
   api project(':samples:containers:common')
 
-  api deps.androidx.transition
-  api deps.kotlin.stdLib.jdk6
-  api deps.rxjava2.rxjava2
+  api Dep.get("androidx.transition")
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("rxjava2.rxjava2")
 
   implementation project(':workflow-runtime')
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.lifecycle.reactivestreams
-  implementation deps.androidx.savedstate
-  implementation deps.kotlin.coroutines.android
-  implementation deps.kotlin.coroutines.core
-  implementation deps.kotlin.coroutines.rx2
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.lifecycle.reactivestreams")
+  implementation Dep.get("androidx.savedstate")
+  implementation Dep.get("kotlin.coroutines.android")
+  implementation Dep.get("kotlin.coroutines.core")
+  implementation Dep.get("kotlin.coroutines.rx2")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.kotlin.coroutines.test
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("kotlin.coroutines.test")
 }

--- a/kotlin/samples/containers/app-poetry/build.gradle
+++ b/kotlin/samples/containers/app-poetry/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.sample.containers.poetry"
     minSdkVersion 21
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -40,8 +40,8 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.recyclerview
-  implementation deps.rxjava2.rxjava2
-  implementation deps.timber
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.recyclerview")
+  implementation Dep.get("rxjava2.rxjava2")
+  implementation Dep.get("timber")
 }

--- a/kotlin/samples/containers/app-raven/build.gradle
+++ b/kotlin/samples/containers/app-raven/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.sample.containers.raven"
     minSdkVersion 21
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -36,7 +36,7 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.androidx.appcompat
-  implementation deps.rxjava2.rxjava2
-  implementation deps.timber
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("rxjava2.rxjava2")
+  implementation Dep.get("timber")
 }

--- a/kotlin/samples/containers/common/build.gradle
+++ b/kotlin/samples/containers/common/build.gradle
@@ -22,13 +22,13 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-rx2')
 
-  implementation deps.kotlin.stdLib.jdk6
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("kotlin.stdLib.jdk6")
+  implementation Dep.get("rxjava2.rxjava2")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.hamcrestCore
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.rxjava2.extensions
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("test.hamcrestCore")
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("rxjava2.extensions")
   testImplementation project(':workflow-testing')
 }

--- a/kotlin/samples/containers/hello-back-button/build.gradle
+++ b/kotlin/samples/containers/hello-back-button/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.sample.hellobackbutton"
     minSdkVersion 21
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -35,6 +35,6 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.androidx.appcompat
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("rxjava2.rxjava2")
 }

--- a/kotlin/samples/containers/poetry/build.gradle
+++ b/kotlin/samples/containers/poetry/build.gradle
@@ -26,22 +26,22 @@ dependencies {
   api project(':workflow-ui:backstack-android')
   api project(':samples:containers:common')
 
-  api deps.androidx.transition
-  api deps.kotlin.stdLib.jdk6
-  api deps.rxjava2.rxjava2
+  api Dep.get("androidx.transition")
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("rxjava2.rxjava2")
 
   implementation project(':samples:containers:android')
   implementation project(':workflow-runtime')
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.lifecycle.reactivestreams
-  implementation deps.androidx.recyclerview
-  implementation deps.androidx.savedstate
-  implementation deps.kotlin.coroutines.android
-  implementation deps.kotlin.coroutines.core
-  implementation deps.kotlin.coroutines.rx2
-  implementation deps.timber
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.lifecycle.reactivestreams")
+  implementation Dep.get("androidx.recyclerview")
+  implementation Dep.get("androidx.savedstate")
+  implementation Dep.get("kotlin.coroutines.android")
+  implementation Dep.get("kotlin.coroutines.core")
+  implementation Dep.get("kotlin.coroutines.rx2")
+  implementation Dep.get("timber")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.kotlin.coroutines.test
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("kotlin.coroutines.test")
 }

--- a/kotlin/samples/dungeon/app/build.gradle
+++ b/kotlin/samples/dungeon/app/build.gradle
@@ -24,7 +24,7 @@ android {
     applicationId "com.squareup.sample.dungeon"
     minSdkVersion 21
     multiDexEnabled true
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -45,7 +45,7 @@ android {
 
 dependencies {
   // Required for SnakeYAML.
-  coreLibraryDesugaring deps.desugar_jdk_libs
+  coreLibraryDesugaring Dep.get("desugar_jdk_libs")
 
   implementation project(':samples:dungeon:common')
   implementation project(':samples:dungeon:timemachine-shakeable')
@@ -54,19 +54,19 @@ dependencies {
   implementation project(':workflow-runtime')
   implementation project(':workflow-tracing')
 
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.constraint_layout
-  implementation deps.androidx.material
-  implementation deps.androidx.gridlayout
-  implementation deps.kotlin.coroutines.rx2
-  implementation deps.okio
-  implementation deps.rxandroid2
-  implementation deps.rxjava2.rxjava2
-  implementation deps.timber
-  implementation deps.cycler
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.constraint_layout")
+  implementation Dep.get("androidx.material")
+  implementation Dep.get("androidx.gridlayout")
+  implementation Dep.get("kotlin.coroutines.rx2")
+  implementation Dep.get("okio")
+  implementation Dep.get("rxandroid2")
+  implementation Dep.get("rxjava2.rxjava2")
+  implementation Dep.get("timber")
+  implementation Dep.get("cycler")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
 
-  androidTestImplementation deps.test.androidx.uiautomator
+  androidTestImplementation Dep.get("test.androidx.uiautomator")
 }

--- a/kotlin/samples/dungeon/common/build.gradle
+++ b/kotlin/samples/dungeon/common/build.gradle
@@ -22,12 +22,12 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-rx2')
 
-  implementation deps.kotlin.serialization.kaml
-  implementation deps.kotlin.serialization.runtime
-  implementation deps.kotlin.stdLib.jdk8
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("kotlin.serialization.kaml")
+  implementation Dep.get("kotlin.serialization.runtime")
+  implementation Dep.get("kotlin.stdLib.jdk8")
+  implementation Dep.get("rxjava2.rxjava2")
 
   testImplementation project(':workflow-testing')
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.truth
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("test.truth")
 }

--- a/kotlin/samples/dungeon/timemachine-shakeable/build.gradle
+++ b/kotlin/samples/dungeon/timemachine-shakeable/build.gradle
@@ -25,8 +25,8 @@ dependencies {
   api project(':samples:dungeon:timemachine')
 
   implementation project(':workflow-ui:core-android')
-  implementation deps.androidx.constraint_layout
-  implementation deps.androidx.material
-  implementation deps.kotlin.stdLib.jdk8
+  implementation Dep.get("androidx.constraint_layout")
+  implementation Dep.get("androidx.material")
+  implementation Dep.get("kotlin.stdLib.jdk8")
   implementation 'com.squareup:seismic:1.0.2'
 }

--- a/kotlin/samples/dungeon/timemachine/build.gradle
+++ b/kotlin/samples/dungeon/timemachine/build.gradle
@@ -19,12 +19,12 @@ apply plugin: 'kotlin'
 dependencies {
   implementation project(':workflow-core')
 
-  implementation deps.kotlin.stdLib.jdk8
+  implementation Dep.get("kotlin.stdLib.jdk8")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.hamcrestCore
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.rxjava2.extensions
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("test.hamcrestCore")
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("rxjava2.extensions")
   testImplementation project(':workflow-testing')
 }

--- a/kotlin/samples/hello-compose-binding/build.gradle
+++ b/kotlin/samples/hello-compose-binding/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.sample.hellocomposebinding"
     minSdkVersion 21
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -42,13 +42,13 @@ dependencies {
   implementation project(':workflow-runtime')
   implementation project(':workflow-ui:core-compose')
 
-  implementation deps.androidx.appcompat
-  implementation deps.compose.layout
-  implementation deps.compose.material
-  implementation deps.compose.tooling
-  implementation deps.compose.foundation
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("compose.layout")
+  implementation Dep.get("compose.material")
+  implementation Dep.get("compose.tooling")
+  implementation Dep.get("compose.foundation")
+  implementation Dep.get("rxjava2.rxjava2")
 
-  androidTestImplementation deps.compose.test
-  androidTestImplementation deps.test.junit
+  androidTestImplementation Dep.get("compose.test")
+  androidTestImplementation Dep.get("test.junit")
 }

--- a/kotlin/samples/hello-terminal/terminal-workflow/build.gradle
+++ b/kotlin/samples/hello-terminal/terminal-workflow/build.gradle
@@ -20,5 +20,5 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.lanterna
+  implementation Dep.get("lanterna")
 }

--- a/kotlin/samples/hello-workflow-fragment/build.gradle
+++ b/kotlin/samples/hello-workflow-fragment/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.sample.helloworkflowfragment"
     minSdkVersion 21
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -34,6 +34,6 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.androidx.appcompat
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("rxjava2.rxjava2")
 }

--- a/kotlin/samples/hello-workflow/build.gradle
+++ b/kotlin/samples/hello-workflow/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.sample.helloworkflow"
     minSdkVersion 21
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -34,7 +34,7 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.viewbinding
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.viewbinding")
+  implementation Dep.get("rxjava2.rxjava2")
 }

--- a/kotlin/samples/recyclerview/build.gradle
+++ b/kotlin/samples/recyclerview/build.gradle
@@ -23,7 +23,7 @@ android {
   defaultConfig {
     applicationId "com.squareup.sample.recyclerview"
     minSdkVersion 21
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -34,10 +34,10 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-runtime')
 
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.recyclerview
-  implementation deps.kotlin.coroutines.android
-  implementation deps.kotlin.coroutines.core
-  implementation deps.rxjava2.rxjava2
-  implementation deps.timber
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.recyclerview")
+  implementation Dep.get("kotlin.coroutines.android")
+  implementation Dep.get("kotlin.coroutines.core")
+  implementation Dep.get("rxjava2.rxjava2")
+  implementation Dep.get("timber")
 }

--- a/kotlin/samples/tictactoe/app/build.gradle
+++ b/kotlin/samples/tictactoe/app/build.gradle
@@ -24,7 +24,7 @@ android {
     applicationId "com.squareup.sample.tictacworkflow"
     minSdkVersion 21
     multiDexEnabled true
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -40,18 +40,18 @@ dependencies {
   implementation project(':workflow-runtime')
   implementation project(':workflow-tracing')
 
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.constraint_layout
-  implementation deps.kotlin.coroutines.rx2
-  implementation deps.okio
-  implementation deps.rxandroid2
-  implementation deps.rxjava2.rxjava2
-  implementation deps.test.androidx.espresso.idlingResource
-  implementation deps.timber
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.constraint_layout")
+  implementation Dep.get("kotlin.coroutines.rx2")
+  implementation Dep.get("okio")
+  implementation Dep.get("rxandroid2")
+  implementation Dep.get("rxjava2.rxjava2")
+  implementation Dep.get("test.androidx.espresso.idlingResource")
+  implementation Dep.get("timber")
 
-  androidTestImplementation deps.test.androidx.espresso.intents
-  androidTestImplementation deps.test.androidx.runner
-  androidTestImplementation deps.test.androidx.truthExt
-  androidTestImplementation deps.test.junit
-  androidTestImplementation deps.test.truth
+  androidTestImplementation Dep.get("test.androidx.espresso.intents")
+  androidTestImplementation Dep.get("test.androidx.runner")
+  androidTestImplementation Dep.get("test.androidx.truthExt")
+  androidTestImplementation Dep.get("test.junit")
+  androidTestImplementation Dep.get("test.truth")
 }

--- a/kotlin/samples/tictactoe/common/build.gradle
+++ b/kotlin/samples/tictactoe/common/build.gradle
@@ -23,12 +23,12 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-rx2')
 
-  implementation deps.kotlin.stdLib.jdk6
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("kotlin.stdLib.jdk6")
+  implementation Dep.get("rxjava2.rxjava2")
 
-  testImplementation deps.test.hamcrestCore
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.rxjava2.extensions
+  testImplementation Dep.get("test.hamcrestCore")
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("rxjava2.extensions")
   testImplementation project(':workflow-testing')
 }

--- a/kotlin/samples/todo-android/app/build.gradle
+++ b/kotlin/samples/todo-android/app/build.gradle
@@ -24,7 +24,7 @@ android {
     applicationId "com.squareup.sample.todo"
     minSdkVersion 21
     multiDexEnabled true
-    targetSdkVersion versions.targetSdk
+    targetSdkVersion Versions.targetSdk
     versionCode 1
     versionName "1.0.0"
   }
@@ -42,17 +42,17 @@ dependencies {
   implementation project(':workflow-runtime')
   implementation project(':workflow-tracing')
 
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.constraint_layout
-  implementation deps.androidx.material
-  implementation deps.kotlin.coroutines.rx2
-  implementation deps.okio
-  implementation deps.rxandroid2
-  implementation deps.rxjava2.rxjava2
-  implementation deps.timber
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.constraint_layout")
+  implementation Dep.get("androidx.material")
+  implementation Dep.get("kotlin.coroutines.rx2")
+  implementation Dep.get("okio")
+  implementation Dep.get("rxandroid2")
+  implementation Dep.get("rxjava2.rxjava2")
+  implementation Dep.get("timber")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
 
-  androidTestImplementation deps.test.androidx.uiautomator
+  androidTestImplementation Dep.get("test.androidx.uiautomator")
 }

--- a/kotlin/samples/todo-android/common/build.gradle
+++ b/kotlin/samples/todo-android/common/build.gradle
@@ -22,12 +22,12 @@ dependencies {
   implementation project(':workflow-core')
   implementation project(':workflow-rx2')
 
-  implementation deps.kotlin.stdLib.jdk6
-  implementation deps.rxjava2.rxjava2
+  implementation Dep.get("kotlin.stdLib.jdk6")
+  implementation Dep.get("rxjava2.rxjava2")
 
-  testImplementation deps.test.hamcrestCore
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.rxjava2.extensions
+  testImplementation Dep.get("test.hamcrestCore")
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("rxjava2.extensions")
   testImplementation project(':workflow-testing')
 }

--- a/kotlin/trace-encoder/build.gradle
+++ b/kotlin/trace-encoder/build.gradle
@@ -23,14 +23,14 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("annotations.intellij")
 
-  api deps.kotlin.stdLib.jdk6
-  api deps.kotlin.coroutines.core
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("kotlin.coroutines.core")
 
-  implementation deps.kotlin.reflect
-  implementation deps.kotlin.moshi
-  implementation deps.moshi
+  implementation Dep.get("kotlin.reflect")
+  implementation Dep.get("kotlin.moshi")
+  implementation Dep.get("moshi")
   
-  testImplementation deps.kotlin.test.jdk
+  testImplementation Dep.get("kotlin.test.jdk")
 }

--- a/kotlin/workflow-core/build.gradle
+++ b/kotlin/workflow-core/build.gradle
@@ -23,12 +23,12 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("annotations.intellij")
 
-  api deps.kotlin.stdLib.jdk6
-  api deps.kotlin.coroutines.core
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("kotlin.coroutines.core")
   // For Snapshot.
-  api deps.okio
+  api Dep.get("okio")
 
-  testImplementation deps.kotlin.test.jdk
+  testImplementation Dep.get("kotlin.test.jdk")
 }

--- a/kotlin/workflow-runtime/build.gradle
+++ b/kotlin/workflow-runtime/build.gradle
@@ -46,17 +46,17 @@ compileJmhKotlin {
 }
 
 dependencies {
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("annotations.intellij")
 
   api project(':workflow-core')
-  api deps.kotlin.stdLib.jdk6
-  api deps.kotlin.coroutines.core
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("kotlin.coroutines.core")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.kotlin.reflect
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("kotlin.reflect")
 
   // These dependencies will be available on the classpath for source inside src/jmh.
-  jmh deps.kotlin.stdLib.jdk6
-  jmh deps.jmh.core
-  jmh deps.jmh.generator
+  jmh Dep.get("kotlin.stdLib.jdk6")
+  jmh Dep.get("jmh.core")
+  jmh Dep.get("jmh.generator")
 }

--- a/kotlin/workflow-rx2/build.gradle
+++ b/kotlin/workflow-rx2/build.gradle
@@ -23,15 +23,15 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("annotations.intellij")
 
   api project(':workflow-core')
-  api deps.kotlin.stdLib.jdk6
-  api deps.kotlin.coroutines.core
-  api deps.rxjava2.rxjava2
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("kotlin.coroutines.core")
+  api Dep.get("rxjava2.rxjava2")
 
-  implementation deps.kotlin.coroutines.rx2
+  implementation Dep.get("kotlin.coroutines.rx2")
 
   testImplementation project(':workflow-testing')
-  testImplementation deps.kotlin.test.jdk
+  testImplementation Dep.get("kotlin.test.jdk")
 }

--- a/kotlin/workflow-testing/build.gradle
+++ b/kotlin/workflow-testing/build.gradle
@@ -23,15 +23,15 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("annotations.intellij")
 
   api project(':workflow-core')
   api project(':workflow-runtime')
-  api deps.kotlin.coroutines.test
-  api deps.kotlin.stdLib.jdk7
+  api Dep.get("kotlin.coroutines.test")
+  api Dep.get("kotlin.stdLib.jdk7")
 
   implementation project(':internal-testing-utils')
-  implementation deps.kotlin.reflect
+  implementation Dep.get("kotlin.reflect")
 
-  testImplementation deps.kotlin.test.jdk
+  testImplementation Dep.get("kotlin.test.jdk")
 }

--- a/kotlin/workflow-tracing/build.gradle
+++ b/kotlin/workflow-tracing/build.gradle
@@ -23,18 +23,18 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  compileOnly deps.annotations.intellij
+  compileOnly Dep.get("annotations.intellij")
 
   api project(':trace-encoder')
   api project(':workflow-runtime')
-  api deps.kotlin.stdLib.jdk6
-  api deps.kotlin.coroutines.core
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("kotlin.coroutines.core")
 
-  implementation deps.kotlin.reflect
-  implementation deps.kotlin.moshi
-  implementation deps.okio
-  implementation deps.moshi
+  implementation Dep.get("kotlin.reflect")
+  implementation Dep.get("kotlin.moshi")
+  implementation Dep.get("okio")
+  implementation Dep.get("moshi")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.kotlin.test.mockito
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("kotlin.test.mockito")
 }

--- a/kotlin/workflow-ui/backstack-android/build.gradle
+++ b/kotlin/workflow-ui/backstack-android/build.gradle
@@ -32,22 +32,22 @@ dependencies {
   api project(':workflow-ui:backstack-common')
   api project(':workflow-ui:core-android')
 
-  api deps.androidx.transition
-  api deps.kotlin.stdLib.jdk6
-  api deps.rxjava2.rxjava2
+  api Dep.get("androidx.transition")
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("rxjava2.rxjava2")
 
   implementation project(':workflow-runtime')
-  implementation deps.androidx.activity
-  implementation deps.androidx.fragment
-  implementation deps.androidx.lifecycle.reactivestreams
-  implementation deps.androidx.savedstate
-  implementation deps.kotlin.coroutines.android
-  implementation deps.kotlin.coroutines.core
-  implementation deps.kotlin.coroutines.rx2
+  implementation Dep.get("androidx.activity")
+  implementation Dep.get("androidx.fragment")
+  implementation Dep.get("androidx.lifecycle.reactivestreams")
+  implementation Dep.get("androidx.savedstate")
+  implementation Dep.get("kotlin.coroutines.android")
+  implementation Dep.get("kotlin.coroutines.core")
+  implementation Dep.get("kotlin.coroutines.rx2")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.kotlin.coroutines.test
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.kotlin.test.mockito
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("kotlin.coroutines.test")
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("kotlin.test.mockito")
 }

--- a/kotlin/workflow-ui/backstack-common/build.gradle
+++ b/kotlin/workflow-ui/backstack-common/build.gradle
@@ -23,9 +23,9 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  api deps.kotlin.stdLib.jdk6
-  api deps.okio
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("okio")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.truth
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("test.truth")
 }

--- a/kotlin/workflow-ui/core-android/build.gradle
+++ b/kotlin/workflow-ui/core-android/build.gradle
@@ -25,27 +25,27 @@ apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 android rootProject.ext.defaultAndroidConfig
 
 dependencies {
-  compileOnly deps.androidx.viewbinding
+  compileOnly Dep.get("androidx.viewbinding")
 
   api project(':workflow-core')
   api project(':workflow-ui:core-common')
 
-  api deps.androidx.transition
-  api deps.kotlin.stdLib.jdk6
-  api deps.rxjava2.rxjava2
+  api Dep.get("androidx.transition")
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("rxjava2.rxjava2")
 
   implementation project(':workflow-runtime')
-  implementation deps.androidx.activity
-  implementation deps.androidx.fragment
-  implementation deps.androidx.lifecycle.reactivestreams
-  implementation deps.androidx.savedstate
-  implementation deps.kotlin.coroutines.android
-  implementation deps.kotlin.coroutines.core
-  implementation deps.kotlin.coroutines.rx2
+  implementation Dep.get("androidx.activity")
+  implementation Dep.get("androidx.fragment")
+  implementation Dep.get("androidx.lifecycle.reactivestreams")
+  implementation Dep.get("androidx.savedstate")
+  implementation Dep.get("kotlin.coroutines.android")
+  implementation Dep.get("kotlin.coroutines.core")
+  implementation Dep.get("kotlin.coroutines.rx2")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.kotlin.coroutines.test
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.kotlin.test.mockito
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("kotlin.coroutines.test")
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("kotlin.test.mockito")
 }

--- a/kotlin/workflow-ui/core-common/build.gradle
+++ b/kotlin/workflow-ui/core-common/build.gradle
@@ -23,9 +23,9 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  api deps.kotlin.stdLib.jdk6
-  api deps.okio
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("okio")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.truth
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("test.truth")
 }

--- a/kotlin/workflow-ui/core-compose/build.gradle
+++ b/kotlin/workflow-ui/core-compose/build.gradle
@@ -27,13 +27,13 @@ apply from: rootProject.file('.buildscript/configure-compose.gradle')
 
 dependencies {
   api project(':workflow-ui:core-android')
-  api deps.kotlin.stdLib.jdk8
+  api Dep.get("kotlin.stdLib.jdk8")
 
   implementation project(':workflow-runtime')
-  implementation deps.compose.foundation
-  implementation deps.compose.layout
-  implementation deps.compose.tooling
+  implementation Dep.get("compose.foundation")
+  implementation Dep.get("compose.layout")
+  implementation Dep.get("compose.tooling")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
 }

--- a/kotlin/workflow-ui/modal-android/build.gradle
+++ b/kotlin/workflow-ui/modal-android/build.gradle
@@ -29,23 +29,23 @@ dependencies {
   api project(':workflow-ui:core-android')
   api project(':workflow-ui:modal-common')
 
-  api deps.androidx.transition
-  api deps.kotlin.stdLib.jdk6
-  api deps.rxjava2.rxjava2
+  api Dep.get("androidx.transition")
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("rxjava2.rxjava2")
 
   implementation project(':workflow-runtime')
-  implementation deps.androidx.appcompat
-  implementation deps.androidx.activity
-  implementation deps.androidx.fragment
-  implementation deps.androidx.lifecycle.reactivestreams
-  implementation deps.androidx.savedstate
-  implementation deps.kotlin.coroutines.android
-  implementation deps.kotlin.coroutines.core
-  implementation deps.kotlin.coroutines.rx2
+  implementation Dep.get("androidx.appcompat")
+  implementation Dep.get("androidx.activity")
+  implementation Dep.get("androidx.fragment")
+  implementation Dep.get("androidx.lifecycle.reactivestreams")
+  implementation Dep.get("androidx.savedstate")
+  implementation Dep.get("kotlin.coroutines.android")
+  implementation Dep.get("kotlin.coroutines.core")
+  implementation Dep.get("kotlin.coroutines.rx2")
 
-  testImplementation deps.test.junit
-  testImplementation deps.test.truth
-  testImplementation deps.kotlin.coroutines.test
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.kotlin.test.mockito
+  testImplementation Dep.get("test.junit")
+  testImplementation Dep.get("test.truth")
+  testImplementation Dep.get("kotlin.coroutines.test")
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("kotlin.test.mockito")
 }

--- a/kotlin/workflow-ui/modal-common/build.gradle
+++ b/kotlin/workflow-ui/modal-common/build.gradle
@@ -23,9 +23,9 @@ targetCompatibility = JavaVersion.VERSION_1_8
 apply from: rootProject.file('.buildscript/configure-maven-publish.gradle')
 
 dependencies {
-  api deps.kotlin.stdLib.jdk6
-  api deps.okio
+  api Dep.get("kotlin.stdLib.jdk6")
+  api Dep.get("okio")
 
-  testImplementation deps.kotlin.test.jdk
-  testImplementation deps.test.truth
+  testImplementation Dep.get("kotlin.test.jdk")
+  testImplementation Dep.get("test.truth")
 }


### PR DESCRIPTION
Groovy can't access nested kotlin `object`s, so until the rest of the gradle files
are converted to kotlin this change introduces a helper, `Dep.get`, which takes the
dot-separated name of the dependency as a string.