### PR TITLE
Adding Alert Screen to Workflow Samples

### DIFF
--- a/.gen_config.yml
+++ b/.gen_config.yml
@@ -3,7 +3,8 @@ local_sources:
   - swift/Samples/SplitScreenContainer
   - swift/Samples/BackStackContainer
   - swift/Samples/ModalContainer
-  
+  - swift/Samples/AlertContainer
+
 platforms:
   - ios
 podspec_paths:

--- a/Development.podspec
+++ b/Development.podspec
@@ -56,6 +56,7 @@ Pod::Spec.new do |s|
     app_spec.resources = 'swift/Samples/TicTacToe/Resources/**/*'
     app_spec.dependency 'BackStackContainer'
     app_spec.dependency 'ModalContainer'
+    app_spec.dependency 'AlertContainer'
   end
 
   s.test_spec 'TicTacToeTests' do |test_spec|

--- a/swift/Samples/AlertContainer/AlertContainer.podspec
+++ b/swift/Samples/AlertContainer/AlertContainer.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name         = 'AlertContainer'
+  s.version      = '1.0.0.LOCAL'
+  s.summary      = 'See the README.'
+  s.homepage     = 'https://www.github.com/square/workflow'
+  s.license      = 'Apache License, Version 2.0'
+  s.author       = 'Square'
+  s.source       = { git: 'Not Published', tag: "podify/#{s.version}" }
+
+  # 1.7 is needed for `swift_versions` support
+  s.cocoapods_version = '>= 1.7.0' 
+
+  s.swift_versions = ['5.0']
+  s.ios.deployment_target = '10.0'
+
+  s.source_files = 'Sources/**/*.swift'
+
+  s.dependency 'WorkflowUI'
+
+end

--- a/swift/Samples/AlertContainer/README.md
+++ b/swift/Samples/AlertContainer/README.md
@@ -1,0 +1,4 @@
+# AlertContainer
+
+Container to display alert screens
+

--- a/swift/Samples/AlertContainer/Sources/AlertContainerScreen.swift
+++ b/swift/Samples/AlertContainer/Sources/AlertContainerScreen.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import WorkflowUI
+
+/// An `AlertContainerScreen` displays a base screen with an optional alert over top of it.
+public struct AlertContainerScreen<BaseScreen: Screen>: Screen {
+    /// The base screen to show underneath any visible alert.
+    public var baseScreen: BaseScreen
+
+    /// The presented alert.
+    public var alert: Alert?
+
+    public init(baseScreen: BaseScreen, alert: Alert? = nil) {
+        self.baseScreen = baseScreen
+        self.alert = alert
+    }
+
+    public func viewControllerDescription(environment: ViewEnvironment) -> ViewControllerDescription {
+        return AlertContainerViewController.description(for: self, environment: environment)
+    }
+}
+
+public struct Alert {
+    public var title: String
+    public var message: String
+    public var actions: [AlertAction]
+
+    public init(title: String, message: String, actions: [AlertAction]) {
+        self.title = title
+        self.message = message
+        self.actions = actions
+    }
+}
+
+public struct AlertAction {
+    public var title: String
+    public var style: Style
+    public var handler: () -> Void
+
+    public init(title: String, style: Style, handler: @escaping () -> Void) {
+        self.title = title
+        self.style = style
+        self.handler = handler
+    }
+}
+
+extension AlertAction {
+    public enum Style {
+        case `default`
+        case cancel
+        case destructive
+    }
+}

