### PR TITLE
Allowing opt-out of lenient worker expectations

### DIFF
--- a/kotlin/workflow-testing/api/workflow-testing.api
+++ b/kotlin/workflow-testing/api/workflow-testing.api
@@ -29,8 +29,10 @@ public final class com/squareup/workflow/testing/RenderTester$DefaultImpls {
 public final class com/squareup/workflow/testing/RenderTesterKt {
 	public static final fun expectWorker (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/testing/EmittedOutput;)Lcom/squareup/workflow/testing/RenderTester;
 	public static synthetic fun expectWorker$default (Lcom/squareup/workflow/testing/RenderTester;Lcom/squareup/workflow/Worker;Ljava/lang/String;Lcom/squareup/workflow/testing/EmittedOutput;ILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
-	public static final fun renderTester (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
-	public static final fun renderTester (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun renderTester (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;Z)Lcom/squareup/workflow/testing/RenderTester;
+	public static final fun renderTester (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;Z)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun renderTester$default (Lcom/squareup/workflow/StatefulWorkflow;Ljava/lang/Object;Ljava/lang/Object;ZILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
+	public static synthetic fun renderTester$default (Lcom/squareup/workflow/Workflow;Ljava/lang/Object;ZILjava/lang/Object;)Lcom/squareup/workflow/testing/RenderTester;
 }
 
 public final class com/squareup/workflow/testing/WorkerSink : com/squareup/workflow/Worker {

--- a/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
+++ b/kotlin/workflow-testing/src/main/java/com/squareup/workflow/testing/RenderTester.kt
@@ -29,12 +29,14 @@ import kotlin.reflect.KClass
  */
 @Suppress("UNCHECKED_CAST")
 fun <PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, RenderingT>.renderTester(
-  props: PropsT
+  props: PropsT,
+  allowUnexpectedWorkers: Boolean = true
 ): RenderTester<PropsT, *, OutputT, RenderingT> {
   val statefulWorkflow = asStatefulWorkflow() as StatefulWorkflow<PropsT, Any?, OutputT, RenderingT>
   return statefulWorkflow.renderTester(
       props = props,
-      initialState = statefulWorkflow.initialState(props, null)
+      initialState = statefulWorkflow.initialState(props, null),
+      allowUnexpectedWorkers = allowUnexpectedWorkers
   ) as RenderTester<PropsT, Nothing, OutputT, RenderingT>
 }
 
@@ -47,15 +49,16 @@ fun <PropsT, OutputT : Any, RenderingT> Workflow<PropsT, OutputT, RenderingT>.re
 fun <PropsT, StateT, OutputT : Any, RenderingT>
     StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>.renderTester(
   props: PropsT,
-  initialState: StateT
+  initialState: StateT,
+  allowUnexpectedWorkers: Boolean = true
 ): RenderTester<PropsT, StateT, OutputT, RenderingT> =
 /* ktlint-enable parameter-list-wrapping */
-  RealRenderTester(this, props, initialState)
+  RealRenderTester(this, props, initialState, allowUnexpectedWorkers)
 
 /**
- * The props must be specified, the initial state may be specified, and then all child workflows
- * and workers that are expected to run, and any outputs from them, must be specified with
- * [expectWorkflow] and [expectWorker] calls. Then call [render] and perform any assertions on the
+ * The props must be specified, the initial state may be specified. Child workflows must be
+ * specified with [expectWorkflow], but workers are optionally specified with [expectWorker] unless
+ * configured otherwise, see [renderTester]. Then call [render] and perform any assertions on the
  * rendering. An event may also be sent to the rendering if no workflows or workers emitted an
  * output. Lastly, the [RenderTestResult] returned by `render` may be used to assert on the
  * [WorkflowAction]s processed to handle events or outputs by calling

--- a/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
+++ b/kotlin/workflow-testing/src/test/java/com/squareup/workflow/testing/RealRenderTesterTest.kt
@@ -383,6 +383,30 @@ class RealRenderTesterTest {
     tester.render()
   }
 
+  @Test fun `runningWorker throws when none expected with strict worker expectations`() {
+    val worker = object : Worker<Nothing> {
+      override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
+      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun toString(): String = "TestWorker"
+    }
+
+    val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      runningWorker(worker)
+    }
+    val tester = workflow.renderTester(
+        props = Unit,
+        allowUnexpectedWorkers = false
+    )
+
+    val error = assertFailsWith<AssertionError> {
+      tester.render()
+    }
+    assertEquals(
+        "Tried to render unexpected worker TestWorker.",
+        error.message
+    )
+  }
+
   @Test fun `runningWorker throws when expectation doesn't match`() {
     val worker = object : Worker<Nothing> {
       override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
@@ -416,6 +440,31 @@ class RealRenderTesterTest {
     val tester = workflow.renderTester(Unit)
 
     tester.render()
+  }
+
+  @Test fun `runningWorker with key throws when none expected with strict worker expectations`() {
+    val worker = object : Worker<Nothing> {
+      override fun doesSameWorkAs(otherWorker: Worker<*>): Boolean = true
+      override fun run(): Flow<Nothing> = emptyFlow()
+      override fun toString(): String = "TestWorker"
+    }
+
+    val workflow = Workflow.stateless<Unit, Nothing, Unit> {
+      runningWorker(worker, key = "key")
+    }
+    val tester = workflow.renderTester(
+        props = Unit,
+        allowUnexpectedWorkers = false
+    )
+
+    val error = assertFailsWith<AssertionError> {
+      tester.render()
+      tester.render()
+    }
+    assertEquals(
+        "Tried to render unexpected worker TestWorker with key \"key\".",
+        error.message
+    )
   }
 
   @Test fun `runningWorker with key throws when no key expected`() {


### PR DESCRIPTION
## Checklist

- [x] Unit Tests
- [ ] UI Tests
- [ ] Snapshot Tests (iOS only)
- [x] I have made corresponding changes to the documentation

Note the base is https://github.com/square/workflow/pull/1172. I had made some changes to documentation earlier but missed a spot
