### PR TITLE
Stops promising to re-render on noAction.

### DIFF
--- a/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
+++ b/kotlin/workflow-core/src/main/java/com/squareup/workflow/WorkflowAction.kt
@@ -59,8 +59,8 @@ interface WorkflowAction<StateT, out OutputT : Any> {
 
   companion object {
     /**
-     * Returns a [WorkflowAction] that does nothing: no output will be emitted, and `render` will be
-     * called again with the same `state` as last time.
+     * Returns a [WorkflowAction] that does nothing: no output will be emitted, and
+     * the state will not change.
      *
      * Use this to, for example, ignore the output of a child workflow or worker.
      */


### PR DESCRIPTION
There are obvious optimizations we'd like to make to ensure that we don't re-render when the state does not change.