### PR TITLE
Fix Kotlin build caching.

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -14,6 +14,12 @@ on:
       - .github/workflows/kotlin.yml
       - kotlin/**
 
+env:
+  # Must use $HOME here, NOT a tilde, because of the order in which bash does expansion:
+  # Tilde happens before variables, so will be used literally, whereas $HOME will be
+  # recursively expanded.
+  GRADLE_CACHE_PATH: $HOME/.gradle/caches
+
 jobs:
   assemble:
     name: Assemble
@@ -29,23 +35,35 @@ jobs:
           java-version: 1.8
 
       ## Caching
-      - name: Cache build artifacts
+      - name: Cache gradle dependencies
         uses: actions/cache@v1
         with:
-            path: ~/.gradle/caches
-            # Include the SHA in the hash so this step always adds a cache entry. If we didn't use the SHA, the artifacts
-            # would only get cached once for each build config hash.
-            # Don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
-            key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
-            # The first time a SHA is assembled, we still want to load dependencies from the cache.
-            # Note that none of jobs dependent on this one need restore keys, since they'll always have an exact hit.
-            restore-keys: |
-              gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-
+          path: ${{ env.GRADLE_CACHE_PATH }}
+          # Include the SHA in the hash so this step always adds a cache entry. If we didn't use the SHA, the artifacts
+          # would only get cached once for each build config hash.
+          # Don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
+          key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
+          # The first time a SHA is assembled, we still want to load dependencies from the cache.
+          # Note that none of jobs dependent on this one need restore keys, since they'll always have an exact hit.
+          restore-keys: |
+            gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-
+
+      # We want to keep the dependencies from the cache, but clear out the build cache which contains the actual
+      # compiled artifacts from this project. This ensures we don't run into any issues with stale cache entries,
+      # and that the resulting cache we upload for the other jobs won't waste any space on stale binaries.
+      # A simpler approach would be simply to delete the build-cache before uploading the cache archive, however
+      # if we did that in this job it would defeat the purpose of sharing that directory with dependent jobs,
+      # and there's no way to modify the cache after the job that created it finishes.
+      - name: Clean gradle build cache to assemble fresh
+        run: |
+          ls -lhrt $GRADLE_CACHE_PATH || true
+          rm -rf $GRADLE_CACHE_PATH/build-cache-1
+          ls -lhrt $GRADLE_CACHE_PATH || true
 
       ## Actual task
-      - name: Assemble with Gradle
+      - name: Assemble with gradle
         working-directory: ./kotlin
-        run: ./gradlew assemble --stacktrace
+        run: ./gradlew assemble --build-cache --no-daemon --stacktrace
 
   # Runs all check tasks in parallel.
   check:
@@ -69,7 +87,6 @@ jobs:
           - jmhJar
     steps:
       - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -79,15 +96,15 @@ jobs:
       - name: Cache build artifacts
         uses: actions/cache@v1
         with:
-            path: ~/.gradle/caches
-            # Don't set restore-keys so cache is always only valid for the current build config.
-            # Also don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
-            key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
+          path: ${{ env.GRADLE_CACHE_PATH }}
+          # Don't set restore-keys so cache is always only valid for the current build config.
+          # Also don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
+          key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
 
       ## Actual task
       - name: Check with Gradle
         working-directory: ./kotlin
-        run: ./gradlew ${{ matrix.gradle-task }} --stacktrace
+        run: ./gradlew ${{ matrix.gradle-task }} --build-cache --no-daemon --stacktrace
 
   instrumentation-tests:
     name: Instrumentation tests
@@ -106,7 +123,6 @@ jobs:
           - 29
     steps:
       - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -116,10 +132,10 @@ jobs:
       - name: Cache build artifacts
         uses: actions/cache@v1
         with:
-            path: ~/.gradle/caches
-            # Don't set restore-keys so cache is always only valid for the current build config.
-            # Also don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
-            key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
+          path: ${{ env.GRADLE_CACHE_PATH }}
+          # Don't set restore-keys so cache is always only valid for the current build config.
+          # Also don't use ${{ runner.os }} in the key so we don't re-assemble for UI tests.
+          key: gradle-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/buildSrc/**') }}-${{ github.sha }}
 
       ## Actual task
       - name: Instrumentation Tests
@@ -128,4 +144,4 @@ jobs:
           working-directory: ./kotlin
           api-level: ${{ matrix.api-level }}
           arch: x86_64
-          script: ./gradlew connectedCheck --stacktrace
+          script: ./gradlew connectedCheck --build-cache --no-daemon --stacktrace

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -85,7 +85,7 @@ echo "SWIFT_API_DIR=$SWIFT_API_DIR"
 
 # Generate the Kotlin API docs.
 echo "Building Kotlin docs…"
-( cd kotlin && ./gradlew assemble --quiet && ./gradlew siteDokka --quiet )
+( cd kotlin && ./gradlew assemble --build-cache --quiet && ./gradlew siteDokka --build-cache --quiet )
 
 # Generate the Swift API docs.
 echo "Building Swift docs…"


### PR DESCRIPTION
Gradle doesn't use the build cache by default, so we weren't actually caching any
build artifacts, just dependencies. This change turns on build caching for all
gradle invocations, and adds some logic to the kotlin workflow to wipe the build cache
before each fresh assemble run.
