### PR TITLE
Increase CI timeout for Kotlin assemble job (for real)

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -18,7 +18,7 @@ jobs:
   assemble:
     name: Assemble
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       # These setup steps should be common across all jobs in this workflow.
       - uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
     name: Check
     needs: assemble
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       # Run all checks, even if some fail.
       fail-fast: false


### PR DESCRIPTION
I'm an idiot, and #1062 changed the timeout for the Check job, not the Assemble job.

> Some assemble runs take ~8 minutes, which, when added to the durations of the other steps in the job, exceeds the timeout.
>
> Also removes the '!gh-pages' from the push branch list, since master doesn't use globs it's good enough.