### PR TITLE
Upgrade compose to dev09.

### DIFF
--- a/kotlin/buildSrc/src/main/java/Dependencies.kt
+++ b/kotlin/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@ import java.util.Locale.US
 import kotlin.reflect.full.declaredMembers
 
 object Versions {
-  const val compose = "0.1.0-dev07"
+  const val compose = "0.1.0-dev09"
   const val coroutines = "1.3.4"
   const val kotlin = "1.3.71"
   const val targetSdk = 29

--- a/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
+++ b/kotlin/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
@@ -16,12 +16,15 @@
 package com.squareup.sample.hellocomposebinding
 
 import androidx.compose.Composable
-import androidx.ui.core.Text
+import androidx.ui.core.Alignment
+import androidx.ui.core.Modifier
 import androidx.ui.foundation.Clickable
-import androidx.ui.layout.Center
+import androidx.ui.foundation.Text
+import androidx.ui.layout.fillMaxSize
+import androidx.ui.layout.wrapContentSize
 import androidx.ui.material.MaterialTheme
 import androidx.ui.material.Surface
-import androidx.ui.material.ripple.Ripple
+import androidx.ui.material.ripple.ripple
 import androidx.ui.tooling.preview.Preview
 import com.squareup.sample.hellocomposebinding.HelloWorkflow.Rendering
 import com.squareup.workflow.ui.compose.bindCompose
@@ -34,12 +37,12 @@ val HelloBinding = bindCompose<Rendering> { rendering, _ ->
 
 @Composable
 private fun DrawHelloRendering(rendering: Rendering) {
-  Ripple(bounded = true) {
-    Clickable(onClick = { rendering.onClick() }) {
-      Center {
-        Text(rendering.message)
-      }
-    }
+  Clickable(
+      modifier = Modifier.fillMaxSize()
+          .ripple(bounded = true),
+      onClick = { rendering.onClick() }
+  ) {
+    Text(rendering.message, modifier = Modifier.wrapContentSize(Alignment.Center))
   }
 }
 


### PR DESCRIPTION
# Description
This converts to the new modifier fluent syntax, as well as changes how updates are
sent into `bindCompose` compositions.

Previously, every time we got a rendering, we would call `setContent` on the view hosting
the composition and call `showRendering` from there. It worked, but probably wasn't the
most efficient solution (the content function isn't really changing, we just need to
pass some new data to the composition). However, in dev09, there seems to be a bug in
Compose (filed [here](https://issuetracker.google.com/issues/155106688)) that causes a crash when this is done from an input handler. So this PR changes
that mechanism to only call `setContent` at view initialization and use a `MutableState`
object to pass new renderings/`ViewEnvironment`s into the composition. This avoids the
crash but also makes more sense from a dataflow standpoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] API change this is not Backward compatible (fix or feature that would cause existing functionality to not work as expected or change the API contract)
- [ ] This change requires a documentation update
- [x] Dependency update

## Testing Checklist
How was this change tested?

- [ ] Unit Tests
- [x] UI Tests
- [ ] Snapshot Tests (iOS only)
- [x] Manual tests

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published 
