### PR TITLE
Rename trunk branch to main.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
   PREFIX_FOR_TEST: ${{ github.event.client_payload.test_prefix }}
 
 jobs:
-  bump-trunk:
+  bump-main:
     runs-on: macos-latest
 
     steps:
@@ -23,16 +23,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Checkout Trunk
+    - name: Checkout Main
       uses: actions/checkout@v2
       with:
-        ref: ${{ env.PREFIX_FOR_TEST }}trunk
-        path: trunk
+        ref: ${{ env.PREFIX_FOR_TEST }}main
+        path: main
 
     - name: Setup Release Branch (major, minor)
       if: env.RELEASE_TYPE == 'major' || env.RELEASE_TYPE == 'minor'
       run: |
-        cp -R trunk release
+        cp -R main release
         cd release
         git checkout -b ${{ env.RELEASE_BRANCH }}
 
@@ -43,12 +43,12 @@ jobs:
         ref: ${{ env.RELEASE_BRANCH }}
         path: release
 
-    - name: Push changes to trunk
+    - name: Push changes to main
       env:
         GIT_USERNAME: ${{ github.actor }}
         GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        cd trunk
+        cd main
         git add -A . && git commit -m "Releasing ${{ env.WORKFLOW_VERSION }}" && git push -f
 
     - name: Push Release Branch

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -26,7 +26,7 @@ navigation in apps with dozens or hundreds of screens.
 ## How do I get involved and/or contribute?
 
 - [Workflow is open source!](https://github.com/square/workflow)
-- See our [CONTRIBUTING](https://github.com/square/workflow/blob/trunk/CONTRIBUTING.md) doc to get
+- See our [CONTRIBUTING](https://github.com/square/workflow/blob/main/CONTRIBUTING.md) doc to get
   started.
 - Stay tuned! We're considering hosting a public Slack channel for open source contributors.
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -2,7 +2,7 @@
 
 !!! tip
     For a comprehensive tutorial with code that you can build and follow along with, see the
-    [Tutorials](https://github.com/square/workflow/tree/trunk/swift/Samples/Tutorial#tutorial) in
+    [Tutorials](https://github.com/square/workflow/tree/main/swift/Samples/Tutorial#tutorial) in
     the repo.
 
     This section will be restructured soon to incorporate that and Kotlin tutorials.


### PR DESCRIPTION
In the last week, the discussion around git branch naming seems to have
settled around "main" being the most popular choice. Github is even
changing their default branch name to this.