### PR TITLE
WIP Spike kotlin dsl common build scripts

### DIFF
--- a/kotlin/.idea/misc.xml
+++ b/kotlin/.idea/misc.xml
@@ -13,6 +13,7 @@
       <item index="3" class="java.lang.String" itemvalue="org.openjdk.jmh.annotations.BenchmarkMode" />
     </list>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/kotlin/buildSrc/build.gradle.kts
+++ b/kotlin/buildSrc/build.gradle.kts
@@ -1,11 +1,50 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   `kotlin-dsl`
+  `kotlin-dsl-precompiled-script-plugins`
+}
+
+gradlePlugin {
+  plugins {
+    register("android-defaults-plugin") {
+      id = "android-defaults-plugin"
+      implementationClass = "plugins.AndroidDefaultsBinaryPlugin"
+    }
+  }
+}
+
+buildscript {
+  repositories {
+    mavenCentral()
+    jcenter()
+    google()
+  }
+
+  dependencies {
+    // not sure how to reference Dependencies.kt
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71")
+  }
 }
 
 repositories {
   mavenCentral()
+  jcenter()
+  google()
 }
 
 kotlinDslPluginOptions {
   experimentalWarning.set(false)
+}
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions {
+  languageVersion = "1.3.71"
+}
+
+dependencies {
+  implementation("com.android.tools.build:gradle:4.0.0-beta03")
+  implementation("com.android.tools.build:gradle-api:4.0.0-beta03")
+  implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.71")
 }

--- a/kotlin/buildSrc/src/main/java/Dependencies.kt
+++ b/kotlin/buildSrc/src/main/java/Dependencies.kt
@@ -8,6 +8,7 @@ object Versions {
   const val coroutines = "1.3.4"
   const val kotlin = "1.3.71"
   const val targetSdk = 29
+  const val minSdk = 21
 }
 
 @Suppress("unused")

--- a/kotlin/buildSrc/src/main/java/plugins/AndroidDefaultsBinaryPlugin.kt
+++ b/kotlin/buildSrc/src/main/java/plugins/AndroidDefaultsBinaryPlugin.kt
@@ -1,0 +1,66 @@
+package plugins
+
+import Versions
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class AndroidDefaultsBinaryPlugin : Plugin<Project> {
+  val Project.android: LibraryExtension
+    // why is there no api for this? why does this feel so hacky?
+    // from https://proandroiddev.com/sharing-build-logic-with-kotlin-dsl-203274f73013
+    get() = extensions.findByName("android") as? LibraryExtension
+        ?: error("Not an android module: $name")
+
+  override fun apply(project: Project) =
+    with(project) {
+      applyPlugins()
+      androidConfig()
+      packagingOptions()
+    }
+
+  private fun Project.applyPlugins() {
+    plugins.run {
+      apply("com.android.library")
+      apply("kotlin-android")
+      apply("kotlin-android-extensions")
+    }
+  }
+
+  private fun Project.androidConfig() {
+    android.run {
+      compileSdkVersion(Versions.targetSdk)
+      buildToolsVersion("29.0.2")
+      compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+      }
+      defaultConfig {
+        minSdkVersion(Versions.minSdk)
+        targetSdkVersion(Versions.targetSdk)
+        versionCode = 1
+        versionName = "1.0"
+      }
+      buildTypes {
+        getByName("debug") {
+          isMinifyEnabled = false
+        }
+      }
+      buildFeatures {
+        viewBinding = true
+      }
+    }
+  }
+
+  private fun Project.packagingOptions() {
+    android.run {
+      packagingOptions {
+        exclude("META-INF/atomicfu.kotlin_module")
+        exclude("META-INF/common.kotlin_module")
+        exclude("META-INF/android_debug.kotlin_module")
+        exclude("META-INF/android_release.kotlin_module")
+      }
+    }
+  }
+}

--- a/kotlin/samples/containers/android/build.gradle.kts
+++ b/kotlin/samples/containers/android/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id("com.android.library")
+  id("android-defaults-plugin")
   kotlin("android")
 }
 
@@ -22,8 +22,6 @@ java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
-
-apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 dependencies {
   api(project(":workflow-core"))

--- a/kotlin/samples/containers/poetry/build.gradle.kts
+++ b/kotlin/samples/containers/poetry/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id("com.android.library")
+  id("android-defaults-plugin")
   kotlin("android")
 }
 
@@ -22,8 +22,6 @@ java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
-
-apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 dependencies {
   api(project(":workflow-core"))

--- a/kotlin/samples/dungeon/timemachine-shakeable/build.gradle.kts
+++ b/kotlin/samples/dungeon/timemachine-shakeable/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id("com.android.library")
+  id("android-defaults-plugin")
   kotlin("android")
 }
 
@@ -22,8 +22,6 @@ java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
-
-apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 dependencies {
   api(project(":samples:dungeon:timemachine"))

--- a/kotlin/workflow-ui/backstack-android/api/backstack-android.api
+++ b/kotlin/workflow-ui/backstack-android/api/backstack-android.api
@@ -19,6 +19,8 @@ public class com/squareup/workflow/ui/backstack/BackStackContainer : android/wid
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun _$_clearFindViewByIdCache ()V
+	public fun _$_findCachedViewById (I)Landroid/view/View;
 	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
 	protected fun performTransition (Landroid/view/View;Landroid/view/View;Z)V

--- a/kotlin/workflow-ui/backstack-android/build.gradle.kts
+++ b/kotlin/workflow-ui/backstack-android/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id("com.android.library")
+  id("android-defaults-plugin")
   kotlin("android")
   id("org.jetbrains.dokka")
 }
