### PR TITLE
Upload android instrumentation test results from CI.

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -151,3 +151,9 @@ jobs:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
           script: ./gradlew connectedCheck --build-cache --no-daemon --stacktrace
+
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: insrumentation-test-results
+          path: ./**/build/reports/androidTests/connected/**


### PR DESCRIPTION
The upload-archive action now supports globbing, so we can easily
upload all the test reports from all modules.


## Checklist

- [ ] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [ ] I have made corresponding changes to the documentation
