### PR TITLE
Fix missing libswiftos.dylib

### DIFF
--- a/Workflow.podspec
+++ b/Workflow.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'swift/Workflow/Tests/**/*.swift'
     test_spec.framework = 'XCTest'
+    test_spec.library = 'swiftos'
   end
 
 end


### PR DESCRIPTION
`pod spec lint` was failing with the error:

> xctest encountered an error (Failed to load the test bundle. (Underlying error: The bundle “Workflow-Unit-Tests” couldn’t be loaded because it is damaged or missing necessary resources. The bundle is damaged or missing necessary resources. dlopen_preflight(DerivedData/App-fjnxhlsdrldlhtbvawtgcubjgass/Build/Products/Debug-iphonesimulator/Workflow-Unit-Tests.xctest/Workflow-Unit-Tests): Library not loaded: @rpath/libswiftos.dylib

*Note*: This PR is targeting the `release-v0.28.x` branch, as we should probably tag a `v0.28.1`.