### PR TITLE
Extract all the os_signpost calls to a single place

### DIFF
--- a/swift/Workflow/Sources/OSLog+Workflow.swift
+++ b/swift/Workflow/Sources/OSLog+Workflow.swift
@@ -16,7 +16,82 @@
 
 import os.signpost
 
-extension OSLog {
+fileprivate extension OSLog {
     static let workflow = OSLog(subsystem: "com.squareup.Workflow", category: "Workflow")
     static let worker = OSLog(subsystem: "com.squareup.Workflow", category: "Worker")
+}
+
+// MARK: -
+
+final class WorkflowLogger {
+    // MARK: Workflows
+
+    static func logWorkflowStarted<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .workflow, object: ref)
+            os_signpost(.begin, log: .workflow, name: "Alive", signpostID: signpostID,
+                        "Workflow: %{public}@", String(describing: WorkflowType.self))
+        }
+    }
+
+    static func logWorkflowFinished<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .workflow, object: ref)
+            os_signpost(.end, log: .workflow, name: "Alive", signpostID: signpostID)
+        }
+    }
+
+    static func logSinkEvent<Action>(ref: AnyObject, action: Action) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .workflow, object: ref)
+            os_signpost(.event, log: .workflow, name: "Sink Event", signpostID: signpostID,
+                        "Event: %@", String(describing: action))
+        }
+    }
+
+    // MARK: Rendering
+
+    static func logWorkflowStartedRendering<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .workflow, object: ref)
+            os_signpost(.begin, log: .workflow, name: "Render", signpostID: signpostID,
+                        "Render Workflow: %{public}@", String(describing: WorkflowType.self))
+        }
+    }
+
+    static func logWorkflowFinishedRendering<WorkflowType>(ref: WorkflowNode<WorkflowType>) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .workflow, object: ref)
+            os_signpost(.end, log: .workflow, name: "Render", signpostID: signpostID)
+        }
+    }
+
+    // MARK: - Workers
+
+    static func logWorkerStartedRunning<WorkerType>(ref: AnyObject, workerType: WorkerType.Type) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .worker, object: ref)
+            os_signpost(.begin, log: .worker, name: "Running", signpostID: signpostID,
+                        "Worker: %{public}@", String(describing: WorkerType.self))
+        }
+    }
+
+    static func logWorkerFinishedRunning(ref: AnyObject, status: StaticString? = nil) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .worker, object: ref)
+            if let status = status {
+                os_signpost(.end, log: .worker, name: "Running", signpostID: signpostID, status)
+            } else {
+                os_signpost(.end, log: .worker, name: "Running", signpostID: signpostID)
+            }
+        }
+    }
+
+    static func logWorkerOutput<Output>(ref: AnyObject, output: Output) {
+        if #available(iOS 12.0, macOS 10.14, *) {
+            let signpostID = OSSignpostID(log: .worker, object: ref)
+            os_signpost(.event, log: .worker, name: "Worker Event", signpostID: signpostID,
+                        "Event: %@", String(describing: output))
+        }
+    }
 }

--- a/swift/Workflow/Sources/WorkflowNode.swift
+++ b/swift/Workflow/Sources/WorkflowNode.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import ReactiveSwift
-import os.signpost
 
 /// Manages a running workflow.
 final class WorkflowNode<WorkflowType: Workflow> {
@@ -35,10 +34,7 @@ final class WorkflowNode<WorkflowType: Workflow> {
         self.workflow = workflow
         self.state = workflow.makeInitialState()
 
-        if #available(iOS 12.0, *) {
-            let signpostID = OSSignpostID(log: .workflow, object: self)
-            os_signpost(.begin, log: .workflow, name: "Alive", signpostID: signpostID, "Workflow: %{public}@", String(describing: WorkflowType.self))
-        }
+        WorkflowLogger.logWorkflowStarted(ref: self)
 
         subtreeManager.onUpdate = { [weak self] output in
             self?.handle(subtreeOutput: output)
@@ -46,10 +42,7 @@ final class WorkflowNode<WorkflowType: Workflow> {
     }
 
     deinit {
-        if #available(iOS 12.0, *) {
-            let signpostID = OSSignpostID(log: .workflow, object: self)
-            os_signpost(.end, log: .workflow, name: "Alive", signpostID: signpostID)
-        }
+        WorkflowLogger.logWorkflowFinished(ref: self)
     }
 
     /// Handles an event produced by the subtree manager
@@ -81,16 +74,10 @@ final class WorkflowNode<WorkflowType: Workflow> {
     }
 
     func render() -> WorkflowType.Rendering {
-        if #available(iOS 12.0, *) {
-            let signpostID = OSSignpostID(log: .workflow, object: self)
-            os_signpost(.begin, log: .workflow, name: "Render", signpostID: signpostID, "Render Workflow: %{public}@", String(describing: WorkflowType.self))
-        }
+        WorkflowLogger.logWorkflowStartedRendering(ref: self)
 
         defer {
-            if #available(iOS 12.0, *) {
-                let signpostID = OSSignpostID(log: .workflow, object: self)
-                os_signpost(.end, log: .workflow, name: "Render", signpostID: signpostID)
-            }
+            WorkflowLogger.logWorkflowFinishedRendering(ref: self)
         }
 
         return subtreeManager.render { context in


### PR DESCRIPTION
Another way around the limitations in the `os_signpost` APIs is to create specific logging calls and do all the integration with `os_signpost` behind the scenes (instead of trying to create a wrapper for it).