### PR TITLE
Modal Container with Modal Sample App

### DIFF
--- a/.gen_config.yml
+++ b/.gen_config.yml
@@ -2,6 +2,8 @@ local_sources:
   - .
   - swift/Samples/SplitScreenContainer
   - swift/Samples/BackStackContainer
+  - swift/Samples/ModalContainer
+  
 platforms:
   - ios
 podspec_paths:

--- a/Development.podspec
+++ b/Development.podspec
@@ -55,6 +55,7 @@ Pod::Spec.new do |s|
     app_spec.source_files = 'swift/Samples/TicTacToe/Sources/**/*.swift'
     app_spec.resources = 'swift/Samples/TicTacToe/Resources/**/*'
     app_spec.dependency 'BackStackContainer'
+    app_spec.dependency 'ModalContainer'
   end
 
   s.test_spec 'TicTacToeTests' do |test_spec|

--- a/swift/Samples/ModalContainer/ModalContainer.podspec
+++ b/swift/Samples/ModalContainer/ModalContainer.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = 'ModalContainer'
+  s.version      = '1.0.0.LOCAL'
+  s.summary      = 'See the README.'
+  s.homepage     = 'https://www.github.com/square/workflow'
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = 'Square'
+  s.source       = { git: 'Not Published', tag: "podify/#{s.version}" }
+
+  # 1.7 is needed for `swift_versions` support
+  s.cocoapods_version = '>= 1.7.0.beta.1'
+
+  s.swift_versions = ['5.0']
+  s.ios.deployment_target = '9.3'
+
+  s.source_files = 'Sources/**/*.swift'
+
+  s.dependency 'WorkflowUI'
+
+end

--- a/swift/Samples/ModalContainer/README.md
+++ b/swift/Samples/ModalContainer/README.md
@@ -1,0 +1,3 @@
+# ModalContainer
+
+Container to display screens modally

--- a/swift/Samples/ModalContainer/Sources/ModalContainerScreen.swift
+++ b/swift/Samples/ModalContainer/Sources/ModalContainerScreen.swift
@@ -1,0 +1,50 @@
+import WorkflowUI
+
+
+/// A `ModalContainerScreen` displays a base screen and optionally one or more modals on top of it.
+public struct ModalContainerScreen: Screen {
+
+    /// The base screen to show underneath any modally presented screens.
+    public var baseScreen: AnyScreen
+
+    /// Modally presented screens
+    public var modals: [Modal]
+
+    public init<ScreenType: Screen>(baseScreen: ScreenType, modals: [Modal]) {
+        self.baseScreen = AnyScreen(baseScreen)
+        self.modals = modals
+    }
+
+    public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        return ModalContainerViewController.description(for: self, environment: environment)
+    }
+}
+
+
+extension ModalContainerScreen {
+
+    /// Represents a single screen to be displayed modally
+    public struct Modal {
+
+        public enum Style: Hashable {
+            case fullScreen(animated: Bool)
+            case card
+        }
+
+        /// The screen to be displayed
+        public var screen: AnyScreen
+
+        /// The style in which the screen should be presented
+        public var style: Style
+
+        /// A key used to differentiate modal screens during updates
+        public var key: String
+
+        public init<ScreenType: Screen>(screen: ScreenType, style: Style = .fullScreen(animated: true), key: String = "") {
+            self.screen = AnyScreen(screen)
+            self.style = style
+            self.key = key
+        }
+    }
+
+}

--- a/swift/Samples/ModalContainer/Sources/ModalContainerScreen.swift
+++ b/swift/Samples/ModalContainer/Sources/ModalContainerScreen.swift
@@ -1,17 +1,17 @@
 import WorkflowUI
 
-
 /// A `ModalContainerScreen` displays a base screen and optionally one or more modals on top of it.