--- a/swift/Samples/AlertContainer/Sources/AlertContainerViewController.swift
+++ b/swift/Samples/AlertContainer/Sources/AlertContainerViewController.swift
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import UIKit
+import Workflow
+import WorkflowUI
+
+private struct AlertStyleConstants {
+    static let viewWidth: CGFloat = 343.0
+    static let buttonTitleColor = UIColor(red: 41 / 255, green: 150 / 255, blue: 204 / 255, alpha: 1.0)
+    static let titleFont = UIFont.systemFont(ofSize: 18, weight: .medium)
+}
+
+internal final class AlertContainerViewController<AlertScreen: Screen>: ScreenViewController<AlertContainerScreen<AlertScreen>> {
+    private var baseScreenViewController: DescribedViewController
+
+    private let dimmingView = UIView()
+
+    private var alertView: AlertView?
+
+    required init(screen: AlertContainerScreen<AlertScreen>, environment: ViewEnvironment) {
+        self.baseScreenViewController = DescribedViewController(screen: screen.baseScreen, environment: environment)
+        super.init(screen: screen, environment: environment)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        addChild(baseScreenViewController)
+        view.addSubview(baseScreenViewController.view)
+        baseScreenViewController.didMove(toParent: self)
+
+        dimmingView.backgroundColor = UIColor(white: 0, alpha: 0.5)
+        view.addSubview(dimmingView)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        baseScreenViewController.view.frame = view.bounds
+
+        dimmingView.frame = view.bounds
+        dimmingView.isUserInteractionEnabled = (alertView != nil)
+        dimmingView.alpha = (alertView != nil) ? 1 : 0
+    }
+
+    override func screenDidChange(from previousScreen: AlertContainerScreen<AlertScreen>, previousEnvironment: ViewEnvironment) {
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
+        update()
+    }
+
+    func update() {
+        baseScreenViewController.update(screen: screen.baseScreen, environment: environment)
+
+        if let alert = screen.alert {
+            if let alertView = alertView {
+                alertView.alert = alert
+            } else {
+                let inAlertView = AlertView(alert: alert)
+                inAlertView.backgroundColor = .init(white: 0.95, alpha: 1)
+                inAlertView.layer.cornerRadius = 10
+                inAlertView.translatesAutoresizingMaskIntoConstraints = false
+                alertView = inAlertView
+                inAlertView.accessibilityViewIsModal = true
+                view.insertSubview(inAlertView, aboveSubview: dimmingView)
+
+                NSLayoutConstraint.activate([
+                    inAlertView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                    inAlertView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+                    inAlertView.heightAnchor.constraint(greaterThanOrEqualToConstant: 0),
+                    inAlertView.widthAnchor.constraint(greaterThanOrEqualToConstant: AlertStyleConstants.viewWidth),
+                ])
+
+                view.setNeedsLayout()
+                view.layoutIfNeeded()
+
+                dimmingView.alpha = 0
+
+                UIView.animate(
+                    withDuration: 0.1,
+                    delay: 0,
+                    options: [
+                        .curveEaseInOut,
+                        .allowUserInteraction,
+                    ],
+                    animations: {
+                        self.dimmingView.alpha = 1
+                        inAlertView.transform = .identity
+                        inAlertView.alpha = 1
+                    },
+                    completion: { _ in
+                        UIAccessibility.post(notification: .screenChanged, argument: nil)
+                    }
+                )
+            }
+        } else {
+            if let alertView = alertView {
+                UIView.animate(
+                    withDuration: 0.1,
+                    delay: 0,
+                    options: .curveEaseInOut,
+                    animations: {
+                        alertView.transform = CGAffineTransform(scaleX: 0.85, y: 0.85)
+                        alertView.alpha = 0
+                        self.dimmingView.alpha = 0
+                    },
+                    completion: { _ in
+                        alertView.removeFromSuperview()
+                        self.view.setNeedsLayout()
+                        UIAccessibility.post(notification: .screenChanged, argument: nil)
+                    }
+                )
+                self.alertView = nil
+            }
+        }
+    }
+
+    override var childForStatusBarStyle: UIViewController? {
+        return baseScreenViewController
+    }
+
+    override var childForStatusBarHidden: UIViewController? {
+        return baseScreenViewController
+    }
+
+    override var childForHomeIndicatorAutoHidden: UIViewController? {
+        return baseScreenViewController
+    }
+
+    override var childForScreenEdgesDeferringSystemGestures: UIViewController? {
+        return baseScreenViewController
+    }
+
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return baseScreenViewController.supportedInterfaceOrientations
+    }
+}
+
+private final class AlertView: UIView {
+    public var alert: Alert?
+    private lazy var title: UILabel = {
+        let title = UILabel()
+        title.font = AlertStyleConstants.titleFont
+        title.textAlignment = .center
+        title.translatesAutoresizingMaskIntoConstraints = false
+        return title
+    }()
+
+    private lazy var message: UILabel = {
+        let message = UILabel()
+        message.font = AlertStyleConstants.titleFont
+        message.textAlignment = .center
+        message.numberOfLines = 0
+        message.lineBreakMode = .byWordWrapping
+        message.translatesAutoresizingMaskIntoConstraints = false
+        return message
+    }()
+
+    public required init(alert: Alert?) {
+        self.alert = alert
+        super.init(frame: .zero)
+        commonInit()
+    }
+
+    private func commonInit() {
+        guard let alert = alert else {
+            return
+        }
+        title.text = alert.title
+        addSubview(title)
+
+        message.text = alert.message
+        addSubview(message)
+
+        let buttonStackView = setupButtons(actions: alert.actions)
+        addSubview(buttonStackView)
+
+        var constraints: [NSLayoutConstraint] = []
+
+        constraints.append(title.topAnchor.constraint(equalTo: topAnchor, constant: 10))
+        constraints.append(title.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10))
+        constraints.append(title.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10))
+        constraints.append(title.heightAnchor.constraint(equalToConstant: 25))
+
+        constraints.append(message.topAnchor.constraint(equalTo: title.bottomAnchor, constant: 10))
+        constraints.append(message.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10))
+        constraints.append(message.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10))
+
+        constraints.append(buttonStackView.topAnchor.constraint(equalTo: message.bottomAnchor, constant: 15))
+        constraints.append(buttonStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0))
+        constraints.append(buttonStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0))
+        constraints.append(buttonStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0))
+        constraints.append(buttonStackView.heightAnchor.constraint(greaterThanOrEqualToConstant: 50))
+
+        addConstraints(constraints)
+    }
+
+    private func setupButtons(actions: [AlertAction]) -> UIStackView {
+        let buttonStackView = UIStackView()
+        buttonStackView.axis = actions.count == 2 ? .horizontal : .vertical
+        buttonStackView.distribution = .fillEqually
+        buttonStackView.alignment = .fill
+        buttonStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        for action in actions {
+            let alertButton = AlertButton(action: action)
+            alertButton.backgroundColor = backgroundColor
+            alertButton.layer.borderColor = UIColor.gray.cgColor
+            alertButton.layer.borderWidth = 0.2
+            alertButton.translatesAutoresizingMaskIntoConstraints = false
+
+            buttonStackView.addArrangedSubview(alertButton)
+        }
+
+        return buttonStackView
+    }
+
+    @available(*, unavailable)
+    public required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private final class AlertButton: UIButton {
+    private var action: AlertAction
+
+    required init(action: AlertAction) {
+        self.action = action
+        super.init(frame: .zero)
+        commonInit()
+    }
+
+    private func commonInit() {
+        setTitle(action.title, for: .normal)
+
+        switch action.style {
+        case .default, .cancel:
+            setTitleColor(AlertStyleConstants.buttonTitleColor, for: .normal)
+        case .destructive:
+            setTitleColor(.systemRed, for: .normal)
+        }
+
+        addTarget(self, action: #selector(triggerActionHandler), for: .touchUpInside)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc func triggerActionHandler() {
+        action.handler()
+    }
+}

--- a/swift/Samples/TicTacToe/Sources/Authentication/LoadingScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/LoadingScreen.swift
@@ -39,6 +39,8 @@ private final class LoadingScreenViewController: ScreenViewController<LoadingScr
         loadingLabel.textAlignment = .center
         loadingLabel.text = "Loading..."
 
+        view.backgroundColor = .white
+
         view.addSubview(loadingLabel)
     }
 

