### PR TITLE
Bumping ios deployment target

### DIFF
--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.7.0.beta.1'
 
   s.swift_versions = ['5.0']
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
 
   s.source_files = 'swift/Workflow/Sources/*.swift'

--- a/WorkflowTesting.podspec
+++ b/WorkflowTesting.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.7.0.beta.1'
 
   s.swift_versions = ['5.0']
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
 
   s.source_files = 'swift/WorkflowTesting/Sources/*.swift'

--- a/WorkflowUI.podspec
+++ b/WorkflowUI.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.7.0.beta.1'
 
   s.swift_versions = ['5.0']
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '10.0'
   s.osx.deployment_target = '10.12'
 
   s.source_files = 'swift/WorkflowUI/Sources/**/*.swift'

--- a/swift/Samples/BackStackContainer/BackStackContainer.podspec
+++ b/swift/Samples/BackStackContainer/BackStackContainer.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.7.0.beta.1'
 
   s.swift_versions = ['5.0']
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '10.0'
 
   s.source_files = 'Sources/**/*.{swift}'
 

--- a/swift/Samples/ModalContainer/ModalContainer.podspec
+++ b/swift/Samples/ModalContainer/ModalContainer.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.7.0.beta.1'
 
   s.swift_versions = ['5.0']
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '10.0'
 
   s.source_files = 'Sources/**/*.swift'
 

--- a/swift/Samples/SplitScreenContainer/SplitScreenContainer.podspec
+++ b/swift/Samples/SplitScreenContainer/SplitScreenContainer.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.7.0.beta.1'
 
   s.swift_versions = ['5.0']
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '10.0'
 
   s.source_files = 'Sources/**/*.swift'
 


### PR DESCRIPTION
Bumped iOS deployment target of podspec files which were at 9.3 to 10.0. Development.podspec is already at 11 so we will not change it. We are keeping the rest 10.0 since we still have to support iOS 10 for SPOS