### PR TITLE
Reorder RenderTester render arguments

### DIFF
--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -184,7 +184,7 @@ public final class RenderTester<WorkflowType: Workflow> {
 
     /// Call `render` with a set of expectations. If the expectations have not been fulfilled, the test will fail.
     @discardableResult
-    public func render(with expectations: RenderExpectations<WorkflowType>, assertions: (WorkflowType.Rendering) -> Void, file: StaticString = #file, line: UInt = #line) -> RenderTester<WorkflowType> {
+    public func render(file: StaticString = #file, line: UInt = #line, with expectations: RenderExpectations<WorkflowType>, assertions: (WorkflowType.Rendering) -> Void) -> RenderTester<WorkflowType> {
 
         let testContext = RenderTestContext<WorkflowType>(
             state: state,
@@ -206,12 +206,12 @@ public final class RenderTester<WorkflowType: Workflow> {
     /// Convenience method for testing without creating an explicit RenderExpectation.
     @discardableResult
     public func render(
+        file: StaticString = #file, line: UInt = #line,
         expectedState: ExpectedState<WorkflowType>? = nil,
         expectedOutput: ExpectedOutput<WorkflowType>? = nil,
         expectedWorkers: [ExpectedWorker] = [],
         expectedWorkflows: [ExpectedWorkflow] = [],
-        assertions: (WorkflowType.Rendering) -> Void,
-        file: StaticString = #file, line: UInt = #line
+        assertions: (WorkflowType.Rendering) -> Void
     ) -> RenderTester<WorkflowType> {
 
         let expectations = RenderExpectations(
@@ -220,7 +220,7 @@ public final class RenderTester<WorkflowType: Workflow> {
             expectedWorkers: expectedWorkers,
             expectedWorkflows: expectedWorkflows)
 
-        return self.render(with: expectations, assertions: assertions, file: file, line: line)
+        return self.render(file: file, line: line, with: expectations, assertions: assertions)
     }
 
     /// Assert the internal state.

--- a/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -49,6 +49,14 @@ final class WorkflowRenderTesterTests: XCTestCase {
         XCTAssertTrue(testedAssertion)
     }
 
+    func test_simple_render() {
+        let renderTester = TestWorkflow(initialText: "initial").renderTester()
+
+        renderTester.render { screen in
+            XCTAssertEqual("initial", screen.text)
+        }
+    }
+
     func test_action() {
         let renderTester = TestWorkflow(initialText: "initial").renderTester()
 


### PR DESCRIPTION
This PR moves `file: StaticString = #file, line: UInt = #line` in the `render` function of `RenderTester` to the beginning of the signature. This allows us to use the assertion: part of the function as a trailing closure. 

Currently if you're writing tests using a `RenderTester`, the following throws a `Ambiguous reference to member 'render'` error:

```
        let renderTester = TestWorkflow(initialText: "initial").renderTester()
        renderTester.render { screen in
            XCTAssertEqual("initial", screen.text)
        }
```

To get it to work you would need to explicitly use the `assertion:` label 

```
        let renderTester = TestWorkflow(initialText: "initial").renderTester()
        renderTester.render(
                assertions: { screen in
                     XCTAssertEqual("initial", screen.text)
               }
        )
```

This PR resolve this and allows us to use trailing closure for RenderTester