--- a/swift/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
@@ -21,8 +21,6 @@ import WorkflowUI
 // MARK: Input and Output
 
 struct LoginWorkflow: Workflow {
-    var error: AuthenticationService.AuthenticationError?
-
     enum Output {
         case login(email: String, password: String)
     }
@@ -78,15 +76,8 @@ extension LoginWorkflow {
     func render(state: LoginWorkflow.State, context: RenderContext<LoginWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Action.self)
 
-        let title: String
-        if let authenticationError = error {
-            title = authenticationError.localizedDescription
-        } else {
-            title = "Welcome! Please log in to play TicTacToe!"
-        }
-
         return LoginScreen(
-            title: title,
+            title: "Welcome! Please log in to play TicTacToe!",
             email: state.email,
             onEmailChanged: { email in
                 sink.send(.emailUpdated(email))

--- a/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import AlertContainer
 import BackStackContainer
 import ModalContainer
 import Workflow
@@ -66,7 +67,7 @@ extension MainWorkflow {
 // MARK: Rendering
 
 extension MainWorkflow {
-    typealias Rendering = ModalContainerScreen<BackStackScreen>
+    typealias Rendering = AlertContainerScreen<ModalContainerScreen<BackStackScreen>>
 
     func render(state: MainWorkflow.State, context: RenderContext<MainWorkflow>) -> Rendering {
         switch state {
@@ -81,9 +82,9 @@ extension MainWorkflow {
                 }
                 )
                 .rendered(with: context)
+
         case .runningGame:
-            return RunGameWorkflow()
-                .rendered(with: context)
+            return RunGameWorkflow().rendered(with: context)
         }
     }
 }


### PR DESCRIPTION
- Added AlertContainerScreen and AlertContainerViewController to Workflow samples.
- Created a basic alert view using UIKit
- Adding alert view to TicTacToe app:
           - AuthenticationWorkflow for auth failure 
           - ConfirmQuitWorkflow for show a confirm again dialog

[Demo Video](https://drive.google.com/open?id=1EFCNivfqkII9bMpFWUhxWHM53O5dGrs2)

## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