@@ -25,8 +25,6 @@ java {
 }
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
-
-apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 // See https://github.com/Kotlin/kotlinx.coroutines/issues/1064#issuecomment-479412940
 android.packagingOptions.exclude("**/*.kotlin_*")

--- a/kotlin/workflow-ui/core-android/api/core-android.api
+++ b/kotlin/workflow-ui/core-android/api/core-android.api
@@ -120,17 +120,22 @@ public final class com/squareup/workflow/ui/ViewShowRenderingKt {
 
 public abstract class com/squareup/workflow/ui/WorkflowFragment : androidx/fragment/app/Fragment {
 	public fun <init> ()V
+	public fun _$_clearFindViewByIdCache ()V
+	public fun _$_findCachedViewById (I)Landroid/view/View;
 	protected final fun getRunner ()Lcom/squareup/workflow/ui/WorkflowRunner;
 	protected abstract fun getViewEnvironment ()Lcom/squareup/workflow/ui/ViewEnvironment;
 	public fun onActivityCreated (Landroid/os/Bundle;)V
 	public synthetic fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
 	public final fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Lcom/squareup/workflow/ui/WorkflowLayout;
 	protected abstract fun onCreateWorkflow ()Lcom/squareup/workflow/ui/WorkflowRunner$Config;
+	public synthetic fun onDestroyView ()V
 }
 
 public final class com/squareup/workflow/ui/WorkflowLayout : android/widget/FrameLayout {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun _$_clearFindViewByIdCache ()V
+	public fun _$_findCachedViewById (I)Landroid/view/View;
 	public final fun start (Lio/reactivex/Observable;Lcom/squareup/workflow/ui/ViewEnvironment;)V
 	public final fun start (Lio/reactivex/Observable;Lcom/squareup/workflow/ui/ViewRegistry;)V
 }
@@ -171,6 +176,8 @@ public final class com/squareup/workflow/ui/WorkflowViewStub : android/view/View
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun _$_clearFindViewByIdCache ()V
+	public fun _$_findCachedViewById (I)Landroid/view/View;
 	public final fun getActual ()Landroid/view/View;
 	public final fun setActual (Landroid/view/View;)V
 	public final fun update (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Landroid/view/View;

--- a/kotlin/workflow-ui/core-android/build.gradle.kts
+++ b/kotlin/workflow-ui/core-android/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id("com.android.library")
+  id("android-defaults-plugin")
   kotlin("android")
   id("org.jetbrains.dokka")
 }
@@ -25,8 +25,6 @@ java {
 }
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
-
-apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 dependencies {
   compileOnly(Dependencies.AndroidX.viewbinding)

--- a/kotlin/workflow-ui/core-compose/build.gradle.kts
+++ b/kotlin/workflow-ui/core-compose/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id("com.android.library")
+  id("android-defaults-plugin")
   kotlin("android")
 }
 
@@ -24,8 +24,6 @@ java {
 }
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
-
-apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
 

--- a/kotlin/workflow-ui/modal-android/api/modal-android.api
+++ b/kotlin/workflow-ui/modal-android/api/modal-android.api
@@ -6,6 +6,8 @@ public final class com/squareup/workflow/ui/modal/AlertContainer : com/squareup/
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;III)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun _$_clearFindViewByIdCache ()V
+	public fun _$_findCachedViewById (I)Landroid/view/View;
 	public synthetic fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
 }
 
@@ -32,6 +34,8 @@ public abstract class com/squareup/workflow/ui/modal/ModalContainer : android/wi
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun _$_clearFindViewByIdCache ()V
+	public fun _$_findCachedViewById (I)Landroid/view/View;
 	protected abstract fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
 	protected fun onRestoreInstanceState (Landroid/os/Parcelable;)V
 	protected fun onSaveInstanceState ()Landroid/os/Parcelable;
@@ -64,6 +68,8 @@ public class com/squareup/workflow/ui/modal/ModalViewContainer : com/squareup/wo
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun _$_clearFindViewByIdCache ()V
+	public fun _$_findCachedViewById (I)Landroid/view/View;
 	protected final fun buildDialog (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;)Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;
 	public fun buildDialogForView (Landroid/view/View;)Landroid/app/Dialog;
 	protected fun updateDialog (Lcom/squareup/workflow/ui/modal/ModalContainer$DialogRef;)V

--- a/kotlin/workflow-ui/modal-android/build.gradle.kts
+++ b/kotlin/workflow-ui/modal-android/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 plugins {
-  id("com.android.library")
+  id("android-defaults-plugin")
   kotlin("android")
   id("org.jetbrains.dokka")
 }
@@ -25,8 +25,6 @@ java {
 }
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
-
-apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
 
 dependencies {
   api(project(":workflow-core"))


### PR DESCRIPTION
Following this guide https://proandroiddev.com/sharing-build-logic-with-kotlin-dsl-203274f73013

I don't really like it, especially this bit in `AndroidDefaultsBinaryPlugin`
```
val Project.android: LibraryExtension
    get() = extensions.findByName("android") as? LibraryExtension
        ?: error("Not an android module: $name")
```

I've combed through https://github.com/gradle/kotlin-dsl-samples and there's not really an example of doing this so this feels hacky. I'm also way out of my depth here, really am unfamiliar with gradle.

This builds, but I couldn't figure out how to also share this plugin script with application modules. 