### PR TITLE
Provide empty `makeInitialState` and `workflowDidChange` when State is Void 

### DIFF
--- a/swift/Workflow/Sources/Workflow.swift
+++ b/swift/Workflow/Sources/Workflow.swift
@@ -85,6 +85,21 @@ public protocol Workflow: AnyWorkflowConvertible {
 
 }
 
+
+/// When State is Void, provide empty `makeInitialState` and `workflowDidChange`
+/// implementations, making a “stateless workflow”.
+extension Workflow where State == Void {
+
+    public func makeInitialState() -> State {
+        return ()
+    }
+
+    public func workflowDidChange(from previousWorkflow: Self, state: inout State) {
+    }
+
+}
+
+
 extension Workflow {
 
     public func asAnyWorkflow() -> AnyWorkflow<Rendering, Output> {

--- a/swift/WorkflowUI/Sources/Container/ContainerViewController+AnyWorkflow.swift
+++ b/swift/WorkflowUI/Sources/Container/ContainerViewController+AnyWorkflow.swift
@@ -39,13 +39,6 @@ fileprivate struct WrapperWorkflow<Rendering, Output>: Workflow {
         self.wrapped = wrapped.asAnyWorkflow()
     }
 
-    func makeInitialState() -> State {
-        return ()
-    }
-
-    func workflowDidChange(from previousWorkflow: WrapperWorkflow, state: inout State) {
-    }
-
     func render(state: State, context: RenderContext<WrapperWorkflow>) -> Rendering {
         return wrapped
             .mapOutput { AnyWorkflowAction(sendingOutput: $0) }


### PR DESCRIPTION
Essentially a “StatelessWorkflow” without that being a separate type.

#236