### PR TITLE
Provide default workflowDidChange implementation

### DIFF
--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -60,8 +60,6 @@ extension DemoWorkflow {
             subscriptionState: .not
         )
     }
-
-    func workflowDidChange(from previousWorkflow: DemoWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/SampleApp/Sources/RootWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/RootWorkflow.swift
@@ -35,8 +35,6 @@ extension RootWorkflow {
     func makeInitialState() -> RootWorkflow.State {
         return .welcome
     }
-
-    func workflowDidChange(from previousWorkflow: RootWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/SampleApp/Sources/WelcomeWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/WelcomeWorkflow.swift
@@ -35,8 +35,6 @@ extension WelcomeWorkflow {
     func makeInitialState() -> WelcomeWorkflow.State {
         return State(name: "")
     }
-
-    func workflowDidChange(from previousWorkflow: WelcomeWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/SplitScreenContainer/DemoApp/DemoWorkflow.swift
+++ b/swift/Samples/SplitScreenContainer/DemoApp/DemoWorkflow.swift
@@ -32,8 +32,6 @@ extension DemoWorkflow {
     func makeInitialState() -> State {
         return 1
     }
-
-    func workflowDidChange(from previousWorkflow: DemoWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -45,8 +45,6 @@ extension AuthenticationWorkflow {
     func makeInitialState() -> AuthenticationWorkflow.State {
         return .emailPassword
     }
-
-    func workflowDidChange(from previousWorkflow: AuthenticationWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/LoginWorkflow.swift
@@ -37,8 +37,6 @@ extension LoginWorkflow {
     func makeInitialState() -> LoginWorkflow.State {
         return State(email: "", password: "")
     }
-
-    func workflowDidChange(from previousWorkflow: LoginWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/ConfirmQuitWorkflow.swift
@@ -44,8 +44,6 @@ extension ConfirmQuitWorkflow {
     func makeInitialState() -> ConfirmQuitWorkflow.State {
         return State(step: .confirmOnce)
     }
-
-    func workflowDidChange(from previousWorkflow: ConfirmQuitWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
@@ -44,8 +44,6 @@ extension RunGameWorkflow {
     func makeInitialState() -> RunGameWorkflow.State {
         return State(playerX: "X", playerO: "O", step: .newGame)
     }
-
-    func workflowDidChange(from previousWorkflow: RunGameWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/TakeTurnsWorkflow.swift
@@ -37,8 +37,6 @@ extension TakeTurnsWorkflow {
     func makeInitialState() -> TakeTurnsWorkflow.State {
         return State(board: Board(), gameState: .ongoing(turn: .x))
     }
-
-    func workflowDidChange(from previousWorkflow: TakeTurnsWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
@@ -37,8 +37,6 @@ extension MainWorkflow {
     func makeInitialState() -> MainWorkflow.State {
         return .authenticating
     }
-
-    func workflowDidChange(from previousWorkflow: MainWorkflow, state: inout State) {}
 }
 
 // MARK: Actions

--- a/swift/Workflow/Sources/Workflow.swift
+++ b/swift/Workflow/Sources/Workflow.swift
@@ -84,6 +84,10 @@ public protocol Workflow: AnyWorkflowConvertible {
     func render(state: State, context: RenderContext<Self>) -> Rendering
 }
 
+extension Workflow {
+    public func workflowDidChange(from previousWorkflow: Self, state: inout State) {}
+}
+
 /// When State is Void, provide empty `makeInitialState` and `workflowDidChange`
 /// implementations, making a “stateless workflow”.
 extension Workflow where State == Void {

--- a/swift/Workflow/Tests/AnyWorkflowTests.swift
+++ b/swift/Workflow/Tests/AnyWorkflowTests.swift
@@ -49,8 +49,6 @@ extension PassthroughWorkflow {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: PassthroughWorkflow<Rendering>, state: inout State) {}
-
     func render(state: State, context: RenderContext<PassthroughWorkflow<Rendering>>) -> Rendering {
         return child.rendered(with: context)
     }
@@ -67,8 +65,6 @@ extension SimpleWorkflow {
     func makeInitialState() -> State {
         return State()
     }
-
-    func workflowDidChange(from previousWorkflow: SimpleWorkflow, state: inout State) {}
 
     func render(state: State, context: RenderContext<SimpleWorkflow>) -> String {
         return String(string.reversed())

--- a/swift/Workflow/Tests/ConcurrencyTests.swift
+++ b/swift/Workflow/Tests/ConcurrencyTests.swift
@@ -142,8 +142,6 @@ final class ConcurrencyTests: XCTestCase {
                 return State(count: 0)
             }
 
-            func workflowDidChange(from previousWorkflow: OneShotWorkflow, state: inout State) {}
-
             enum Action: WorkflowAction {
                 typealias WorkflowType = OneShotWorkflow
 
@@ -230,8 +228,6 @@ final class ConcurrencyTests: XCTestCase {
             func makeInitialState() -> State {
                 return State(count: 0)
             }
-
-            func workflowDidChange(from previousWorkflow: ParentWorkflow, state: inout State) {}
 
             enum Action: WorkflowAction {
                 typealias WorkflowType = ParentWorkflow
@@ -387,8 +383,6 @@ final class ConcurrencyTests: XCTestCase {
                 return State(count: 0)
             }
 
-            func workflowDidChange(from previousWorkflow: AnyActionWorkflow, state: inout State) {}
-
             enum FirstAction: WorkflowAction {
                 typealias WorkflowType = AnyActionWorkflow
                 case update
@@ -491,8 +485,6 @@ final class ConcurrencyTests: XCTestCase {
                 return State(count: 0)
             }
 
-            func workflowDidChange(from previousWorkflow: SourceDifferentiatingWorkflow, state: inout State) {}
-
             enum Action: WorkflowAction {
                 typealias WorkflowType = SourceDifferentiatingWorkflow
 
@@ -591,8 +583,6 @@ final class ConcurrencyTests: XCTestCase {
         func makeInitialState() -> State {
             return State(count: 0, running: running, signal: signal)
         }
-
-        func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {}
 
         enum Action: WorkflowAction {
             typealias WorkflowType = TestWorkflow

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -155,8 +155,6 @@ final class SubtreeManagerTests: XCTestCase {
                 return .notWorking
             }
 
-            func workflowDidChange(from previousWorkflow: WorkerWorkflow, state: inout WorkerWorkflow.State) {}
-
             func render(state: WorkerWorkflow.State, context: RenderContext<WorkerWorkflow>) -> Bool {
                 switch state {
                 case .notWorking:
@@ -240,8 +238,6 @@ final class SubtreeManagerTests: XCTestCase {
                 return State()
             }
 
-            func workflowDidChange(from previousWorkflow: SubscribingWorkflow, state: inout SubscribingWorkflow.State) {}
-
             func render(state: SubscribingWorkflow.State, context: RenderContext<SubscribingWorkflow>) -> Bool {
                 if let signal = signal {
                     context.awaitResult(for: signal.asWorker(key: "signal")) { _ -> AnyWorkflowAction<SubscribingWorkflow> in
@@ -314,8 +310,6 @@ private struct ParentWorkflow: Workflow {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: ParentWorkflow, state: inout State) {}
-
     func render(state: State, context: RenderContext<ParentWorkflow>) -> Never {
         fatalError()
     }
@@ -354,8 +348,6 @@ private struct TestWorkflow: Workflow {
     func makeInitialState() -> State {
         return .foo
     }
-
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {}
 
     func render(state: State, context: RenderContext<TestWorkflow>) -> TestViewModel {
         let sink = context.makeSink(of: Event.self)

--- a/swift/Workflow/Tests/WorkflowHostTests.swift
+++ b/swift/Workflow/Tests/WorkflowHostTests.swift
@@ -40,8 +40,6 @@ final class WorkflowHostTests: XCTestCase {
             return State()
         }
 
-        func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout State) {}
-
         typealias Rendering = Int
 
         func render(state: State, context: RenderContext<TestWorkflow>) -> Rendering {

--- a/swift/Workflow/Tests/WorkflowNodeTests.swift
+++ b/swift/Workflow/Tests/WorkflowNodeTests.swift
@@ -208,8 +208,6 @@ final class WorkflowNodeTests: XCTestCase {
                 return State()
             }
 
-            func workflowDidChange(from previousWorkflow: WF, state: inout WF.State) {}
-
             func render(state: WF.State, context: RenderContext<WF>) {
                 context.awaitResult(for: TestWorker()) { output in
                     AnyWorkflowAction(sendingOutput: output)
@@ -297,8 +295,6 @@ extension CompositeWorkflow {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: CompositeWorkflow<A, B>, state: inout State) {}
-
     func render(state: State, context: RenderContext<CompositeWorkflow<A, B>>) -> Rendering {
         return Rendering(
             aRendering: a
@@ -341,8 +337,6 @@ private struct SimpleWorkflow: Workflow {
         return State()
     }
 
-    func workflowDidChange(from previousWorkflow: SimpleWorkflow, state: inout State) {}
-
     func render(state: State, context: RenderContext<SimpleWorkflow>) -> String {
         return String(string.reversed())
     }
@@ -381,8 +375,6 @@ extension EventEmittingWorkflow {
         case helloWorld
     }
 
-    func workflowDidChange(from previousWorkflow: EventEmittingWorkflow, state: inout State) {}
-
     func render(state: State, context: RenderContext<EventEmittingWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Event.self)
 
@@ -404,8 +396,6 @@ private struct StateTransitioningWorkflow: Workflow {
     func makeInitialState() -> Bool {
         return false
     }
-
-    func workflowDidChange(from previousWorkflow: StateTransitioningWorkflow, state: inout Bool) {}
 
     func render(state: State, context: RenderContext<StateTransitioningWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Event.self)

--- a/swift/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
+++ b/swift/WorkflowTesting/Tests/WorkflowActionTesterTests.swift
@@ -72,8 +72,6 @@ private struct TestWorkflow: Workflow {
         return true
     }
 
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout Bool) {}
-
     func render(state: Bool, context: RenderContext<TestWorkflow>) {
         return ()
     }

--- a/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -229,8 +229,6 @@ private struct TestWorkflow: Workflow {
         return State(text: initialText, substate: .idle)
     }
 
-    func workflowDidChange(from previousWorkflow: TestWorkflow, state: inout TestWorkflow.State) {}
-
     func render(state: State, context: RenderContext<TestWorkflow>) -> TestScreen {
         let sink = context.makeSink(of: Action.self)
 
@@ -283,8 +281,6 @@ private struct OutputWorkflow: Workflow {
     func makeInitialState() -> OutputWorkflow.State {
         return State()
     }
-
-    func workflowDidChange(from previousWorkflow: OutputWorkflow, state: inout OutputWorkflow.State) {}
 
     enum Action: WorkflowAction {
         typealias WorkflowType = OutputWorkflow
@@ -345,8 +341,6 @@ private struct ParentWorkflow: Workflow {
         return State(text: initialText)
     }
 
-    func workflowDidChange(from previousWorkflow: ParentWorkflow, state: inout ParentWorkflow.State) {}
-
     enum Action: WorkflowAction {
         typealias WorkflowType = ParentWorkflow
 
@@ -393,8 +387,6 @@ private struct ChildWorkflow: Workflow {
     func makeInitialState() -> ChildWorkflow.State {
         return State()
     }
-
-    func workflowDidChange(from previousWorkflow: ChildWorkflow, state: inout ChildWorkflow.State) {}
 
     func render(state: ChildWorkflow.State, context: RenderContext<ChildWorkflow>) -> String {
         context.awaitResult(

--- a/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
+++ b/swift/WorkflowUI/Tests/ContainerViewControllerTests.swift
@@ -122,8 +122,6 @@
             return 0
         }
 
-        func workflowDidChange(from previousWorkflow: MockWorkflow, state: inout State) {}
-
         func render(state: State, context: RenderContext<MockWorkflow>) -> TestScreen {
             context.awaitResult(for: subscription.asWorker(key: "signal")) { output in
                 AnyWorkflowAction { state in


### PR DESCRIPTION
`workflowDidChange` is hardly ever used. Providing a default implementation to reduce unnecessary boilerplate.