### PR TITLE
Trim the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,7 @@
-# Description
 
-Please include a summary of the change or the fix you've made. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
-Fixes # (issue)
-
-## Type of change
-
-Please select at least one
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] API change this is not Backward compatible (fix or feature that would cause existing functionality to not work as expected or change the API contract)
-- [ ] This change requires a documentation update
-- [ ] Dependency update
-
-## Testing Checklist
-How was this change tested?
+## Checklist
 
 - [ ] Unit Tests
 - [ ] UI Tests
 - [ ] Snapshot Tests (iOS only)
-
-## Documentation
-
-_Please list any documentation changes or additions. Please delete if not necessary._
-
-## Additional Info
-
-_Please enter any additional information that could be helpful for the reviewers or just to document. Please delete if not necessary._
-
-## Checklist:
-
-- [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [ ] Any dependent changes have been merged and published 
-


### PR DESCRIPTION
The PR template is causing a bit more friction than I think is necessary, so this change makes a few improvements:

- The formatting of the template required moving the commit message text, which was just a hassle. 
- Many options in the "type of change" list already exist as labels, and labels are a better tool for this (searchable).
- Documentation section was redundant with documentation checklist.
- Additional Info section was unclear - that stuff should be in the commit message anyway.
- Removed trivial items from the checklist and merged testing and general checklist