### PR TITLE
[RFC] [DNM] SideEffect as Type

### DIFF
--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -170,16 +170,15 @@ extension DemoWorkflow {
         case .not:
             subscribeTitle = "Subscribe"
         case .subscribing:
-            context.run(
-                sideEffect: SideEffectPerformer<Self, Action>(key: "Timer", action: { sink, lifetime in
-                    let timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
-                        sink.send(.titleButtonTapped)
-                    }
+            context.run(SideEffectPerformer<Action>(key: "Timer") { sink, lifetime in
+                let timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { timer in
+                    sink.send(.titleButtonTapped)
+                }
 
-                    lifetime.onEnded {
-                        timer.invalidate()
-                    }
-                })
+                lifetime.onEnded {
+                    timer.invalidate()
+                }
+            }
             )
             subscribeTitle = "Stop"
         }

--- a/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
+++ b/swift/Samples/SampleApp/Sources/DemoWorkflow.swift
@@ -204,21 +204,3 @@ extension DemoWorkflow {
         )
     }
 }
-
-// private class TimerSignal {
-//    let signal: Signal<Void, Never>
-//    let observer: Signal<Void, Never>.Observer
-//    let timer: Timer
-//
-//    init() {
-//        let (signal, observer) = Signal<Void, Never>.pipe()
-//
-//        let timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak observer] _ in
-//            observer?.send(value: ())
-//        }
-//
-//        self.signal = signal
-//        self.observer = observer
-//        self.timer = timer
-//    }
-// }

--- a/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
+++ b/swift/Samples/TicTacToe/Sources/Authentication/AuthenticationWorkflow.swift
@@ -218,7 +218,8 @@ extension AuthenticationWorkflow {
                     authenticationService: authenticationService,
                     intermediateToken: intermediateSession,
                     twoFactorCode: twoFactorCode
-                ))
+                )
+            )
 
             backStackItems.append(twoFactorScreen(error: nil, intermediateSession: intermediateSession, sink: sink))
             modals.append(ModalContainerScreenModal(screen: AnyScreen(LoadingScreen()), style: .fullScreen, key: "", animated: false))
@@ -226,7 +227,8 @@ extension AuthenticationWorkflow {
         return AlertContainerScreen(
             baseScreen: ModalContainerScreen(
                 baseScreen: BackStackScreen(
-                    items: backStackItems),
+                    items: backStackItems
+                ),
                 modals: modals
             ),
             alert: alert
@@ -259,7 +261,8 @@ extension AuthenticationWorkflow {
                     handler: {
                         sink.send(.back)
                     }
-                ))))
+                ))
+            ))
         )
     }
 }

--- a/swift/Workflow/Sources/RenderContext.swift
+++ b/swift/Workflow/Sources/RenderContext.swift
@@ -75,7 +75,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         fatalError()
     }
 
-    public func run<S: SideEffect>(sideEffect: S) {
+    public func run<S: SideEffect>(_ sideEffect: S) {
         fatalError()
     }
 
@@ -107,9 +107,9 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
             return implementation.makeSink(of: actionType)
         }
 
