### PR TITLE
Make expected workers optional in RenderTester

### DIFF
--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RealRenderTester.kt
@@ -187,7 +187,7 @@ internal class RealRenderTester<PropsT, StateT, OutputT : Any, RenderingT>(
     }
   }
 
-  private inline fun <reified T : Expectation<*>> consumeExpectedChildWorkflow(
+  private inline fun <reified T : ExpectedWorkflow<*, *>> consumeExpectedChildWorkflow(
     predicate: (T) -> Boolean,
     description: () -> String
   ): T {
@@ -213,7 +213,7 @@ internal class RealRenderTester<PropsT, StateT, OutputT : Any, RenderingT>(
     return expected
   }
 
-  private inline fun <reified T : Expectation<*>> consumeExpectedWorker(
+  private inline fun <reified T : ExpectedWorker<*>> consumeExpectedWorker(
     predicate: (T) -> Boolean,
     description: () -> String
   ): T? {

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -62,11 +62,12 @@ fun <PropsT, StateT, OutputT : Any, RenderingT>
  * [verifyAction][RenderTestResult.verifyAction] or
  * [verifyActionResult][RenderTestResult.verifyActionResult].
  *
- * - All workflows and workers that are rendered/ran by this workflow must be specified.
+ * - All workflows that are rendered/ran by this workflow must be specified.
+ * - Workers are optionally specified. Specified workers must run. Unexpected workers on a render
+ *   pass do not cause a test failure.
  * - It is an error if more than one workflow or worker specifies an output.
  * - It is a test failure if any workflows or workers that were expected were not ran.
- * - It is a test failure if the workflow tried to run any workflows or workers that were not
- *   expected.
+ * - It is a test failure if the workflow tried to run any workflows that were not expected.
  * - It is a test failure if no workflow or workflow emitted an output, no rendering event was
  *   invoked, and any of the action verification methods on [RenderTestResult] is called.
  *
@@ -235,8 +236,8 @@ interface RenderTester<PropsT, StateT, OutputT : Any, RenderingT> {
    * Execute the workflow's `render` method and run [block] to perform assertions on and send events
    * to the resulting rendering.
    *
-   * All workflows and workers rendered/ran by the workflow must be specified before calling this
-   * method.
+   * All workflows rendered/ran by the workflow must be specified before calling this
+   * method. Workers are optionally specified.
    *
    * @param block Passed the result of the render pass to perform assertions on.
    * If no child workflow or worker was configured to emit an output, may also invoke one of the

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
@@ -187,7 +187,7 @@ class RealRenderTesterTest {
     val error = assertFailsWith<AssertionError> {
       tester.render()
     }
-    assertEquals("Tried to render unexpected worker Worker1.", error.message)
+    assertTrue(error.message!!.startsWith("Expected 1 more workflows or workers to be ran:"))
   }
 
   @Test fun `sending to sink throws when called multiple times`() {
@@ -369,7 +369,7 @@ class RealRenderTesterTest {
     )
   }
 
-  @Test fun `runningWorker throws when none expected`() {
+  @Test fun `runningWorker doesn't throw when none expected`() {
     val worker = object : Worker<Nothing> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
       override fun run(): Flow<Nothing> = emptyFlow()
@@ -380,14 +380,7 @@ class RealRenderTesterTest {
       runningWorker(worker)
     }
     val tester = workflow.renderTester(Unit)
-
-    val error = assertFailsWith<AssertionError> {
-      tester.render()
-    }
-    assertEquals(
-        "Tried to render unexpected worker TestWorker.",
-        error.message
-    )
+    tester.render()
   }
 
   @Test fun `runningWorker throws when expectation doesn't match`() {
@@ -406,13 +399,11 @@ class RealRenderTesterTest {
     val error = assertFailsWith<AssertionError> {
       tester.render()
     }
-    assertEquals(
-        "Tried to render unexpected worker TestWorker.",
-        error.message
-    )
+
+    assertTrue(error.message!!.startsWith("Expected 1 more workflows or workers to be ran:"))
   }
 
-  @Test fun `runningWorker with key throws when none expected`() {
+  @Test fun `runningWorker with key does not throw when none expected`() {
     val worker = object : Worker<Nothing> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
       override fun run(): Flow<Nothing> = emptyFlow()
@@ -424,13 +415,7 @@ class RealRenderTesterTest {
     }
     val tester = workflow.renderTester(Unit)
 
-    val error = assertFailsWith<AssertionError> {
-      tester.render()
-    }
-    assertEquals(
-        "Tried to render unexpected worker TestWorker with key \"key\".",
-        error.message
-    )
+    tester.render()
   }
 
   @Test fun `runningWorker with key throws when no key expected`() {
@@ -449,10 +434,7 @@ class RealRenderTesterTest {
     val error = assertFailsWith<AssertionError> {
       tester.render()
     }
-    assertEquals(
-        "Tried to render unexpected worker TestWorker with key \"key\".",
-        error.message
-    )
+    assertTrue(error.message!!.startsWith("Expected 1 more workflows or workers to be ran:"))
   }
 
   @Test fun `runningWorker with key throws when wrong key expected`() {
@@ -474,10 +456,7 @@ class RealRenderTesterTest {
     val error = assertFailsWith<AssertionError> {
       tester.render()
     }
-    assertEquals(
-        "Tried to render unexpected worker TestWorker with key \"key\".",
-        error.message
-    )
+    assertTrue(error.message!!.startsWith("Expected 1 more workflows or workers to be ran:"))
   }
 
   @Test fun `runningWorker throws when multiple expectations match`() {


### PR DESCRIPTION
Addressing [#959](https://github.com/square/workflow/issues/959)