### PR TITLE
Remove context.subscribe

### DIFF
--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -185,9 +185,9 @@ extension DemoWorkflow {
             subscribeTitle = "Subscribe"
         case .subscribing:
             // Subscribe to the timer signal, simulating the title being tapped.
-            context.subscribe(signal: state.signal.signal.map({ _ -> Action in
+            context.awaitResult(for: state.signal.signal.asWorker(key: "Timer")) { _ -> Action in
                 return .titleButtonTapped
-            }))
+            }
             subscribeTitle = "Stop"
         }
 

--- a/swift/Workflow/Sources/RenderContext.swift
+++ b/swift/Workflow/Sources/RenderContext.swift
@@ -71,11 +71,6 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         fatalError()
     }
 
-    @available(*, deprecated, message: "Use a SignalWorker instead")
-    public func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, WorkflowType == Action.WorkflowType {
-        fatalError()
-    }
-
     public func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
         fatalError()
     }
@@ -109,12 +104,6 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
             return implementation.makeSink(of: actionType)
         }
 
-        override func subscribe<Action>(signal: Signal<Action, Never>) where WorkflowType == Action.WorkflowType, Action : WorkflowAction {
-            assertStillValid()
-            return implementation.subscribe(signal: signal)
-        }
-
-
         override func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, WorkflowType == Action.WorkflowType {
             assertStillValid()
             implementation.awaitResult(for: worker, outputMap: outputMap)
@@ -135,8 +124,6 @@ internal protocol RenderContextType: class {
     func render<Child, Action>(workflow: Child, key: String, outputMap: @escaping (Child.Output) -> Action) -> Child.Rendering where Child: Workflow, Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
     func makeSink<Action>(of actionType: Action.Type) -> Sink<Action> where Action: WorkflowAction, Action.WorkflowType == WorkflowType
-
-    func subscribe<Action>(signal: Signal<Action, Never>) where Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
     

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -241,9 +241,9 @@ final class SubtreeManagerTests: XCTestCase {
 
             func render(state: SubscribingWorkflow.State, context: RenderContext<SubscribingWorkflow>) -> Bool {
                 if let signal = signal {
-                    context.subscribe(signal: signal.map({ _ -> AnyWorkflowAction<SubscribingWorkflow> in
+                    context.awaitResult(for: signal.asWorker(key: "signal")) { _ -> AnyWorkflowAction<SubscribingWorkflow> in
                         return AnyWorkflowAction.noAction
-                    }))
+                    }
                     return true
                 } else {
                     return false

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -270,16 +270,14 @@ fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         let sink = Sink<Action> { action in
             observer.send(value: AnyWorkflowAction(action))
         }
-        subscribe(signal: signal)
-        return sink
-    }
 
-    func subscribe<Action>(signal: Signal<Action, Never>) where Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
         signal
             .take(during: lifetime)
             .observeValues { [weak self] action in
                 self?.apply(action: action)
             }
+
+        return sink
     }
 
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W : Worker, Action : WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {

--- a/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -135,13 +135,12 @@ fileprivate struct MockWorkflow: Workflow {
     }
 
     func render(state: State, context: RenderContext<MockWorkflow>) -> TestScreen {
-
-        context.subscribe(signal: subscription.map { output in
+        context.awaitResult(for: subscription.asWorker(key: "signal")) { output in
             return AnyWorkflowAction { state in
                 state = output
                 return output
             }
-        })
+        }
 
         return TestScreen(string: "\(state)")
     }


### PR DESCRIPTION
This is a rebase of #1025. It removes `context.subscribe` altogether, now that we've migrated our internal clients. **This is a breaking change.**

This finishes the work on #402 / #744.