### PR TITLE
Add missing function reference in ViewBinding doc.

### DIFF
--- a/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/LayoutRunner.kt
+++ b/kotlin/workflow-ui/core-android/src/main/java/com/squareup/workflow/ui/LayoutRunner.kt
@@ -75,7 +75,7 @@ typealias ViewBindingInflater<BindingT> = (LayoutInflater, ViewGroup?, Boolean) 
  *     }
  *
  *     companion object : ViewFactory<Rendering> by bind(
- *         HelloGoodbyeLayoutBinding, ::HelloLayoutRunner
+ *         HelloGoodbyeLayoutBinding::inflate, ::HelloLayoutRunner
  *     )
  *   }
  *


### PR DESCRIPTION
# Description

PR adds the missing function reference to `inflate` in AndroidX ViewBinding doc for LayoutRunner.

Fixes #1124

## Type of change

Please select at least one

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] API change this is not Backward compatible (fix or feature that would cause existing functionality to not work as expected or change the API contract)
- [x] This change requires a documentation update
- [ ] Dependency update

## Testing Checklist
How was this change tested?

N/A.

## Documentation

This PR is a documentation fix.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published 