-        override func run<S: SideEffect>(sideEffect: S) where S.Action.WorkflowType == WorkflowType {
+        override func run<S: SideEffect>(_ sideEffect: S) where S.Action.WorkflowType == WorkflowType {
             assertStillValid()
-            implementation.run(sideEffect: sideEffect)
+            implementation.run(sideEffect)
         }
 
         override func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, WorkflowType == Action.WorkflowType {
@@ -132,7 +132,7 @@ internal protocol RenderContextType: AnyObject {
 
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
-    func run<S: SideEffect>(sideEffect: S) where S.Action.WorkflowType == WorkflowType
+    func run<S: SideEffect>(_ sideEffect: S) where S.Action.WorkflowType == WorkflowType
 }
 
 extension RenderContext {

--- a/swift/Workflow/Sources/RenderContext.swift
+++ b/swift/Workflow/Sources/RenderContext.swift
@@ -107,7 +107,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
             return implementation.makeSink(of: actionType)
         }
 
-        override func run<S: SideEffect>(sideEffect: S) {
+        override func run<S: SideEffect>(sideEffect: S) where S.Action.WorkflowType == WorkflowType {
             assertStillValid()
             implementation.run(sideEffect: sideEffect)
         }
@@ -132,7 +132,7 @@ internal protocol RenderContextType: AnyObject {
 
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
-    func run<S: SideEffect>(sideEffect: S)
+    func run<S: SideEffect>(sideEffect: S) where S.Action.WorkflowType == WorkflowType
 }
 
 extension RenderContext {

--- a/swift/Workflow/Sources/RenderContext.swift
+++ b/swift/Workflow/Sources/RenderContext.swift
@@ -75,7 +75,7 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
         fatalError()
     }
 
-    public func runSideEffect(key: AnyHashable, action: (Lifetime) -> Void) {
+    public func run<S: SideEffect>(sideEffect: S) {
         fatalError()
     }
 
@@ -107,9 +107,9 @@ public class RenderContext<WorkflowType: Workflow>: RenderContextType {
             return implementation.makeSink(of: actionType)
         }
 
-        override func runSideEffect(key: AnyHashable, action: (_ lifetime: Lifetime) -> Void) {
+        override func run<S: SideEffect>(sideEffect: S) {
             assertStillValid()
-            implementation.runSideEffect(key: key, action: action)
+            implementation.run(sideEffect: sideEffect)
         }
 
         override func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, WorkflowType == Action.WorkflowType {
@@ -132,7 +132,7 @@ internal protocol RenderContextType: AnyObject {
 
     func awaitResult<W, Action>(for worker: W, outputMap: @escaping (W.Output) -> Action) where W: Worker, Action: WorkflowAction, Action.WorkflowType == WorkflowType
 
-    func runSideEffect(key: AnyHashable, action: (_ lifetime: Lifetime) -> Void)
+    func run<S: SideEffect>(sideEffect: S)
 }
 
 extension RenderContext {

--- a/swift/Workflow/Sources/SideEffect.swift
+++ b/swift/Workflow/Sources/SideEffect.swift
@@ -15,5 +15,7 @@
  */
 
 public protocol SideEffect: Hashable {
-    func run() -> Lifetime
+    associatedtype Action: WorkflowAction
+
+    func run(sink: Sink<Action>) -> Lifetime
 }

--- a/swift/Workflow/Sources/SideEffect.swift
+++ b/swift/Workflow/Sources/SideEffect.swift
@@ -14,30 +14,6 @@
  * limitations under the License.
  */
 
-import Foundation
-
-public final class Lifetime {
-    public init(action: @escaping () -> Void) {
-        onEnded(action)
-    }
-
-    public func onEnded(_ action: @escaping () -> Void) {
-        assert(!hasEnded, "Lifetime used after being ended.")
-        onEndedActions.append(action)
-    }
-
-    public private(set) var hasEnded: Bool = false
-    private var onEndedActions: [() -> Void] = []
-
-    deinit {
-        end()
-    }
-
-    func end() {
-        guard !hasEnded else {
-            return
-        }
-        hasEnded = true
-        onEndedActions.forEach { $0() }
-    }
+public protocol SideEffect: Hashable {
+    func run() -> Lifetime
 }

--- a/swift/Workflow/Sources/SideEffectPerformer.swift
+++ b/swift/Workflow/Sources/SideEffectPerformer.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-public struct SideEffectPerformer<WorkflowType, Action: WorkflowAction>: SideEffect where Action.WorkflowType == WorkflowType {
+public struct SideEffectPerformer<Action: WorkflowAction>: SideEffect {
     let key: AnyHashable
     let action: (Sink<Action>, Lifetime) -> Void
 

--- a/swift/Workflow/Sources/SideEffectPerformer.swift
+++ b/swift/Workflow/Sources/SideEffectPerformer.swift
@@ -16,28 +16,21 @@
 
 import Foundation
 
-public final class Lifetime {
-    public init(action: @escaping () -> Void) {
-        onEnded(action)
+struct SideEffectPerformer: SideEffect {
+    let key: AnyHashable
+    let action: (Lifetime) -> Void
+
+    func run() -> Lifetime {
+        let lifetime = Lifetime {}
+        action(lifetime)
+        return lifetime
     }
 
-    public func onEnded(_ action: @escaping () -> Void) {
-        assert(!hasEnded, "Lifetime used after being ended.")
-        onEndedActions.append(action)
+    static func == (lhs: SideEffectPerformer, rhs: SideEffectPerformer) -> Bool {
+        lhs.key == rhs.key
     }
 
-    public private(set) var hasEnded: Bool = false
-    private var onEndedActions: [() -> Void] = []
-
-    deinit {
-        end()
-    }
-
-    func end() {
-        guard !hasEnded else {
-            return
-        }
-        hasEnded = true
-        onEndedActions.forEach { $0() }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(key)
     }
 }

--- a/swift/Workflow/Sources/SideEffectPerformer.swift
+++ b/swift/Workflow/Sources/SideEffectPerformer.swift
@@ -16,21 +16,26 @@
 
 import Foundation
 
-struct SideEffectPerformer: SideEffect {
+public struct SideEffectPerformer<WorkflowType, Action: WorkflowAction>: SideEffect where Action.WorkflowType == WorkflowType {
     let key: AnyHashable
-    let action: (Lifetime) -> Void
+    let action: (Sink<Action>, Lifetime) -> Void
 
-    func run() -> Lifetime {
+    public init(key: AnyHashable, action: @escaping (Sink<Action>, Lifetime) -> Void) {
+        self.key = key
+        self.action = action
+    }
+
+    public func run(sink: Sink<Action>) -> Lifetime {
         let lifetime = Lifetime {}
-        action(lifetime)
+        action(sink, lifetime)
         return lifetime
     }
 
-    static func == (lhs: SideEffectPerformer, rhs: SideEffectPerformer) -> Bool {
+    public static func == (lhs: SideEffectPerformer, rhs: SideEffectPerformer) -> Bool {
         lhs.key == rhs.key
     }
 
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         hasher.combine(key)
     }
 }

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -247,7 +247,7 @@ extension WorkflowNode.SubtreeManager {
             }
         }
 
-        func run<S: SideEffect>(sideEffect: S) where S.Action.WorkflowType == WorkflowType {
+        func run<S: SideEffect>(_ sideEffect: S) where S.Action.WorkflowType == WorkflowType {
             let sink = makeSink(of: S.Action.self)
             if let existingSideEffect = originalSideEffectLifetimes[sideEffect] {
                 usedSideEffectLifetimes[sideEffect] = existingSideEffect

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -247,11 +247,12 @@ extension WorkflowNode.SubtreeManager {
             }
         }
 
-        func run<S>(sideEffect: S) where S: SideEffect {
+        func run<S: SideEffect>(sideEffect: S) where S.Action.WorkflowType == WorkflowType {
+            let sink = makeSink(of: S.Action.self)
             if let existingSideEffect = originalSideEffectLifetimes[sideEffect] {
                 usedSideEffectLifetimes[sideEffect] = existingSideEffect
             } else {
-                let lifetime = sideEffect.run()
+                let lifetime = sideEffect.run(sink: sink)
                 usedSideEffectLifetimes[sideEffect] = SideEffectLifetime(lifetime: lifetime)
             }
         }

--- a/swift/Workflow/Sources/SubtreeManager.swift
+++ b/swift/Workflow/Sources/SubtreeManager.swift
@@ -247,13 +247,12 @@ extension WorkflowNode.SubtreeManager {
             }
         }
 
-        func runSideEffect(key: AnyHashable, action: (Lifetime) -> Void) {
-            if let existingSideEffect = originalSideEffectLifetimes[key] {
-                usedSideEffectLifetimes[key] = existingSideEffect
+        func run<S>(sideEffect: S) where S: SideEffect {
+            if let existingSideEffect = originalSideEffectLifetimes[sideEffect] {
+                usedSideEffectLifetimes[sideEffect] = existingSideEffect
             } else {
-                let sideEffectLifetime = SideEffectLifetime()
-                action(sideEffectLifetime.lifetime)
-                usedSideEffectLifetimes[key] = sideEffectLifetime
+                let lifetime = sideEffect.run()
+                usedSideEffectLifetimes[sideEffect] = SideEffectLifetime(lifetime: lifetime)
             }
         }
     }
@@ -553,7 +552,11 @@ extension WorkflowNode.SubtreeManager {
         fileprivate let lifetime: Lifetime
 
         fileprivate init() {
-            self.lifetime = Lifetime()
+            self.lifetime = Lifetime {}
+        }
+
+        fileprivate init(lifetime: Lifetime) {
+            self.lifetime = lifetime
         }
 
         deinit {

--- a/swift/Workflow/Tests/SubtreeManagerTests.swift
+++ b/swift/Workflow/Tests/SubtreeManagerTests.swift
@@ -305,7 +305,7 @@ final class SubtreeManagerTests: XCTestCase {
         XCTAssertTrue(manager.sideEffectLifetimes.isEmpty)
 
         _ = manager.render { context -> TestViewModel in
-            context.run(sideEffect: TestSideEffect(lifetime: Lifetime()))
+            context.run(TestSideEffect(lifetime: Lifetime()))
             return context.render(
                 workflow: TestWorkflow(),
                 key: "",
@@ -317,7 +317,7 @@ final class SubtreeManagerTests: XCTestCase {
         let sideEffectKey = manager.sideEffectLifetimes.values.first!
 
         _ = manager.render { context -> TestViewModel in
-            context.run(sideEffect: TestSideEffect(lifetime: Lifetime()))
+            context.run(TestSideEffect(lifetime: Lifetime()))
             return context.render(
                 workflow: TestWorkflow(),
                 key: "",
@@ -341,7 +341,7 @@ final class SubtreeManagerTests: XCTestCase {
                 print("\(lifetime)")
                 lifetimeEndedExpectation.fulfill()
             }
-            context.run(sideEffect: TestSideEffect(lifetime: lifetime))
+            context.run(TestSideEffect(lifetime: lifetime))
             return context.render(
                 workflow: TestWorkflow(),
                 key: "",

--- a/swift/WorkflowTesting/Sources/RenderExpectations.swift
+++ b/swift/WorkflowTesting/Sources/RenderExpectations.swift
@@ -102,11 +102,11 @@ public struct ExpectedWorker {
     }
 }
 
-public struct ExpectedSideEffect {
-    let key: AnyHashable
+public struct ExpectedSideEffect: Equatable {
+    private let key: AnyHashable
 
-    public init(key: AnyHashable) {
-        self.key = key
+    public init<S: SideEffect>(sideEffect: S) {
+        self.key = sideEffect
     }
 }
 

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -290,11 +290,10 @@
             }
         }
 
-        func runSideEffect(key: AnyHashable, action: (Lifetime) -> Void) {
-            guard let sideEffectIndex = expectations.expectedSideEffects.firstIndex(where: { (expectedSideEffect) -> Bool in
-                expectedSideEffect.key == key
-            }) else {
-                XCTFail("Unexpected side-effect during render \(key)", file: file, line: line)
+        func run<S>(sideEffect: S) where S: SideEffect {
+            guard let sideEffectIndex = expectations.expectedSideEffects.firstIndex(of: ExpectedSideEffect(sideEffect: sideEffect))
+            else {
+                XCTFail("Unexpected side-effect during render \(sideEffect)", file: file, line: line)
                 return
             }
 
@@ -344,7 +343,7 @@
 
             if !expectations.expectedSideEffects.isEmpty {
                 for expectedSideEffect in expectations.expectedSideEffects {
-                    XCTFail("Expected side-effect with key: \(expectedSideEffect.key)", file: file, line: line)
+                    XCTFail("Expected side-effect with key: \(expectedSideEffect)", file: file, line: line)
                 }
             }
         }

--- a/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
+++ b/swift/WorkflowTesting/Sources/WorkflowRenderTester.swift
@@ -290,7 +290,7 @@
             }
         }
 
-        func run<S>(sideEffect: S) where S: SideEffect {
+        func run<S>(_ sideEffect: S) where S: SideEffect {
             guard let sideEffectIndex = expectations.expectedSideEffects.firstIndex(of: ExpectedSideEffect(sideEffect: sideEffect))
             else {
                 XCTFail("Unexpected side-effect during render \(sideEffect)", file: file, line: line)

--- a/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
+++ b/swift/WorkflowTesting/Tests/WorkflowRenderTesterTests.swift
@@ -16,6 +16,7 @@
 
 import ReactiveSwift
 import Workflow
+import class Workflow.Lifetime
 import WorkflowTesting
 import XCTest
 
@@ -85,7 +86,7 @@ final class WorkflowRenderTesterTests: XCTestCase {
 
         renderTester.render(
             with: RenderExpectations(expectedSideEffects: [
-                ExpectedSideEffect(key: TestSideEffectKey()),
+                ExpectedSideEffect(sideEffect: TestSideEffect()),
             ]),
             assertions: { _ in }
         )
@@ -324,8 +325,11 @@ private struct OutputWorkflow: Workflow {
     }
 }
 
-private struct TestSideEffectKey: Hashable {
+struct TestSideEffect: SideEffect {
     let key: String = "Test Side Effect"
+    func run() -> Lifetime {
+        Lifetime {}
+    }
 }
 
 private struct SideEffectWorkflow: Workflow {
@@ -334,7 +338,7 @@ private struct SideEffectWorkflow: Workflow {
     typealias Rendering = TestScreen
 
     func render(state: State, context: RenderContext<SideEffectWorkflow>) -> TestScreen {
-        context.runSideEffect(key: TestSideEffectKey()) { _ in }
+        context.run(sideEffect: TestSideEffect())
 
         return TestScreen(text: "value", tapped: {})
     }


### PR DESCRIPTION
## Context 
In #1174, we introduce the `sideEffect` API on `RenderContext`:
```swift
runSideEffect(key: AnyHashable, action: (Lifetime) -> Void)
```

`action` is executed the first time a `key` is encountered and `Lifetime.onEnded` is called after it's no longer needed.

Example usage:
```swift
sink = context.makeSink(Action.self)
context.runSideEffect("entity-" + entityId) { lifetime in 
  fetchEntity(entityId) { sink.send(.gotEntity) }
}
```

## Proposal
Make `SideEffect` a type:

```swift
protocol SideEffect: Hashable {
  func run(sink: Sink<Action>) -> Lifetime
}
```

and the API becomes:
```swift
func run<S: SideEffect>(sideEffect: S)
```

## Why?
### Harder to mess-up
The `Hashable` contract implies that the `hashValue` will be calculated based on hashing all the contents of the object (`SideEffect`). If the `hashValue`s are the same, we then compare the two objects to make sure they're the same. This contract gives us a strong guarantee that the **block of work** that will be executed by the `SideEffect` will be the same.

If we instead put the responsibility on the consumer of the API to formulate the right `key`, we will be unnecessarily burdening the caller to carefully generate the right `key` and the impact of doing this incorrectly will be subtle. 

In other words, if we want the `key` to represent the same `action` AND the `action` is a function of `(a, b, c)` I believe that the the key should be `f(a, b, c)`

### Flexible
Making `SideEffect` a protocol (instead of having the `key` and an independent `action` closure) will make this more flexible. We will then be able to get any of the `Worker`s to conform to the `SideEffect`. (Instead of having an intermediate `Workflow` to do the `runSideEffect` call.)