-public struct ModalContainerScreen: Screen {
+public struct ModalContainerScreen<BaseScreen: Screen>: Screen
+{
 
     /// The base screen to show underneath any modally presented screens.
-    public var baseScreen: AnyScreen
+    public let baseScreen: BaseScreen
 
     /// Modally presented screens
-    public var modals: [Modal]
+    public let modals: [ModalContainerScreenModal]
 
-    public init<ScreenType: Screen>(baseScreen: ScreenType, modals: [Modal]) {
-        self.baseScreen = AnyScreen(baseScreen)
+    public init(baseScreen: BaseScreen, modals: [ModalContainerScreenModal]) {
+        self.baseScreen = baseScreen
         self.modals = modals
     }
 
@@ -20,31 +20,32 @@ public struct ModalContainerScreen: Screen {
     }
 }
 
+/// Represents a single screen to be displayed modally
+public struct ModalContainerScreenModal {
 
-extension ModalContainerScreen {
-
-    /// Represents a single screen to be displayed modally
-    public struct Modal {
-
-        public enum Style: Hashable {
-            case fullScreen(animated: Bool)
-            case card
-        }
-
-        /// The screen to be displayed
-        public var screen: AnyScreen
-
-        /// The style in which the screen should be presented
-        public var style: Style
-
-        /// A key used to differentiate modal screens during updates
-        public var key: String
-
-        public init<ScreenType: Screen>(screen: ScreenType, style: Style = .fullScreen(animated: true), key: String = "") {
-            self.screen = AnyScreen(screen)
-            self.style = style
-            self.key = key
-        }
+    public enum Style: Equatable {
+        // full screen modal presentation
+        case fullScreen
+        // formsheet or pagesheet like modal presentation
+        case sheet
     }
 
+    /// The screen to be displayed
+    public var screen: AnyScreen
+    
+    /// A bool used to specify whether presentation should be animated
+    public var animated: Bool
+
+    /// The style in which the screen should be presented
+    public var style: Style
+
+    /// A key used to differentiate modal screens during updates
+    public var key: AnyHashable
+
+    public init<Key: Hashable>(screen: AnyScreen, style: Style = .fullScreen, key: Key, animated: Bool = true) {
+        self.screen = screen
+        self.style = style
+        self.key = AnyHashable(key)
+        self.animated = animated
+    }
 }

--- a/swift/Samples/ModalContainer/Sources/ModalContainerViewController.swift
+++ b/swift/Samples/ModalContainer/Sources/ModalContainerViewController.swift
@@ -1,0 +1,333 @@
+import UIKit
+import Workflow
+import WorkflowUI
+
+/// Container for showing workflow screens modally over a base screen.
+internal final class ModalContainerViewController: ScreenViewController<ModalContainerScreen> {
+
+    private var baseScreenViewController: DescribedViewController? = nil
+
+    private var presentedScreens: [ModallyPresentedScreen] = []
+
+    private var topmostScreenViewController: DescribedViewController? {
+        if let topModal = presentedScreens.last {
+            return topModal.viewController
+        } else if let baseScreenViewController = baseScreenViewController {
+            return baseScreenViewController
+        } else {
+            return nil
+        }
+    }
+
+    required init(screen: ModalContainerScreen, environment: ViewEnvironment) {
+        super.init(screen: screen, environment: environment)
+        update()
+    }
+
+    override func screenDidChange(from previousScreen: ModalContainerScreen, previousEnvironment: ViewEnvironment) {
+        update()
+    }
+
+    func update() {
+
+        if let baseScreenViewController = baseScreenViewController {
+            baseScreenViewController.update(screen: screen.baseScreen,  environment: environment)
+        }
+
+        if baseScreenViewController == nil {
+            // We don't have a base screen view controller, so make one.
+            let viewController = DescribedViewController(screen: screen.baseScreen, environment: environment)
+            addChild(viewController)
+            view.addSubview(viewController.view)
+            viewController.didMove(toParent: self)
+            baseScreenViewController = viewController
+        }
+
+        // Sort our existing modals into keyed buckets. This will typically contain a single view controller
+        // per value, but duplicate keys/styles/screen types will result in more. In that case, we simply dequeue them in order during the update cycle (first to last)
+        var previousScreens: [ModalIdentifier: [ModallyPresentedScreen]] = Dictionary(presentedScreens.map { ($0.identifier, [$0]) }, uniquingKeysWith: +)
+
+        // Will contain the new set of presented screens by the end of this method
+        var newScreens: [ModallyPresentedScreen] = []
+
+        var screensNeedingAppearanceTransition: [ModallyPresentedScreen] = []
+
+        for modal in screen.modals {
+            if let existing = previousScreens[modal.identifier]?.removeFirst() {
+                // Update existing screen view controller
+                existing.viewController.update(screen: modal.screen,  environment: environment)
+                newScreens.append(
+                    ModallyPresentedScreen(
+                        viewController: existing.viewController,
+                        screenType: type(of: modal.screen),
+                        style: modal.style,
+                        key: modal.key,
+                        dimmingView: existing.dimmingView
+                    ))
+            } else {
+                // Make a new screen view controller
+                let newViewController = DescribedViewController(screen: modal.screen, environment: environment)
+                addChild(newViewController)
+                view.addSubview(newViewController.view)
+                newViewController.didMove(toParent: self)
+
+                // Create and set a dimming view if the modal is in card style
+                var newDimmingView: UIView?
+                if .card == modal.style {
+                    let dimmingView = UIView()
+                    dimmingView.backgroundColor = UIColor(white: 0, alpha: 0.5)
+                    dimmingView.frame = view.bounds
+                    dimmingView.alpha = 0
+                    view.addSubview(dimmingView)
+                    newDimmingView = dimmingView
+                }
+
+                let modal = ModallyPresentedScreen(
+                    viewController: newViewController,
+                    screenType: type(of: modal.screen),
+                    style: modal.style,
+                    key: modal.key,
+                    dimmingView: newDimmingView
+                )
+                newScreens.append(modal)
+                screensNeedingAppearanceTransition.append(modal)
+            }
+        }
+
+        for modal in previousScreens.values.flatMap({ $0 }) {
+            // Anything left behind in `previousScreens` should be removed
+
+            let displayInfo = ModalDisplayInfo(containerSize: view.bounds.size, style: modal.style)
+
+            modal.viewController.willMove(toParent: nil)
+
+            UIView.animate(
+                withDuration: displayInfo.duration,
+                delay: 0.0,
+                options: displayInfo.animationOptions,
+                animations: {
+                    modal.viewController.view.frame = displayInfo.outgoingFinalFrame
+                    modal.viewController.view.transform = displayInfo.outgoingFinalTransform
+                    modal.viewController.view.alpha = displayInfo.outgoingFinalAlpha
+                    modal.dimmingView?.alpha = 0
+                },
+                completion: { _ in
+                    modal.viewController.view.removeFromSuperview()
+                    modal.viewController.removeFromParent()
+                    modal.dimmingView?.removeFromSuperview()
+                }
+            )
+        }
+
+        for modal in screensNeedingAppearanceTransition {
+            let displayInfo = ModalDisplayInfo(containerSize: view.bounds.size, style: modal.style)
+            modal.viewController.view.frame = displayInfo.incomingInitialFrame
+            modal.viewController.view.transform = displayInfo.incomingInitialTransform
+            modal.viewController.view.alpha = displayInfo.incomingInitialAlpha
+
+            UIView.animate(
+                withDuration: displayInfo.duration,
+                delay: 0.0,
+                options: displayInfo.animationOptions,
+                animations: {
+                    modal.viewController.view.bounds = CGRect(
+                        origin: .zero,
+                        size: displayInfo.frame.size
+                    )
+                    modal.viewController.view.center = CGPoint(
+                        x: displayInfo.frame.midX,
+                        y: displayInfo.frame.midY
+                    )
+                    modal.viewController.view.transform = displayInfo.transform
+                    modal.viewController.view.alpha = displayInfo.alpha
+                    modal.dimmingView?.alpha = 1
+                },
+                completion: { _ in
+                    UIAccessibility.post(notification: .screenChanged, argument: nil)
+                }
+            )
+        }
+
+        // Update our state to reflect the new screens post-update
+        presentedScreens = newScreens
+
+        // Sort our views. We go front to back to allow dismissed views to appear above currently presented views (this will matter after transition support is added).
+        for modal in presentedScreens.reversed() {
+            view.sendSubviewToBack(modal.viewController.view)
+            if let dimmingView = modal.dimmingView {
+                view.sendSubviewToBack(dimmingView)
+            }
+        }
+
+        view.sendSubviewToBack(baseScreenViewController!.view)
+
+        setNeedsStatusBarAppearanceUpdate()
+
+        if #available(iOS 11.0, *) {
+            setNeedsUpdateOfHomeIndicatorAutoHidden()
+            setNeedsUpdateOfScreenEdgesDeferringSystemGestures()
+        }
+
+        // Set the topmost screen to be the accessibility modal
+        presentedScreens.last?.viewController.view.accessibilityViewIsModal = true
+        for modal in presentedScreens.dropLast() {
+            modal.viewController.view.accessibilityViewIsModal = false
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        baseScreenViewController?.view.frame = view.bounds
+
+        presentedScreens.forEach {
+            let displayInfo = ModalDisplayInfo(containerSize: view.bounds.size, style: $0.style)
+            $0.viewController.view.frame = displayInfo.frame
+            $0.dimmingView?.frame = view.bounds
+        }
+    }
+
+    override var childForStatusBarStyle: UIViewController? {
+        return topmostScreenViewController
+    }
+
+    override var childForStatusBarHidden: UIViewController? {
+        return topmostScreenViewController
+    }
+
+    override var childForHomeIndicatorAutoHidden: UIViewController? {
+        return topmostScreenViewController
+    }
+
+    override var childForScreenEdgesDeferringSystemGestures: UIViewController? {
+        return topmostScreenViewController
+    }
+
+    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return topmostScreenViewController?.supportedInterfaceOrientations ?? super.supportedInterfaceOrientations
+    }
+
+}
+
+fileprivate struct ModallyPresentedScreen {
+    var viewController: DescribedViewController
+    var screenType: Screen.Type
+    var style: ModalContainerScreen.Modal.Style
+    var key: String
+    var dimmingView: UIView?
+
+    var identifier: ModalIdentifier {
+        return ModalIdentifier(
+            screenType: screenType,
+            style: style,
+            key: key
+        )
+    }
+}
+
+extension ModalContainerScreen.Modal {
+    fileprivate var identifier: ModalIdentifier {
+        return ModalIdentifier(
+            screenType: type(of: screen),
+            style: style,
+            key: key
+        )
+    }
+}
+
+fileprivate struct ModalIdentifier: Hashable {
+    var screenType: Any.Type
+    var style: ModalContainerScreen.Modal.Style
+    var key: String
+
+    static func == (lhs: ModalIdentifier, rhs: ModalIdentifier) -> Bool {
+        return lhs.screenType == rhs.screenType
+            && lhs.style == rhs.style
+            && lhs.key == rhs.key
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(screenType))
+        hasher.combine(style)
+        hasher.combine(key)
+    }
+
+}
+
+fileprivate struct ModalDisplayInfo {
+
+    var frame: CGRect
+    var alpha: CGFloat
+    var transform: CGAffineTransform
+    var incomingInitialFrame: CGRect
+    var outgoingFinalFrame: CGRect
+    var incomingInitialTransform: CGAffineTransform
+    var outgoingFinalTransform: CGAffineTransform
+    var incomingInitialAlpha: CGFloat
+    var outgoingFinalAlpha: CGFloat
+    var duration: TimeInterval
+    var animationOptions: UIView.AnimationOptions
+
+    init(containerSize: CGSize, style: ModalContainerScreen.Modal.Style) {
+
+        // Configure all properties so that they default to fullScreen animation.
+        frame = CGRect(origin: .zero, size: containerSize)
+        alpha = 1.0
+        transform = .identity
+        incomingInitialFrame = CGRect(
+            x: frame.origin.x,
+            y: containerSize.height,
+            width: frame.size.width,
+            height: frame.size.height
+        )
+        outgoingFinalFrame = CGRect(
+            x: frame.origin.x,
+            y: containerSize.height,
+            width: frame.size.width,
+            height: frame.size.height
+        )
+        incomingInitialTransform = .identity
+        outgoingFinalTransform = .identity
+        incomingInitialAlpha = 1.0
+        outgoingFinalAlpha = 1.0
+        duration = 0.5
+        animationOptions = UIView.AnimationOptions(rawValue: 7 << 16)
+
+        switch style {
+        case .fullScreen(let animated):
+            if !animated {
+                // Clear the default fullscreen animation configuration.
+                duration = 0
+                animationOptions = UIView.AnimationOptions.init(rawValue: 0)
+                incomingInitialFrame = frame
+                outgoingFinalFrame = frame
+            }
+        case .card:
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                // On iPhone always show modal in fullscreen.
+                break
+            }
+
+            let cardSideLength = min(containerSize.width, containerSize.height)
+            let cardSize = CGSize(width: cardSideLength, height: cardSideLength)
+            let cardOrigin = CGPoint(
+                x: (containerSize.width - cardSideLength) / 2,
+                y: (containerSize.height - cardSideLength) / 2
+            )
+
+            frame = CGRect(origin: cardOrigin, size: cardSize)
+
+            duration = 0.1
+            animationOptions = UIView.AnimationOptions.init(rawValue: 0)
+
+            // Do not animate frame.
+            incomingInitialFrame = frame
+            outgoingFinalFrame = frame
+
+            // Animate transform and alpha.
+            incomingInitialTransform = CGAffineTransform(scaleX: 0.85, y: 0.85)
+            outgoingFinalTransform = CGAffineTransform(scaleX: 0.85, y: 0.85)
+            incomingInitialAlpha = 0.0
+            outgoingFinalAlpha = 0.0
+        }
+    }
+}

--- a/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -17,6 +17,7 @@ import BackStackContainer
 import Workflow
 import WorkflowUI
 import ReactiveSwift
+import ModalContainer
 
 
 // MARK: Input and Output
@@ -172,7 +173,7 @@ extension AuthenticationWorkflow {
 
 extension AuthenticationWorkflow {
 
-    typealias Rendering = [BackStackScreen.Item]
+    typealias Rendering = ModalContainerScreen<BackStackScreen>
 
     func render(state: AuthenticationWorkflow.State, context: RenderContext<AuthenticationWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Action.self)
@@ -225,7 +226,7 @@ extension AuthenticationWorkflow {
             backStackItems.append(BackStackScreen.Item(screen: LoadingScreen(), barVisibility: .hidden))
         }
 
-        return backStackItems
+        return ModalContainerScreen(baseScreen: BackStackScreen(items: backStackItems), modals: [])
     }
 
     private func twoFactorScreen(error: AuthenticationService.AuthenticationError?, intermediateSession: String, sink: Sink<Action>) -> BackStackScreen.Item {

--- a/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitScreen.swift
@@ -1,0 +1,41 @@
+//  
+//  ConfirmQuitScreen.swift
+//  Development - SampleTicTacToe
+//
+//  Created by Astha Trivedi on 3/26/20.
+//
+
+import Workflow
+import WorkflowUI
+
+
+struct ConfirmQuitScreen: Screen {
+    
+    let Question: String
+    // This should contain all data to display in the UI
+
+    // It should also contain callbacks for any UI events, for example:
+    // var onButtonTapped: () -> Void
+
+    func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        return ConfirmQuitViewController.description(for: self, environment: environment)
+    }
+}
+
+
+final class ConfirmQuitViewController: ScreenViewController<ConfirmQuitScreen> {
+
+    required init(screen: ConfirmQuitScreen, environment: ViewEnvironment) {
+        super.init(screen: screen, environment: environment)
+        update(with: screen, environment: environment)
+    }
+
+    override func screenDidChange(from previousScreen: ConfirmQuitScreen, previousEnvironment: ViewEnvironment) {
+        update(with: screen, environment: environment)
+    }
+
+    private func update(with screen: ConfirmQuitScreen, environment: ViewEnvironment) {
+        /// Update UI
+    }
+
+}

--- a/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitScreen.swift
@@ -1,21 +1,27 @@
-//  
-//  ConfirmQuitScreen.swift
-//  Development - SampleTicTacToe
-//
-//  Created by Astha Trivedi on 3/26/20.
-//
-
+/*
+* Copyright 2019 Square Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 import Workflow
 import WorkflowUI
 
 
 struct ConfirmQuitScreen: Screen {
     
-    let Question: String
-    // This should contain all data to display in the UI
-
-    // It should also contain callbacks for any UI events, for example:
-    // var onButtonTapped: () -> Void
+    let question: String
+    var onQuitTapped: () -> Void = {}
+    var onCancelTapped: () -> Void = {}
 
     func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
         return ConfirmQuitViewController.description(for: self, environment: environment)
@@ -24,10 +30,15 @@ struct ConfirmQuitScreen: Screen {
 
 
 final class ConfirmQuitViewController: ScreenViewController<ConfirmQuitScreen> {
+    
+    private let questionLabel: UILabel = UILabel(frame: .zero)
+    private let confirmButton: UIButton = UIButton(frame: .zero)
+    private let cancelButton: UIButton = UIButton(frame: .zero)
+    private var onQuitTapped: () -> Void = {}
+    private var onCancelTapped: () -> Void = {}
 
     required init(screen: ConfirmQuitScreen, environment: ViewEnvironment) {
         super.init(screen: screen, environment: environment)
-        update(with: screen, environment: environment)
     }
 
     override func screenDidChange(from previousScreen: ConfirmQuitScreen, previousEnvironment: ViewEnvironment) {
@@ -36,6 +47,70 @@ final class ConfirmQuitViewController: ScreenViewController<ConfirmQuitScreen> {
 
     private func update(with screen: ConfirmQuitScreen, environment: ViewEnvironment) {
         /// Update UI
+        questionLabel.text = screen.question
+        onQuitTapped = screen.onQuitTapped
+        onCancelTapped = screen.onCancelTapped
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+
+        questionLabel.textAlignment = .center
+        
+        confirmButton.backgroundColor = UIColor(red: 41/255, green: 150/255, blue: 204/255, alpha: 1.0)
+        confirmButton.setTitle("Yes, quit the game", for: .normal)
+        confirmButton.addTarget(self, action: #selector(quitButtonTapped(sender:)), for: .touchUpInside)
+        
+        cancelButton.backgroundColor = UIColor(red: 41/255, green: 150/255, blue: 204/255, alpha: 1.0)
+        cancelButton.setTitle("Go back", for: .normal)
+        cancelButton.addTarget(self, action: #selector(cancelButtonTapped(sender:)), for: .touchUpInside)
+        
+        view.addSubview(questionLabel)
+        view.addSubview(confirmButton)
+        view.addSubview(cancelButton)
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        let inset: CGFloat = 12.0
+        let height: CGFloat = 44.0
+        let buttonHeight: CGFloat = 50.0
+        var yOffset = view.bounds.origin.y + view.bounds.size.height/4
+
+        questionLabel.frame = CGRect(
+            x: view.bounds.origin.x,
+            y: yOffset,
+            width: view.bounds.size.width,
+            height: height)
+
+        yOffset += height + inset*2
+        
+        confirmButton.frame = CGRect(
+            x: view.bounds.origin.x,
+            y: yOffset,
+            width: view.bounds.size.width,
+            height: buttonHeight)
+                .insetBy(dx: inset, dy: 0.0)
+
+        yOffset += height + inset*2
+        
+        cancelButton.frame = CGRect(
+            x: view.bounds.origin.x,
+            y: yOffset,
+            width: view.bounds.size.width,
+            height: buttonHeight)
+                .insetBy(dx: inset, dy: 0.0)
+    }
+    
+    @objc private func cancelButtonTapped(sender: UIButton) {
+        onCancelTapped()
+    }
+    
+    @objc private func quitButtonTapped(sender: UIButton) {
+        onQuitTapped()
     }
 
 }

--- a/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
@@ -1,10 +1,18 @@
-//  
-//  ConfirmQuitWorkflow.swift
-//  AppHost-Development-Unit-Tests
-//
-//  Created by Astha Trivedi on 3/26/20.
-//
-
+/*
+* Copyright 2019 Square Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 import Workflow
 import WorkflowUI
 import ReactiveSwift
@@ -15,13 +23,13 @@ import BackStackContainer
 
 struct ConfirmQuitWorkflow: Workflow {
     
-    //let baseScreen: AnyScreen
+   // let baseScreen: AnyScreen
     
-    typealias Output = Never
-//    enum Output {
-//        case quit
-//        case back
-//    }
+   enum Output {
+        case cancel
+        case confirm
+    }
+
 }
 
 
@@ -29,13 +37,7 @@ struct ConfirmQuitWorkflow: Workflow {
 
 extension ConfirmQuitWorkflow {
 
-    struct State {
-//        var step: Step
-//        enum Step {
-//            case confirmOnce
-//            case confirmTwice
-//        }
-    }
+    typealias State = Void
 
     func makeInitialState() -> ConfirmQuitWorkflow.State {
         return State()
@@ -52,57 +54,42 @@ extension ConfirmQuitWorkflow {
 extension ConfirmQuitWorkflow {
 
     enum Action: WorkflowAction {
+        
+        case cancel
+        case quit
 
         typealias WorkflowType = ConfirmQuitWorkflow
 
         func apply(toState state: inout ConfirmQuitWorkflow.State) -> ConfirmQuitWorkflow.Output? {
 
             switch self {
-                // Update state and produce an optional output based on which action was received.
+                case .cancel:
+                    return .cancel
+                
+                case .quit:
+                    return .confirm
             }
-
         }
     }
-}
-
-
-// MARK: Workers
-
-extension ConfirmQuitWorkflow {
-
-    struct ConfirmQuitWorker: Worker {
-
-        enum Output {
-
-        }
-
-        func run() -> SignalProducer<Output, Never> {
-            fatalError()
-        }
-
-        func isEquivalent(to otherWorker: ConfirmQuitWorker) -> Bool {
-            return true
-        }
-
-    }
-
 }
 
 // MARK: Rendering
 
 extension ConfirmQuitWorkflow {
     
-//    typealias Rendering = ModalContainerScreen
-//
-//    func render(state: ConfirmQuitWorkflow.State, context: RenderContext<ConfirmQuitWorkflow>) -> Rendering {
-//
-//        return ModalContainerScreen(baseScreen: , modals: <#T##[ModalContainerScreen.Modal]#>)
-//    }
-
     typealias Rendering = ConfirmQuitScreen
 
     func render(state: ConfirmQuitWorkflow.State, context: RenderContext<ConfirmQuitWorkflow>) -> Rendering {
-
-        return ConfirmQuitScreen(Question: "Are you sure??")
+        
+        let sink = context.makeSink(of: Action.self)
+        
+        return ConfirmQuitScreen(
+            question: "Are you sure you want to quit?",
+            onQuitTapped: {
+                sink.send(.quit)
+            },
+            onCancelTapped: {
+                sink.send(.cancel)
+            })
     }
 }

--- a/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
@@ -1,0 +1,108 @@
+//  
+//  ConfirmQuitWorkflow.swift
+//  AppHost-Development-Unit-Tests
+//
+//  Created by Astha Trivedi on 3/26/20.
+//
+
+import Workflow
+import WorkflowUI
+import ReactiveSwift
+import BackStackContainer
+
+
+// MARK: Input and Output
+
+struct ConfirmQuitWorkflow: Workflow {
+    
+    //let baseScreen: AnyScreen
+    
+    typealias Output = Never
+//    enum Output {
+//        case quit
+//        case back
+//    }
+}
+
+
+// MARK: State and Initialization
+
+extension ConfirmQuitWorkflow {
+
+    struct State {
+//        var step: Step
+//        enum Step {
+//            case confirmOnce
+//            case confirmTwice
+//        }
+    }
+
+    func makeInitialState() -> ConfirmQuitWorkflow.State {
+        return State()
+    }
+
+    func workflowDidChange(from previousWorkflow: ConfirmQuitWorkflow, state: inout State) {
+
+    }
+}
+
+
+// MARK: Actions
+
+extension ConfirmQuitWorkflow {
+
+    enum Action: WorkflowAction {
+
+        typealias WorkflowType = ConfirmQuitWorkflow
+
+        func apply(toState state: inout ConfirmQuitWorkflow.State) -> ConfirmQuitWorkflow.Output? {
+
+            switch self {
+                // Update state and produce an optional output based on which action was received.
+            }
+
+        }
+    }
+}
+
+
+// MARK: Workers
+
+extension ConfirmQuitWorkflow {
+
+    struct ConfirmQuitWorker: Worker {
+
+        enum Output {
+
+        }
+
+        func run() -> SignalProducer<Output, Never> {
+            fatalError()
+        }
+
+        func isEquivalent(to otherWorker: ConfirmQuitWorker) -> Bool {
+            return true
+        }
+
+    }
+
+}
+
+// MARK: Rendering
+
+extension ConfirmQuitWorkflow {
+    
+//    typealias Rendering = ModalContainerScreen
+//
+//    func render(state: ConfirmQuitWorkflow.State, context: RenderContext<ConfirmQuitWorkflow>) -> Rendering {
+//
+//        return ModalContainerScreen(baseScreen: , modals: <#T##[ModalContainerScreen.Modal]#>)
+//    }
+
+    typealias Rendering = ConfirmQuitScreen
+
+    func render(state: ConfirmQuitWorkflow.State, context: RenderContext<ConfirmQuitWorkflow>) -> Rendering {
+
+        return ConfirmQuitScreen(Question: "Are you sure??")
+    }
+}

--- a/swift/Samples/TicTacToe/Sources/Game/GameState.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/GameState.swift
@@ -1,0 +1,34 @@
+/*
+* Copyright 2019 Square Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+enum GameState {
+    case ongoing(turn: Player)
+    case win(Player)
+    case tie
+
+    mutating func toggle() {
+        switch self {
+        case .ongoing(turn: let player):
+            switch player {
+            case .x:
+                self = .ongoing(turn: .o)
+            case .o:
+                self = .ongoing(turn: .x)
+            }
+        default:
+            break
+        }
+    }
+}

--- a/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
@@ -96,11 +96,11 @@ extension RunGameWorkflow {
 
 extension RunGameWorkflow {
 
-    typealias Rendering = BackStackScreen
-    
+    typealias Rendering = ModalContainerScreen<BackStackScreen>
 
     func render(state: RunGameWorkflow.State, context: RenderContext<RunGameWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Action.self)
+        var modals: [ModalContainerScreenModal] = []
         
         var backStackItems: [BackStackScreen.Item] = [BackStackScreen.Item(
             screen: newGameScreen(
@@ -108,9 +108,9 @@ extension RunGameWorkflow {
                 playerX: state.playerX,
                 playerO: state.playerO),
             barVisibility: .hidden)]
+
         switch state.step {
         case .newGame:
-            //newScreen = BackStackScreen(items: backStackItems)
             break
 
         case .playing:
@@ -125,19 +125,45 @@ extension RunGameWorkflow {
                         content: .text("Quit"),
                         handler: {
                             sink.send(.confirmQuit)
-                        }))))))
-             //newScreen = BackStackScreen(items: backStackItems)
+                        }
+                    ))
+                ))
+            ))
             
         case .maybeQuit:
             
-           // let modalScreen = ModalContainerScreen
+            let takeTurnsScreen = TakeTurnsWorkflow(
+                playerX: state.playerX,
+                playerO: state.playerO)
+                .rendered(with: context)
+            backStackItems.append(BackStackScreen.Item(
+                screen: takeTurnsScreen,
+                barVisibility: .visible(BackStackScreen.BarContent(
+                    leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
+                        content: .text("Quit"),
+                        handler: {
+                            sink.send(.confirmQuit)
+                        }
+                    ))
+                ))
+            ))
             
             let confirmQuitScreen = ConfirmQuitWorkflow()
-                                    .rendered(with: context)
-            backStackItems.append(BackStackScreen.Item(screen: confirmQuitScreen))
+                .mapOutput( { output -> Action in
+                    switch output {
+                    case .cancel:
+                        return .startGame
+                    case .confirm:
+                        return .back
+                    }
+                })
+                .rendered(with: context)
+            modals.append(ModalContainerScreenModal(screen: AnyScreen(confirmQuitScreen), style: .fullScreen, key: "0", animated: true))
         }
+        
+        let modalContainerScreen = ModalContainerScreen(baseScreen: BackStackScreen(items: backStackItems), modals: modals)
 
-        return BackStackScreen(items: backStackItems)
+        return modalContainerScreen // this is the base screen. Render all of the pieces of the backstack.
     }
 
     private func newGameScreen(sink: Sink<Action>, playerX: String, playerO: String) -> NewGameScreen {

--- a/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
@@ -16,6 +16,7 @@
 import Workflow
 import WorkflowUI
 import BackStackContainer
+import ModalContainer
 
 
 // MARK: Input and Output
@@ -37,6 +38,7 @@ extension RunGameWorkflow {
         enum Step {
             case newGame
             case playing
+            case maybeQuit
         }
     }
 
@@ -62,6 +64,7 @@ extension RunGameWorkflow {
         case updatePlayerO(String)
         case startGame
         case back
+        case confirmQuit
 
         func apply(toState state: inout RunGameWorkflow.State) -> RunGameWorkflow.Output? {
 
@@ -77,6 +80,10 @@ extension RunGameWorkflow {
 
             case .back:
                 state.step = .newGame
+            
+            case .confirmQuit:
+                state.step = .maybeQuit
+                
             }
 
             return nil
@@ -90,10 +97,11 @@ extension RunGameWorkflow {
 extension RunGameWorkflow {
 
     typealias Rendering = BackStackScreen
+    
 
     func render(state: RunGameWorkflow.State, context: RenderContext<RunGameWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Action.self)
-
+        
         var backStackItems: [BackStackScreen.Item] = [BackStackScreen.Item(
             screen: newGameScreen(
                 sink: sink,
@@ -102,6 +110,7 @@ extension RunGameWorkflow {
             barVisibility: .hidden)]
         switch state.step {
         case .newGame:
+            //newScreen = BackStackScreen(items: backStackItems)
             break
 
         case .playing:
@@ -115,8 +124,17 @@ extension RunGameWorkflow {
                     leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
                         content: .text("Quit"),
                         handler: {
-                            sink.send(.back)
+                            sink.send(.confirmQuit)
                         }))))))
+             //newScreen = BackStackScreen(items: backStackItems)
+            
+        case .maybeQuit:
+            
+           // let modalScreen = ModalContainerScreen
+            
+            let confirmQuitScreen = ConfirmQuitWorkflow()
+                                    .rendered(with: context)
+            backStackItems.append(BackStackScreen.Item(screen: confirmQuitScreen))
         }
 
         return BackStackScreen(items: backStackItems)

--- a/swift/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
@@ -17,26 +17,6 @@ import Workflow
 import WorkflowUI
 
 
-enum GameState {
-    case ongoing(turn: Player)
-    case win(Player)
-    case tie
-
-    mutating func toggle() {
-        switch self {
-        case .ongoing(turn: let player):
-            switch player {
-            case .x:
-                self = .ongoing(turn: .o)
-            case .o:
-                self = .ongoing(turn: .x)
-            }
-        default:
-            break
-        }
-    }
-}
-
 // MARK: Input and Output
 
 struct TakeTurnsWorkflow: Workflow {

--- a/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
@@ -16,6 +16,7 @@
 import Workflow
 import WorkflowUI
 import BackStackContainer
+import ModalContainer
 
 
 // MARK: Input and Output
@@ -76,26 +77,25 @@ extension MainWorkflow {
 
 extension MainWorkflow {
 
-    typealias Rendering = BackStackScreen
+    typealias Rendering = ModalContainerScreen<BackStackScreen>
 
     func render(state: MainWorkflow.State, context: RenderContext<MainWorkflow>) -> Rendering {
 
         switch state {
         case .authenticating:
-            let authenticationBackStackItems = AuthenticationWorkflow(
+            return AuthenticationWorkflow(
                 authenticationService: AuthenticationService())
                 .mapOutput({ output -> Action in
                     switch output {
                     case .authorized(session: let sessionToken):
                         return .authenticated(sessionToken: sessionToken)
                     }
-                })
-                .rendered(with: context)
-
-            return BackStackScreen(items: authenticationBackStackItems)
-
+                }
+            )
+            .rendered(with: context)
         case .runningGame:
-            return RunGameWorkflow().rendered(with: context)
+            return RunGameWorkflow()
+                .rendered(with: context)
         }
 
     }


### PR DESCRIPTION
This PR has all the changes addressing the PR i had created a few days ago. Git is not letting me reopen the earlier closed PR since i used force-push in order to fix some commit history issue. I had seen that issue before and have finally found the root cause. I do not foresee this being a problem anymore. I will add everyone's respective comments to make things easier for everyone. For reference, here's the older closed [PR](https://github.com/square/workflow/pull/1087). 

PR includes:

1. Adding ModalContainerScreen and ModalContainerViewController to open source adding a podspec file for the same.
2. Presenting modal view controller as a "confirm to quit" screen to TicTacToe app. 
3. All the PR feedback from the previous PR which i will mention at each line for reference.