### PR TITLE
Make BackStackScreen generic

### DIFF
--- a/swift/Samples/BackStackContainer/Sources/BackStackContainer.swift
+++ b/swift/Samples/BackStackContainer/Sources/BackStackContainer.swift
@@ -16,10 +16,10 @@
 
 import WorkflowUI
 
-public final class BackStackContainer: ScreenViewController<BackStackScreen>, UINavigationControllerDelegate {
+public final class BackStackContainer<Content: Screen>: ScreenViewController<BackStackScreen<Content>>, UINavigationControllerDelegate {
     private let navController: UINavigationController
 
-    public required init(screen: BackStackScreen, environment: ViewEnvironment) {
+    public required init(screen: BackStackScreen<Content>, environment: ViewEnvironment) {
         self.navController = UINavigationController()
 
         super.init(screen: screen, environment: environment)
@@ -42,7 +42,7 @@ public final class BackStackContainer: ScreenViewController<BackStackScreen>, UI
         navController.view.frame = view.bounds
     }
 
-    override public func screenDidChange(from previousScreen: BackStackScreen, previousEnvironment: ViewEnvironment) {
+    override public func screenDidChange(from previousScreen: BackStackScreen<Content>, previousEnvironment: ViewEnvironment) {
         update(with: screen)
     }
 
@@ -54,9 +54,9 @@ public final class BackStackContainer: ScreenViewController<BackStackScreen>, UI
 
     // MARK: - Private Methods
 
-    private func update(with screen: BackStackScreen) {
-        var existingViewControllers: [ScreenWrapperViewController] = navController.viewControllers as! [ScreenWrapperViewController]
-        var updatedViewControllers: [ScreenWrapperViewController] = []
+    private func update(with screen: BackStackScreen<Content>) {
+        var existingViewControllers: [ScreenWrapperViewController<Content>] = navController.viewControllers as! [ScreenWrapperViewController<Content>]
+        var updatedViewControllers: [ScreenWrapperViewController<Content>] = []
 
         for item in screen.items {
             if let idx = existingViewControllers.firstIndex(where: { viewController -> Bool in
@@ -73,7 +73,7 @@ public final class BackStackContainer: ScreenViewController<BackStackScreen>, UI
         navController.setViewControllers(updatedViewControllers, animated: true)
     }
 
-    private func setNavigationBarVisibility(with screen: BackStackScreen, animated: Bool) {
+    private func setNavigationBarVisibility(with screen: BackStackScreen<Content>, animated: Bool) {
         guard let topScreen = screen.items.last else {
             return
         }

--- a/swift/Samples/BackStackContainer/Sources/BackStackScreen.swift
+++ b/swift/Samples/BackStackContainer/Sources/BackStackScreen.swift
@@ -16,10 +16,10 @@
 
 import WorkflowUI
 
-public struct BackStackScreen: Screen {
+public struct BackStackScreen<ScreenType: Screen>: Screen {
     var items: [Item]
 
-    public init(items: [BackStackScreen.Item]) {
+    public init(items: [Item]) {
         self.items = items
     }
 
@@ -32,13 +32,11 @@ extension BackStackScreen {
     /// A specific item in the back stack. The key and screen type is used to differentiate reused vs replaced screens.
     public struct Item {
         public var key: AnyHashable
-        public var screen: AnyScreen
-        var screenType: Any.Type
+        public var screen: ScreenType
         public var barVisibility: BarVisibility
 
-        public init<ScreenType: Screen, Key: Hashable>(key: Key?, screen: ScreenType, barVisibility: BarVisibility) {
-            self.screen = AnyScreen(screen)
-            self.screenType = ScreenType.self
+        public init<Key: Hashable>(key: Key?, screen: ScreenType, barVisibility: BarVisibility) {
+            self.screen = screen
 
             if let key = key {
                 self.key = AnyHashable(key)
@@ -48,26 +46,26 @@ extension BackStackScreen {
             self.barVisibility = barVisibility
         }
 
-        public init<ScreenType: Screen>(screen: ScreenType, barVisibility: BarVisibility) {
+        public init(screen: ScreenType, barVisibility: BarVisibility) {
             let key = Optional<AnyHashable>.none
             self.init(key: key, screen: screen, barVisibility: barVisibility)
         }
 
-        public init<ScreenType: Screen, Key: Hashable>(key: Key?, screen: ScreenType, barContent: BackStackScreen.BarContent) {
+        public init<Key: Hashable>(key: Key?, screen: ScreenType, barContent: BackStackScreen.BarContent) {
             self.init(key: key, screen: screen, barVisibility: .visible(barContent))
         }
 
-        public init<ScreenType: Screen>(screen: ScreenType, barContent: BackStackScreen.BarContent) {
+        public init(screen: ScreenType, barContent: BackStackScreen.BarContent) {
             let key = Optional<AnyHashable>.none
             self.init(key: key, screen: screen, barContent: barContent)
         }
 
-        public init<ScreenType: Screen, Key: Hashable>(key: Key?, screen: ScreenType) {
+        public init<Key: Hashable>(key: Key?, screen: ScreenType) {
             let barVisibility: BarVisibility = .visible(BarContent())
             self.init(key: key, screen: screen, barVisibility: barVisibility)
         }
 
-        public init<ScreenType: Screen>(screen: ScreenType) {
+        public init(screen: ScreenType) {
             let key = Optional<AnyHashable>.none
             self.init(key: key, screen: screen)
         }

--- a/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -161,12 +161,12 @@ extension AuthenticationWorkflow {
 // MARK: Rendering
 
 extension AuthenticationWorkflow {
-    typealias Rendering = AlertContainerScreen<ModalContainerScreen<BackStackScreen>>
+    typealias Rendering = AlertContainerScreen<ModalContainerScreen<BackStackScreen<AnyScreen>>>
 
     func render(state: AuthenticationWorkflow.State, context: RenderContext<AuthenticationWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Action.self)
 
-        var backStackItems: [BackStackScreen.Item] = []
+        var backStackItems: [BackStackScreen<AnyScreen>.Item] = []
         var modals: [ModalContainerScreenModal] = []
         var alert: Alert?
 
@@ -176,7 +176,7 @@ extension AuthenticationWorkflow {
                 return .login(email: email, password: password)
             }
         }.rendered(with: context)
-        backStackItems.append(BackStackScreen.Item(screen: loginScreen, barVisibility: .hidden))
+        backStackItems.append(BackStackScreen.Item(screen: AnyScreen(loginScreen), barVisibility: .hidden))
 
         switch state {
         case .emailPassword:
@@ -233,7 +233,7 @@ extension AuthenticationWorkflow {
         )
     }
 
-    private func twoFactorScreen(error: AuthenticationService.AuthenticationError?, intermediateSession: String, sink: Sink<Action>) -> BackStackScreen.Item {
+    private func twoFactorScreen(error: AuthenticationService.AuthenticationError?, intermediateSession: String, sink: Sink<Action>) -> BackStackScreen<AnyScreen>.Item {
         let title: String
         if let authenticationError = error {
             title = authenticationError.localizedDescription
@@ -252,7 +252,7 @@ extension AuthenticationWorkflow {
         )
 
         return BackStackScreen.Item(
-            screen: twoFactorScreen,
+            screen: AnyScreen(twoFactorScreen),
             barVisibility: .visible(BackStackScreen.BarContent(
                 leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
                     content: .text("Cancel"),

--- a/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -176,7 +176,7 @@ extension AuthenticationWorkflow {
                 return .login(email: email, password: password)
             }
         }.rendered(with: context)
-        backStackItems.append(BackStackScreen.Item(screen: AnyScreen(loginScreen), barVisibility: .hidden))
+        backStackItems.append(BackStackScreen.Item(screen: loginScreen.asAnyScreen(), barVisibility: .hidden))
 
         switch state {
         case .emailPassword:
@@ -252,7 +252,7 @@ extension AuthenticationWorkflow {
         )
 
         return BackStackScreen.Item(
-            screen: AnyScreen(twoFactorScreen),
+            screen: twoFactorScreen.asAnyScreen(),
             barVisibility: .visible(BackStackScreen.BarContent(
                 leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
                     content: .text("Cancel"),

--- a/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
@@ -84,19 +84,19 @@ extension RunGameWorkflow {
 // MARK: Rendering
 
 extension RunGameWorkflow {
-    typealias Rendering = AlertContainerScreen<ModalContainerScreen<BackStackScreen>>
+    typealias Rendering = AlertContainerScreen<ModalContainerScreen<BackStackScreen<AnyScreen>>>
 
     func render(state: RunGameWorkflow.State, context: RenderContext<RunGameWorkflow>) -> Rendering {
         let sink = context.makeSink(of: Action.self)
         var modals: [ModalContainerScreenModal] = []
         var alert: Alert?
 
-        var backStackItems: [BackStackScreen.Item] = [BackStackScreen.Item(
-            screen: newGameScreen(
+        var backStackItems: [BackStackScreen<AnyScreen>.Item] = [BackStackScreen.Item(
+            screen: AnyScreen(newGameScreen(
                 sink: sink,
                 playerX: state.playerX,
                 playerO: state.playerO
-            ),
+            )),
             barVisibility: .hidden
         )]
 
@@ -111,7 +111,7 @@ extension RunGameWorkflow {
             )
             .rendered(with: context)
             backStackItems.append(BackStackScreen.Item(
-                screen: takeTurnsScreen,
+                screen: AnyScreen(takeTurnsScreen),
                 barVisibility: .visible(BackStackScreen.BarContent(
                     leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
                         content: .text("Quit"),
@@ -130,7 +130,7 @@ extension RunGameWorkflow {
             )
             .rendered(with: context)
             backStackItems.append(BackStackScreen.Item(
-                screen: takeTurnsScreen,
+                screen: AnyScreen(takeTurnsScreen),
                 barVisibility: .visible(BackStackScreen.BarContent(
                     leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
                         content: .text("Quit"),

--- a/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Game/RunGameWorkflow.swift
@@ -92,11 +92,11 @@ extension RunGameWorkflow {
         var alert: Alert?
 
         var backStackItems: [BackStackScreen<AnyScreen>.Item] = [BackStackScreen.Item(
-            screen: AnyScreen(newGameScreen(
+            screen: newGameScreen(
                 sink: sink,
                 playerX: state.playerX,
                 playerO: state.playerO
-            )),
+            ).asAnyScreen(),
             barVisibility: .hidden
         )]
 
@@ -111,7 +111,7 @@ extension RunGameWorkflow {
             )
             .rendered(with: context)
             backStackItems.append(BackStackScreen.Item(
-                screen: AnyScreen(takeTurnsScreen),
+                screen: takeTurnsScreen.asAnyScreen(),
                 barVisibility: .visible(BackStackScreen.BarContent(
                     leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
                         content: .text("Quit"),
@@ -130,7 +130,7 @@ extension RunGameWorkflow {
             )
             .rendered(with: context)
             backStackItems.append(BackStackScreen.Item(
-                screen: AnyScreen(takeTurnsScreen),
+                screen: takeTurnsScreen.asAnyScreen(),
                 barVisibility: .visible(BackStackScreen.BarContent(
                     leftItem: BackStackScreen.BarContent.BarButtonItem.button(BackStackScreen.BarContent.Button(
                         content: .text("Quit"),

--- a/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Main/MainWorkflow.swift
@@ -65,7 +65,7 @@ extension MainWorkflow {
 // MARK: Rendering
 
 extension MainWorkflow {
-    typealias Rendering = AlertContainerScreen<ModalContainerScreen<BackStackScreen>>
+    typealias Rendering = AlertContainerScreen<ModalContainerScreen<BackStackScreen<AnyScreen>>>
 
     func render(state: MainWorkflow.State, context: RenderContext<MainWorkflow>) -> Rendering {
         switch state {

--- a/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial2Complete/Sources/RootWorkflow.swift
@@ -86,14 +86,14 @@ extension RootWorkflow {
 // MARK: Rendering
 
 extension RootWorkflow {
-    typealias Rendering = BackStackScreen
+    typealias Rendering = BackStackScreen<AnyScreen>
 
     func render(state: RootWorkflow.State, context: RenderContext<RootWorkflow>) -> Rendering {
         // Create a sink to handle the back action from the TodoListWorkflow to logout.
         let sink = context.makeSink(of: Action.self)
 
         // Our list of back stack items. Will always include the "WelcomeScreen".
-        var backStackItems: [BackStackScreen.Item] = []
+        var backStackItems: [BackStackScreen<AnyScreen>.Item] = []
 
         let welcomeScreen = WelcomeWorkflow()
             .mapOutput { output -> Action in
@@ -107,7 +107,7 @@ extension RootWorkflow {
 
         let welcomeBackStackItem = BackStackScreen.Item(
             key: "welcome",
-            screen: welcomeScreen,
+            screen: welcomeScreen.asAnyScreen(),
             // Hide the navigation bar.
             barVisibility: .hidden
         )
@@ -129,9 +129,9 @@ extension RootWorkflow {
 
             let todoListBackStackItem = BackStackScreen.Item(
                 key: "todoList",
-                screen: todoListScreen,
+                screen: todoListScreen.asAnyScreen(),
                 // Specify the title, back button, and right button.
-                barContent: BackStackScreen.BarContent(
+                barContent: .init(
                     title: "Welcome \(name)",
                     // When `back` is pressed, emit the .logout action to return to the welcome screen.
                     leftItem: .button(.back(handler: {

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/RootWorkflow.swift
@@ -86,13 +86,13 @@ extension RootWorkflow {
 // MARK: Rendering
 
 extension RootWorkflow {
-    typealias Rendering = BackStackScreen
+    typealias Rendering = BackStackScreen<AnyScreen>
 
     func render(state: RootWorkflow.State, context: RenderContext<RootWorkflow>) -> Rendering {
         // Delete the `let sink = context.makeSink(of: ...) as we no longer need a sink.
 
         // Our list of back stack items. Will always include the "WelcomeScreen".
-        var backStackItems: [BackStackScreen.Item] = []
+        var backStackItems: [BackStackScreen<AnyScreen>.Item] = []
 
         let welcomeScreen = WelcomeWorkflow()
             .mapOutput { output -> Action in
@@ -106,7 +106,7 @@ extension RootWorkflow {
 
         let welcomeBackStackItem = BackStackScreen.Item(
             key: "welcome",
-            screen: welcomeScreen,
+            screen: welcomeScreen.asAnyScreen(),
             // Hide the navigation bar.
             barVisibility: .hidden
         )

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -106,7 +106,7 @@ extension TodoEditWorkflow {
 // MARK: Rendering
 
 extension TodoEditWorkflow {
-    typealias Rendering = BackStackScreen.Item
+    typealias Rendering = BackStackScreen<AnyScreen>.Item
 
     func render(state: TodoEditWorkflow.State, context: RenderContext<TodoEditWorkflow>) -> Rendering {
         // The sink is used to send actions back to this workflow.
@@ -125,13 +125,13 @@ extension TodoEditWorkflow {
 
         let backStackItem = BackStackScreen.Item(
             key: "edit",
-            screen: todoEditScreen,
-            barContent: BackStackScreen.BarContent(
+            screen: todoEditScreen.asAnyScreen(),
+            barContent: .init(
                 title: "Edit",
                 leftItem: .button(.back(handler: {
                     sink.send(.discardChanges)
                 })),
-                rightItem: .button(BackStackScreen.BarContent.Button(
+                rightItem: .button(.init(
                     content: .text("Save"),
                     handler: {
                         sink.send(.saveChanges)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial3Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -116,7 +116,7 @@ extension TodoListWorkflow {
 // MARK: Rendering
 
 extension TodoListWorkflow {
-    typealias Rendering = [BackStackScreen.Item]
+    typealias Rendering = [BackStackScreen<AnyScreen>.Item]
 
     func render(state: TodoListWorkflow.State, context: RenderContext<TodoListWorkflow>) -> Rendering {
         // Define a sink to be able to send actions.
@@ -135,8 +135,8 @@ extension TodoListWorkflow {
 
         let todoListItem = BackStackScreen.Item(
             key: "list",
-            screen: todoListScreen,
-            barContent: BackStackScreen.BarContent(
+            screen: todoListScreen.asAnyScreen(),
+            barContent: .init(
                 title: "Welcome \(name)",
                 leftItem: .button(.back(handler: {
                     // When the left button is tapped, send the .onBack action.

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/RootWorkflow.swift
@@ -86,13 +86,13 @@ extension RootWorkflow {
 // MARK: Rendering
 
 extension RootWorkflow {
-    typealias Rendering = BackStackScreen
+    typealias Rendering = BackStackScreen<AnyScreen>
 
     func render(state: RootWorkflow.State, context: RenderContext<RootWorkflow>) -> Rendering {
         // Delete the `let sink = context.makeSink(of: ...) as we no longer need a sink.
 
         // Our list of back stack items. Will always include the "WelcomeScreen".
-        var backStackItems: [BackStackScreen.Item] = []
+        var backStackItems: [BackStackScreen<AnyScreen>.Item] = []
 
         let welcomeScreen = WelcomeWorkflow()
             .mapOutput { output -> Action in
@@ -106,7 +106,7 @@ extension RootWorkflow {
 
         let welcomeBackStackItem = BackStackScreen.Item(
             key: "welcome",
-            screen: welcomeScreen,
+            screen: welcomeScreen.asAnyScreen(),
             // Hide the navigation bar.
             barVisibility: .hidden
         )

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -106,7 +106,7 @@ extension TodoEditWorkflow {
 // MARK: Rendering
 
 extension TodoEditWorkflow {
-    typealias Rendering = BackStackScreen.Item
+    typealias Rendering = BackStackScreen<AnyScreen>.Item
 
     func render(state: TodoEditWorkflow.State, context: RenderContext<TodoEditWorkflow>) -> Rendering {
         // The sink is used to send actions back to this workflow.
@@ -125,13 +125,13 @@ extension TodoEditWorkflow {
 
         let backStackItem = BackStackScreen.Item(
             key: "edit",
-            screen: todoEditScreen,
-            barContent: BackStackScreen.BarContent(
+            screen: todoEditScreen.asAnyScreen(),
+            barContent: .init(
                 title: "Edit",
                 leftItem: .button(.back(handler: {
                     sink.send(.discardChanges)
                 })),
-                rightItem: .button(BackStackScreen.BarContent.Button(
+                rightItem: .button(.init(
                     content: .text("Save"),
                     handler: {
                         sink.send(.saveChanges)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -93,7 +93,7 @@ extension TodoListWorkflow {
 // MARK: Rendering
 
 extension TodoListWorkflow {
-    typealias Rendering = BackStackScreen.Item
+    typealias Rendering = BackStackScreen<AnyScreen>.Item
 
     func render(state: TodoListWorkflow.State, context: RenderContext<TodoListWorkflow>) -> Rendering {
         // Define a sink to be able to send the .onBack action.
@@ -112,14 +112,14 @@ extension TodoListWorkflow {
 
         let todoListItem = BackStackScreen.Item(
             key: "list",
-            screen: todoListScreen,
-            barContent: BackStackScreen.BarContent(
+            screen: todoListScreen.asAnyScreen(),
+            barContent: .init(
                 title: "Welcome \(name)",
                 leftItem: .button(.back(handler: {
                     // When the left button is tapped, send the .onBack action.
                     sink.send(.onBack)
                 })),
-                rightItem: .button(BackStackScreen.BarContent.Button(
+                rightItem: .button(.init(
                     content: .text("New Todo"),
                     handler: {
                         sink.send(.new)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial4Complete/Sources/Todo/TodoWorkflow.swift
@@ -133,7 +133,7 @@ extension TodoWorkflow {
 // MARK: Rendering
 
 extension TodoWorkflow {
-    typealias Rendering = [BackStackScreen.Item]
+    typealias Rendering = [BackStackScreen<AnyScreen>.Item]
 
     func render(state: TodoWorkflow.State, context: RenderContext<TodoWorkflow>) -> Rendering {
         let todoListItem = TodoListWorkflow(

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/RootWorkflow.swift
@@ -86,13 +86,13 @@ extension RootWorkflow {
 // MARK: Rendering
 
 extension RootWorkflow {
-    typealias Rendering = BackStackScreen
+    typealias Rendering = BackStackScreen<AnyScreen>
 
     func render(state: RootWorkflow.State, context: RenderContext<RootWorkflow>) -> Rendering {
         // Delete the `let sink = context.makeSink(of: ...) as we no longer need a sink.
 
         // Our list of back stack items. Will always include the "WelcomeScreen".
-        var backStackItems: [BackStackScreen.Item] = []
+        var backStackItems: [BackStackScreen<AnyScreen>.Item] = []
 
         let welcomeScreen = WelcomeWorkflow()
             .mapOutput { output -> Action in
@@ -106,7 +106,7 @@ extension RootWorkflow {
 
         let welcomeBackStackItem = BackStackScreen.Item(
             key: "welcome",
-            screen: welcomeScreen,
+            screen: welcomeScreen.asAnyScreen(),
             // Hide the navigation bar.
             barVisibility: .hidden
         )

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/Edit/TodoEditWorkflow.swift
@@ -106,7 +106,7 @@ extension TodoEditWorkflow {
 // MARK: Rendering
 
 extension TodoEditWorkflow {
-    typealias Rendering = BackStackScreen.Item
+    typealias Rendering = BackStackScreen<AnyScreen>.Item
 
     func render(state: TodoEditWorkflow.State, context: RenderContext<TodoEditWorkflow>) -> Rendering {
         // The sink is used to send actions back to this workflow.
@@ -125,13 +125,13 @@ extension TodoEditWorkflow {
 
         let backStackItem = BackStackScreen.Item(
             key: "edit",
-            screen: todoEditScreen,
-            barContent: BackStackScreen.BarContent(
+            screen: todoEditScreen.asAnyScreen(),
+            barContent: .init(
                 title: "Edit",
                 leftItem: .button(.back(handler: {
                     sink.send(.discardChanges)
                 })),
-                rightItem: .button(BackStackScreen.BarContent.Button(
+                rightItem: .button(.init(
                     content: .text("Save"),
                     handler: {
                         sink.send(.saveChanges)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/List/TodoListWorkflow.swift
@@ -93,7 +93,7 @@ extension TodoListWorkflow {
 // MARK: Rendering
 
 extension TodoListWorkflow {
-    typealias Rendering = BackStackScreen.Item
+    typealias Rendering = BackStackScreen<AnyScreen>.Item
 
     func render(state: TodoListWorkflow.State, context: RenderContext<TodoListWorkflow>) -> Rendering {
         // Define a sink to be able to send the .onBack action.
@@ -112,14 +112,14 @@ extension TodoListWorkflow {
 
         let todoListItem = BackStackScreen.Item(
             key: "list",
-            screen: todoListScreen,
-            barContent: BackStackScreen.BarContent(
+            screen: todoListScreen.asAnyScreen(),
+            barContent: .init(
                 title: "Welcome \(name)",
                 leftItem: .button(.back(handler: {
                     // When the left button is tapped, send the .onBack action.
                     sink.send(.onBack)
                 })),
-                rightItem: .button(BackStackScreen.BarContent.Button(
+                rightItem: .button(.init(
                     content: .text("New Todo"),
                     handler: {
                         sink.send(.new)

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Sources/Todo/TodoWorkflow.swift
@@ -133,7 +133,7 @@ extension TodoWorkflow {
 // MARK: Rendering
 
 extension TodoWorkflow {
-    typealias Rendering = [BackStackScreen.Item]
+    typealias Rendering = [BackStackScreen<AnyScreen>.Item]
 
     func render(state: TodoWorkflow.State, context: RenderContext<TodoWorkflow>) -> Rendering {
         let todoListItem = TodoListWorkflow(

--- a/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
+++ b/swift/Samples/Tutorial/Frameworks/Tutorial5Complete/Tests/TodoWorkflowTests.swift
@@ -17,6 +17,7 @@
 import BackStackContainer
 import WorkflowTesting
 import XCTest
+import Workflow
 @testable import Tutorial5
 
 class TodoWorkflowTests: XCTestCase {
@@ -39,7 +40,7 @@ class TodoWorkflowTests: XCTestCase {
                             screen: TodoListScreen(
                                 todoTitles: ["Title"],
                                 onTodoSelected: { _ in }
-                            )),
+                            ).asAnyScreen()),
                         // Simulate selecting the first todo:
                         output: TodoListWorkflow.Output.selectTodo(index: 0)
                     ),
@@ -81,7 +82,7 @@ class TodoWorkflowTests: XCTestCase {
                             screen: TodoListScreen(
                                 todoTitles: ["Title"],
                                 onTodoSelected: { _ in }
-                            ))
+                            ).asAnyScreen())
                     ),
                     // Expect the TodoEditWorkflow. Additionally, simulate it emitting an output of ".save" to update the state.
                     ExpectedWorkflow(
@@ -91,7 +92,7 @@ class TodoWorkflowTests: XCTestCase {
                             note: "Note",
                             onTitleChanged: { _ in },
                             onNoteChanged: { _ in }
-                        )),
+                        ).asAnyScreen()),
                         output: TodoEditWorkflow.Output.save(TodoModel(
                             title: "Updated Title",
                             note: "Updated Note"

--- a/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
+++ b/swift/WorkflowUI/Sources/Screen/AnyScreen/AnyScreen.swift
@@ -40,4 +40,11 @@
         }
     }
 
+    extension Screen {
+        /// Wraps the screen in an AnyScreen
+        public func asAnyScreen() -> AnyScreen {
+            AnyScreen(self)
+        }
+    }
+
 #endif


### PR DESCRIPTION
Part of #1046

**Pros**
* This makes `BackStackScreen` more consistent with our other containers.
* For back stacks that only have one screen type (e.g. single-screen stacks), there isn't an additional `AnyScreen` wrapping layer anymore.
* Potentially easier testing — you can get at the underlying type without having to cast.

**Cons**
* This creates more work when concatenating multiple back stacks together (which could arguably be pushed into the concatenation API (e.g. `appending<T: Screen>(_ other: BackStack<T>) -> BackStackScreen<AnyScreen>`)).
* More work is required to wrap your screen in an `AnyScreen` before adding it to a `BackStackScreen<AnyScreen>`. ~This could be mitigated by adding helper functions (e.g. in `Screen`: `func asAnyScreen() -> AnyScreen`); otherwise you have to prepend the `AnyScreen(` and reindent.~ The `asAnyScreen()` convenience has been added.