### PR TITLE
Rename all references to master branch to trunk in build scripts and documentation.

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -7,7 +7,7 @@
 
 SLUG="square/workflow"
 JDK="oraclejdk8"
-BRANCH="master"
+BRANCH="trunk"
 
 set -e
 

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -3,7 +3,7 @@ name: Kotlin CI
 on:
   push:
     branches:
-      - master
+      - trunk
     paths:
       # Rebuild when workflow configs change.
       - .github/workflows/kotlin.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   PREFIX_FOR_TEST: ${{ github.event.client_payload.test_prefix }}
 
 jobs:
-  bump-master:
+  bump-trunk:
     runs-on: macos-latest
 
     steps:
@@ -27,16 +27,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Checkout Master
+    - name: Checkout Trunk
       uses: actions/checkout@v2
       with:
-        ref: ${{ env.PREFIX_FOR_TEST }}master
-        path: master
+        ref: ${{ env.PREFIX_FOR_TEST }}trunk
+        path: trunk
 
     - name: Setup Release Branch (major, minor)
       if: env.RELEASE_TYPE == 'major' || env.RELEASE_TYPE == 'minor'
       run: |
-        cp -R master release
+        cp -R trunk release
         cd release
         git checkout -b ${{ env.RELEASE_BRANCH }}
 
@@ -49,24 +49,24 @@ jobs:
 
     - name: Update Changelog
       run: |
-        cd master
+        cd trunk
         ../.buildscript/update_changelog.swift
         cd ../release
         ../.buildscript/update_changelog.swift
 
-    - name: Update Master Version (major, minor)
+    - name: Update Trunk Version (major, minor)
       if: env.RELEASE_TYPE == 'major' || env.RELEASE_TYPE == 'minor'
       run: |
-        cd master
+        cd trunk
         sed -i '' -e 's/VERSION_NAME=\(.*\)-SNAPSHOT/VERSION_NAME=${{ env.WORKFLOW_VERSION }}-SNAPSHOT/g' kotlin/gradle.properties
         ls Workflow*.podspec | xargs sed -i '' -e "s/ s.version\( *=\).*/ s.version\1 '${{ env.WORKFLOW_VERSION }}'/"
 
-    - name: Push changes to master
+    - name: Push changes to trunk
       env:
         GIT_USERNAME: ${{ github.actor }}
         GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd master
+        cd trunk
         git add -A . && git commit -m "Releasing ${{ env.WORKFLOW_VERSION }}" && git push -f
 
     - name: Push Release Branch

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -3,7 +3,7 @@ name: Swift CI
 on:
   push:
     branches:
-      - master
+      - trunk
       - '!gh-pages'
     paths:
       - '*.podspec'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ and assign it to @bencochran or @aquageek.*
 ---
 1. Merge an update of [the change log](CHANGELOG.md) with the changes since the last release.
 
-1. Make sure you're on the `master` branch (or fix branch, e.g. `v0.1-fixes`).
+1. Make sure you're on the `trunk` branch (or fix branch, e.g. `v0.1-fixes`).
 
 1. Confirm that the kotlin build is green before committing any changes
    ```bash
@@ -58,7 +58,7 @@ and assign it to @bencochran or @aquageek.*
 
 1. Push your commits and tag:
    ```
-   git push origin master
+   git push origin trunk
    # or git push origin fix-branch
    git push origin v0.1.0
    ```
@@ -73,13 +73,13 @@ and assign it to @bencochran or @aquageek.*
    1. If this is a pre-release version, check the pre-release box.
    1. Hit "Publish release".
 
-1. If this was a fix release, merge changes to the master branch:
+1. If this was a fix release, merge changes to the trunk branch:
    ```bash
-   git checkout master
+   git checkout trunk
    git pull
    git merge --no-ff v0.1-fixes
-   # Resolve conflicts. Accept master's versions of gradle.properties and podspecs.
-   git push origin master
+   # Resolve conflicts. Accept trunk's versions of gradle.properties and podspecs.
+   git push origin trunk
    ```
 
 1. Publish the website. See below.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ navigation in apps with dozens or hundreds of screens.
 ## How do I get involved and/or contribute?
 
 - [Workflow is open source!](https://github.com/square/workflow)
-- See our [CONTRIBUTING](https://github.com/square/workflow/blob/master/CONTRIBUTING.md) doc to get
+- See our [CONTRIBUTING](https://github.com/square/workflow/blob/trunk/CONTRIBUTING.md) doc to get
   started.
 - Stay tuned! We're considering hosting a public Slack channel for open source contributors.
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -2,7 +2,7 @@
 
 !!! tip
     For a comprehensive tutorial with code that you can build and follow along with, see the
-    [Tutorials](https://github.com/square/workflow/tree/master/swift/Samples/Tutorial#tutorial) in
+    [Tutorials](https://github.com/square/workflow/tree/trunk/swift/Samples/Tutorial#tutorial) in
     the repo.
 
     This section will be restructured soon to incorporate that and Kotlin tutorials.


### PR DESCRIPTION
See #1194.


## Checklist

- [x] I have made corresponding changes to the documentation
