### PR TITLE
Minor sample cleanups

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/bash
 git diff --diff-filter=d --staged --name-only | grep -e '\.swift$' | while read line; do
-  swift run swiftformat "${line}";
+  swift run swiftformat "${line}" --quiet;
   git add "$line";
 done

--- a/swift/Samples/AlertContainer/Sources/AlertContainerViewController.swift
+++ b/swift/Samples/AlertContainer/Sources/AlertContainerViewController.swift
@@ -59,10 +59,7 @@ internal final class AlertContainerViewController<AlertScreen: Screen>: ScreenVi
 
     override func screenDidChange(from previousScreen: AlertContainerScreen<AlertScreen>, previousEnvironment: ViewEnvironment) {
         super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
-        update()
-    }
 
-    func update() {
         baseScreenViewController.update(screen: screen.baseScreen, environment: environment)
 
         if let alert = screen.alert {

--- a/swift/Samples/BackStackContainer/Sources/BackStackContainer.swift
+++ b/swift/Samples/BackStackContainer/Sources/BackStackContainer.swift
@@ -17,15 +17,7 @@
 import WorkflowUI
 
 public final class BackStackContainer<Content: Screen>: ScreenViewController<BackStackScreen<Content>>, UINavigationControllerDelegate {
-    private let navController: UINavigationController
-
-    public required init(screen: BackStackScreen<Content>, environment: ViewEnvironment) {
-        self.navController = UINavigationController()
-
-        super.init(screen: screen, environment: environment)
-
-        update(with: screen)
-    }
+    private let navController = UINavigationController()
 
     override public func viewDidLoad() {
         super.viewDidLoad()
@@ -43,18 +35,8 @@ public final class BackStackContainer<Content: Screen>: ScreenViewController<Bac
     }
 
     override public func screenDidChange(from previousScreen: BackStackScreen<Content>, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    // MARK: - UINavigationControllerDelegate
-
-    public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        setNavigationBarVisibility(with: screen, animated: animated)
-    }
-
-    // MARK: - Private Methods
-
-    private func update(with screen: BackStackScreen<Content>) {
         var existingViewControllers: [ScreenWrapperViewController<Content>] = navController.viewControllers as! [ScreenWrapperViewController<Content>]
         var updatedViewControllers: [ScreenWrapperViewController<Content>] = []
 
@@ -72,6 +54,14 @@ public final class BackStackContainer<Content: Screen>: ScreenViewController<Bac
 
         navController.setViewControllers(updatedViewControllers, animated: true)
     }
+
+    // MARK: - UINavigationControllerDelegate
+
+    public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        setNavigationBarVisibility(with: screen, animated: animated)
+    }
+
+    // MARK: - Private Methods
 
     private func setNavigationBarVisibility(with screen: BackStackScreen<Content>, animated: Bool) {
         guard let topScreen = screen.items.last else {

--- a/swift/Samples/ModalContainer/Sources/ModalContainerViewController.swift
+++ b/swift/Samples/ModalContainer/Sources/ModalContainerViewController.swift
@@ -38,10 +38,8 @@ internal final class ModalContainerViewController<ModalScreen: Screen>: ScreenVi
     }
 
     override func screenDidChange(from previousScreen: ModalContainerScreen<ModalScreen>, previousEnvironment: ViewEnvironment) {
-        update()
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    func update() {
         baseScreenViewController.update(screen: screen.baseScreen, environment: environment)
 
         // Sort our existing modals into keyed buckets. This will typically contain a single view controller

--- a/swift/Samples/SampleApp/Sources/CrossFadeContainer.swift
+++ b/swift/Samples/SampleApp/Sources/CrossFadeContainer.swift
@@ -67,6 +67,8 @@ private final class CrossFadeContainerViewController: ScreenViewController<Cross
     }
 
     override func screenDidChange(from previousScreen: CrossFadeScreen, previousEnvironment: ViewEnvironment) {
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
+
         if screen.isEquivalent(to: previousScreen) {
             childViewController.update(screen: screen.baseScreen, environment: environment)
         } else {

--- a/swift/Samples/SampleApp/Sources/DemoScreen.swift
+++ b/swift/Samples/SampleApp/Sources/DemoScreen.swift
@@ -35,20 +35,10 @@ struct DemoScreen: Screen {
 }
 
 private final class DemoViewController: ScreenViewController<DemoScreen> {
-    private let titleButton: UIButton
-    private let subscribeButton: UIButton
-    private let statusLabel: UILabel
-    private let refreshButton: UIButton
-
-    required init(screen: DemoScreen, environment: ViewEnvironment) {
-        self.titleButton = UIButton(frame: .zero)
-        self.subscribeButton = UIButton(frame: .zero)
-        self.statusLabel = UILabel(frame: .zero)
-        self.refreshButton = UIButton(frame: .zero)
-        super.init(screen: screen, environment: environment)
-
-        update(with: screen)
-    }
+    private let titleButton = UIButton(frame: .zero)
+    private let subscribeButton = UIButton(frame: .zero)
+    private let statusLabel = UILabel(frame: .zero)
+    private let refreshButton = UIButton(frame: .zero)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -108,10 +98,8 @@ private final class DemoViewController: ScreenViewController<DemoScreen> {
     }
 
     override func screenDidChange(from previousScreen: DemoScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: DemoScreen) {
         titleButton.setTitle(screen.title, for: .normal)
         titleButton.backgroundColor = screen.color
 

--- a/swift/Samples/SampleApp/Sources/ReversingWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/ReversingWorkflow.swift
@@ -23,20 +23,9 @@ import WorkflowUI
 struct ReversingWorkflow: Workflow {
     typealias Rendering = String
     typealias Output = Never
+    typealias State = Void
 
     var text: String
-}
-
-// MARK: State and Initialization
-
-extension ReversingWorkflow {
-    struct State {}
-
-    func makeInitialState() -> ReversingWorkflow.State {
-        return State()
-    }
-
-    func workflowDidChange(from previousWorkflow: ReversingWorkflow, state: inout State) {}
 }
 
 // MARK: Rendering

--- a/swift/Samples/SampleApp/Sources/RootWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/RootWorkflow.swift
@@ -72,12 +72,14 @@ extension RootWorkflow {
                             return .login(name: name)
                         }
                     }
-                    .rendered(with: context))
+                    .rendered(with: context)
+            )
 
         case let .demo(name: name):
             return CrossFadeScreen(
                 base: DemoWorkflow(name: name)
-                    .rendered(with: context))
+                    .rendered(with: context)
+            )
         }
     }
 }

--- a/swift/Samples/SampleApp/Sources/WelcomeScreen.swift
+++ b/swift/Samples/SampleApp/Sources/WelcomeScreen.swift
@@ -28,18 +28,9 @@ struct WelcomeScreen: Screen {
 }
 
 private final class WelcomeViewController: ScreenViewController<WelcomeScreen> {
-    let welcomeLabel: UILabel
-    let nameField: UITextField
-    let button: UIButton
-
-    required init(screen: WelcomeScreen, environment: ViewEnvironment) {
-        self.welcomeLabel = UILabel(frame: .zero)
-        self.nameField = UITextField(frame: .zero)
-        self.button = UIButton(frame: .zero)
-        super.init(screen: screen, environment: environment)
-
-        update(with: screen)
-    }
+    let welcomeLabel = UILabel(frame: .zero)
+    let nameField = UITextField(frame: .zero)
+    let button = UIButton(frame: .zero)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -92,10 +83,8 @@ private final class WelcomeViewController: ScreenViewController<WelcomeScreen> {
     }
 
     override func screenDidChange(from previousScreen: WelcomeScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: WelcomeScreen) {
         nameField.text = screen.name
     }
 

--- a/swift/Samples/SplitScreenContainer/DemoApp/BarScreen.swift
+++ b/swift/Samples/SplitScreenContainer/DemoApp/BarScreen.swift
@@ -32,12 +32,6 @@ private final class BarScreenViewController: ScreenViewController<BarScreen> {
     private lazy var tapGestureRecognizer: UITapGestureRecognizer = .init()
     private var gradientLayer: CAGradientLayer?
 
-    required init(screen: BarScreen, environment: ViewEnvironment) {
-        super.init(screen: screen, environment: environment)
-
-        update(with: screen)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -58,10 +52,8 @@ private final class BarScreenViewController: ScreenViewController<BarScreen> {
     }
 
     override func screenDidChange(from previousScreen: BarScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: BarScreen) {
         titleLabel.text = screen.title
 
         updateGradient(for: view, colors: screen.backgroundColors)

--- a/swift/Samples/SplitScreenContainer/DemoApp/FooScreen.swift
+++ b/swift/Samples/SplitScreenContainer/DemoApp/FooScreen.swift
@@ -31,12 +31,6 @@ private final class FooScreenViewController: ScreenViewController<FooScreen> {
     private lazy var titleLabel: UILabel = .init()
     private lazy var tapGestureRecognizer: UITapGestureRecognizer = .init()
 
-    required init(screen: FooScreen, environment: ViewEnvironment) {
-        super.init(screen: screen, environment: environment)
-
-        update(with: screen)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -54,10 +48,8 @@ private final class FooScreenViewController: ScreenViewController<FooScreen> {
     }
 
     override func screenDidChange(from previousScreen: FooScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: FooScreen) {
         view.backgroundColor = screen.backgroundColor
         titleLabel.text = screen.title
     }

--- a/swift/Samples/SplitScreenContainer/SnapshotTests/SplitScreenContainerScreenSnapshotTests.swift
+++ b/swift/Samples/SplitScreenContainer/SnapshotTests/SplitScreenContainerScreenSnapshotTests.swift
@@ -68,12 +68,6 @@ private final class FooScreenViewController: ScreenViewController<FooScreen> {
     private lazy var titleLabel: UILabel = .init()
     private lazy var tapGestureRecognizer: UITapGestureRecognizer = .init()
 
-    required init(screen: FooScreen, environment: ViewEnvironment) {
-        super.init(screen: screen, environment: environment)
-
-        update(with: screen)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -91,10 +85,8 @@ private final class FooScreenViewController: ScreenViewController<FooScreen> {
     }
 
     override func screenDidChange(from previousScreen: FooScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: FooScreen) {
         view.backgroundColor = screen.backgroundColor
         titleLabel.text = screen.title
     }

--- a/swift/Samples/SplitScreenContainer/Sources/SplitScreenContainerViewController.swift
+++ b/swift/Samples/SplitScreenContainer/Sources/SplitScreenContainerViewController.swift
@@ -45,6 +45,8 @@ internal final class SplitScreenContainerViewController<LeadingScreenType: Scree
     }
 
     override internal func screenDidChange(from previousScreen: ContainerScreen, previousEnvironment: ViewEnvironment) {
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
+
         if screen.ratio != previousScreen.ratio {
             needsAnimatedLayout = true
         }

--- a/swift/Samples/TicTacToe/Sources/Authentication/LoadingScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/LoadingScreen.swift
@@ -23,13 +23,7 @@ struct LoadingScreen: Screen {
 }
 
 private final class LoadingScreenViewController: ScreenViewController<LoadingScreen> {
-    let loadingLabel: UILabel
-
-    required init(screen: LoadingScreen, environment: ViewEnvironment) {
-        self.loadingLabel = UILabel(frame: .zero)
-
-        super.init(screen: screen, environment: environment)
-    }
+    let loadingLabel = UILabel(frame: .zero)
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/swift/Samples/TicTacToe/Sources/Authentication/TwoFactorScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/TwoFactorScreen.swift
@@ -26,19 +26,9 @@ struct TwoFactorScreen: Screen {
 }
 
 private final class TwoFactorViewController: ScreenViewController<TwoFactorScreen> {
-    let titleLabel: UILabel
-    let twoFactorField: UITextField
-    let button: UIButton
-
-    required init(screen: TwoFactorScreen, environment: ViewEnvironment) {
-        self.titleLabel = UILabel(frame: .zero)
-        self.twoFactorField = UITextField(frame: .zero)
-        self.button = UIButton(frame: .zero)
-
-        super.init(screen: screen, environment: environment)
-
-        update(with: screen)
-    }
+    let titleLabel = UILabel(frame: .zero)
+    let twoFactorField = UITextField(frame: .zero)
+    let button = UIButton(frame: .zero)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -92,10 +82,7 @@ private final class TwoFactorViewController: ScreenViewController<TwoFactorScree
     }
 
     override func screenDidChange(from previousScreen: TwoFactorScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
-
-    private func update(with screen: TwoFactorScreen) {
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
         titleLabel.text = screen.title
     }
 

--- a/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitScreen.swift
@@ -34,15 +34,9 @@ final class ConfirmQuitViewController: ScreenViewController<ConfirmQuitScreen> {
     private var onQuitTapped: () -> Void = {}
     private var onCancelTapped: () -> Void = {}
 
-    required init(screen: ConfirmQuitScreen, environment: ViewEnvironment) {
-        super.init(screen: screen, environment: environment)
-    }
-
     override func screenDidChange(from previousScreen: ConfirmQuitScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen, environment: environment)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: ConfirmQuitScreen, environment: ViewEnvironment) {
         /// Update UI
         questionLabel.text = screen.question
         onQuitTapped = screen.onQuitTapped

--- a/swift/Samples/TicTacToe/Sources/Game/GamePlayScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/GamePlayScreen.swift
@@ -29,25 +29,12 @@ struct GamePlayScreen: Screen {
 }
 
 final class GamePlayViewController: ScreenViewController<GamePlayScreen> {
-    let titleLabel: UILabel
-    let cells: [[UIButton]]
-
-    required init(screen: GamePlayScreen, environment: ViewEnvironment) {
-        self.titleLabel = UILabel(frame: .zero)
-        var cells: [[UIButton]] = []
-
-        for _ in 0 ..< 3 {
-            var row: [UIButton] = []
-            for _ in 0 ..< 3 {
-                row.append(UIButton(frame: .zero))
-            }
-            cells.append(row)
+    let titleLabel: UILabel = UILabel(frame: .zero)
+    let cells: [[UIButton]] = {
+        (0 ..< 3).map { _ in
+            (0 ..< 3).map { _ in UIButton(frame: .zero) }
         }
-
-        self.cells = cells
-        super.init(screen: screen, environment: environment)
-        update(with: screen)
-    }
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -108,10 +95,8 @@ final class GamePlayViewController: ScreenViewController<GamePlayScreen> {
     }
 
     override func screenDidChange(from previousScreen: GamePlayScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: GamePlayScreen) {
         let title: String
         switch screen.gameState {
         case let .ongoing(turn: turn):

--- a/swift/Samples/TicTacToe/Sources/Game/NewGameScreen.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/NewGameScreen.swift
@@ -33,22 +33,11 @@ struct NewGameScreen: Screen {
 }
 
 final class NewGameViewController: ScreenViewController<NewGameScreen> {
-    let playerXLabel: UILabel
-    let playerXField: UITextField
-    let playerOLabel: UILabel
-    let playerOField: UITextField
-    let startGameButton: UIButton
-
-    required init(screen: NewGameScreen, environment: ViewEnvironment) {
-        self.playerXLabel = UILabel(frame: .zero)
-        self.playerXField = UITextField(frame: .zero)
-        self.playerOLabel = UILabel(frame: .zero)
-        self.playerOField = UITextField(frame: .zero)
-        self.startGameButton = UIButton(frame: .zero)
-
-        super.init(screen: screen, environment: environment)
-        update(with: screen)
-    }
+    let playerXLabel = UILabel(frame: .zero)
+    let playerXField = UITextField(frame: .zero)
+    let playerOLabel = UILabel(frame: .zero)
+    let playerOField = UITextField(frame: .zero)
+    let startGameButton = UIButton(frame: .zero)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -135,10 +124,8 @@ final class NewGameViewController: ScreenViewController<NewGameScreen> {
     }
 
     override func screenDidChange(from previousScreen: NewGameScreen, previousEnvironment: ViewEnvironment) {
-        update(with: screen)
-    }
+        super.screenDidChange(from: previousScreen, previousEnvironment: previousEnvironment)
 
-    private func update(with screen: NewGameScreen) {
         playerXField.text = screen.playerX
         playerOField.text = screen.playerO
     }

--- a/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
@@ -70,15 +70,13 @@ extension MainWorkflow {
     func render(state: MainWorkflow.State, context: RenderContext<MainWorkflow>) -> Rendering {
         switch state {
         case .authenticating:
-            return AuthenticationWorkflow(
-                authenticationService: AuthenticationService())
-                .mapOutput({ output -> Action in
+            return AuthenticationWorkflow(authenticationService: AuthenticationService())
+                .mapOutput { output -> Action in
                     switch output {
                     case let .authorized(session: sessionToken):
                         return .authenticated(sessionToken: sessionToken)
                     }
                 }
-                )
                 .rendered(with: context)
 
         case .runningGame:


### PR DESCRIPTION
I took a quick pass through the Samples and updated it based on recent API changes. 

Changes:
* `screenDidChange` gets called on `init`. Hence, we don't need an `update()` method that gets called from `init` and from `screenDidChange`. Removing `update` and where possible `init`.
* When `State = Void` we have default conformances for `makeInitialState` and `workflowDidChange`. 

Will be good to discuss any change that folks might feel are not purely positive.