### PR TITLE
Introduce SideEffect #1021

### DIFF
--- a/swift/Workflow/Sources/Debugging.swift
+++ b/swift/Workflow/Sources/Debugging.swift
@@ -75,6 +75,7 @@ extension WorkflowUpdateDebugInfo {
     public indirect enum Source: Equatable {
         case external
         case worker
+        case sideEffect
         case subtree(WorkflowUpdateDebugInfo)
     }
 }
@@ -96,6 +97,8 @@ extension WorkflowUpdateDebugInfo.Source: Codable {
         case let .subtree(debugInfo):
             try container.encode("subtree", forKey: .type)
             try container.encode(debugInfo, forKey: .debugInfo)
+        case .sideEffect:
+            try container.encode("side-effect", forKey: .type)
         }
     }
 
@@ -114,6 +117,8 @@ extension WorkflowUpdateDebugInfo.Source: Codable {
         case "subtree":
             let debugInfo = try container.decode(WorkflowUpdateDebugInfo.self, forKey: .debugInfo)
             self = .subtree(debugInfo)
+        case "side-effect":
+            self = .sideEffect
         default:
             throw MalformedDataError()
         }

--- a/swift/Workflow/Sources/Lifetime.swift
+++ b/swift/Workflow/Sources/Lifetime.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Represents the lifetime of an object.
+///
+/// Once ended, the `onEnded` closure is called.
+public final class Lifetime {
+    /// Hook to clean-up after end of `lifetime`.
+    public func onEnded(_ action: @escaping () -> Void) {
+        assert(!hasEnded, "Lifetime used after being ended.")
+        onEndedActions.append(action)
+    }
+
+    public private(set) var hasEnded: Bool = false
+    private var onEndedActions: [() -> Void] = []
+
+    deinit {
+        end()
+    }
+
+    func end() {
+        guard !hasEnded else {
+            return
+        }
+        hasEnded = true
+        onEndedActions.forEach { $0() }
+    }
+}

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -557,6 +557,7 @@ extension WorkflowNode.SubtreeManager {
         }
 
         deinit {
+            // Explicitly end the lifetime in case someone retained it from outside
             lifetime.end()
         }
     }

--- a/swift/Workflow/Tests/WorkflowNodeTests.swift
+++ b/swift/Workflow/Tests/WorkflowNodeTests.swift
@@ -141,7 +141,7 @@ final class WorkflowNodeTests: XCTestCase {
             XCTFail()
         case let .didUpdate(source):
             switch source {
-            case .external, .worker:
+            case .external, .worker, .sideEffect:
                 XCTFail()
             case let .subtree(childInfo):
                 XCTAssert(childInfo.workflowType == "\(EventEmittingWorkflow.self)")
@@ -152,7 +152,7 @@ final class WorkflowNodeTests: XCTestCase {
                     switch source {
                     case .external:
                         break
-                    case .subtree(_), .worker:
+                    case .subtree(_), .worker, .sideEffect:
                         XCTFail()
                     }
                 }

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -22,6 +22,7 @@
     @testable import Workflow
 
     import ReactiveSwift
+    import class Workflow.Lifetime
     import XCTest
 
     extension Workflow {
@@ -207,13 +208,15 @@
             expectedOutput: ExpectedOutput<WorkflowType>? = nil,
             expectedWorkers: [ExpectedWorker] = [],
             expectedWorkflows: [ExpectedWorkflow] = [],
+            expectedSideEffects: [ExpectedSideEffect<WorkflowType>] = [],
             assertions: (WorkflowType.Rendering) -> Void
         ) -> RenderTester<WorkflowType> {
             let expectations = RenderExpectations(
                 expectedState: expectedState,
                 expectedOutput: expectedOutput,
                 expectedWorkers: expectedWorkers,
-                expectedWorkflows: expectedWorkflows
+                expectedWorkflows: expectedWorkflows,
+                expectedSideEffects: expectedSideEffects
             )
 
             return render(file: file, line: line, with: expectations, assertions: assertions)
@@ -230,7 +233,7 @@
     fileprivate final class RenderTestContext<T: Workflow>: RenderContextType {
         typealias WorkflowType = T
 
-        private var (lifetime, token) = Lifetime.make()
+        private var (lifetime, token) = ReactiveSwift.Lifetime.make()
 
         var state: WorkflowType.State
         var expectations: RenderExpectations<WorkflowType>
@@ -247,7 +250,7 @@
         func render<Child, Action>(workflow: Child, key: String, outputMap: @escaping (Child.Output) -> Action) -> Child.Rendering where Child: Workflow, Action: WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
             guard let workflowIndex = expectations.expectedWorkflows.firstIndex(where: { expectedWorkflow -> Bool in
                 type(of: workflow) == expectedWorkflow.workflowType && key == expectedWorkflow.key
-        }) else {
+            }) else {
                 XCTFail("Unexpected child workflow of type \(workflow.self)", file: file, line: line)
                 fatalError()
             }
@@ -277,7 +280,7 @@
         func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, RenderTestContext<T>.WorkflowType == Action.WorkflowType {
             guard let workerIndex = expectations.expectedWorkers.firstIndex(where: { (expectedWorker) -> Bool in
                 expectedWorker.isEquivalent(to: worker)
-        }) else {
+            }) else {
                 XCTFail("Unexpected worker during render \(worker)", file: file, line: line)
                 return
             }
@@ -286,6 +289,15 @@
             if let action = expectedWorker.outputAction(outputMap: outputMap) {
                 apply(action: action)
             }
+        }
+
+        func runSideEffect(key: AnyHashable, action: (Lifetime) -> Void) {
+            guard let sideEffect = expectations.expectedSideEffects.removeValue(forKey: key) else {
+                XCTFail("Unexpected side-effect during render \(key)", file: file, line: line)
+                return
+            }
+
+            sideEffect.action?(RenderContext.make(implementation: self))
         }
 
         private func apply<Action>(action: Action) where Action: WorkflowAction, Action.WorkflowType == WorkflowType {
@@ -317,15 +329,21 @@
                 XCTFail("Expected output of '\(outputExpectation.output)' but received none.", file: file, line: line)
             }
 
-            if expectations.expectedWorkers.count != 0 {
+            if !expectations.expectedWorkers.isEmpty {
                 for expectedWorker in expectations.expectedWorkers {
                     XCTFail("Expected worker \(expectedWorker.worker)", file: file, line: line)
                 }
             }
 
-            if expectations.expectedWorkflows.count != 0 {
+            if !expectations.expectedWorkflows.isEmpty {
                 for expectedWorkflow in expectations.expectedWorkflows {
                     XCTFail("Expected child workflow of type: \(expectedWorkflow.workflowType) key: \(expectedWorkflow.key)", file: file, line: line)
+                }
+            }
+
+            if !expectations.expectedSideEffects.isEmpty {
+                for expectedSideEffect in expectations.expectedSideEffects {
+                    XCTFail("Expected side-effect with key: \(expectedSideEffect.key)", file: file, line: line)
                 }
             }
         }


### PR DESCRIPTION
Introduces a `SideEffect` hook that will be used to perform the functionality currently provided by `Worker`s. 

This is a subset of @bencochran's implementation in the [bc/guwt-prototype](https://github.com/square/workflow/compare/bc/guwt-prototype) branch.