### PR TITLE
Create GitHub action to manually publish documentation

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,8 +1,6 @@
 name: Publish Documentation Site
 
 on:
-  push:
-    branches: [stromberg/manual-publish]
   workflow_dispatch:
     inputs:
       main-ref:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,8 +1,9 @@
 name: Publish Documentation Site
 
 on:
+  push:
+    branches: [stromberg/manual-publish]
   workflow_dispatch:
-    # Inputs the workflow accepts.
     inputs:
       branch:
         description: 'Branch'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,49 @@
+name: Publish Documentation Site
+
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      branch:
+        description: 'Branch'
+        default: 'main'
+        required: true
+
+jobs:
+  build-docs:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout Branch
+      uses: actions/checkout@v2.3.3
+      with:
+        ref: ${{ github.event.inputs.name }}
+        path: ${{ github.event.inputs.name }}
+
+    # Ruby Gems
+    - name: Load gem cache
+      uses: actions/cache@v2.1.2
+      with:
+        path: ${{ github.event.inputs.name }}/.bundle
+        key: gems-${{ hashFiles('Gemfile.lock') }}
+
+    - name: Set up Swift environment
+      run: |
+        # Set global bundle path so it gets used by build_swift_docs.sh running in the nested repo as well.
+        cd "${{ github.event.inputs.name }}"
+        bundle config --global path "$(pwd)/.bundle"
+        bundle check || bundle install
+        # Don't need to run pod gen, the website script does that itself.
+        brew install sourcedocs
+        sudo xcode-select -s /Applications/Xcode_11.4.app
+
+    # Docs dependencies
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -5,9 +5,20 @@ on:
     branches: [stromberg/manual-publish]
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'Branch'
+      main-ref:
+        description: 'Main Workflow repo ref to publish'
         default: 'main'
+        required: true
+      kotlin-ref:
+        description: 'Kotlin Git ref to publish'
+        default: 'main'
+        required: true
+      swift-ref:
+        description: 'Swift Git ref to publish'
+        default: 'main'
+        required: true
+      docs-branch:
+        description: 'Branch name for updated documentation to be published'
         required: true
 
 jobs:
@@ -15,27 +26,46 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Checkout Branch
+    - name: Check out main repo
       uses: actions/checkout@v2.3.3
       with:
-        ref: ${{ github.event.inputs.name }}
-        path: ${{ github.event.inputs.name }}
+        ref: ${{ github.event.inputs.main-ref }}
+        path: 'workflow'
+
+    - name: Check out Kotlin repo
+      uses: actions/checkout@v2.3.3
+      with:
+        repository: 'square/workflow-kotlin'
+        ref: ${{ github.event.inputs.kotlin-ref }}
+        path: 'workflow-kotlin'
+
+    - name: Check out Swift ref
+      uses: actions/checkout@v2.3.3
+      with:
+        repository: 'square/workflow-swift'
+        ref: ${{ github.event.inputs.swift-ref }}
+        path: 'workflow-swift'
 
     # Ruby Gems
     - name: Load gem cache
       uses: actions/cache@v2.1.2
       with:
-        path: ${{ github.event.inputs.name }}/.bundle
-        key: gems-${{ hashFiles('Gemfile.lock') }}
+        path: workflow-swift/.bundle
+        key: gems-${{ hashFiles('workflow-swift/Gemfile.lock') }}
 
     - name: Set up Swift environment
       run: |
         # Set global bundle path so it gets used by build_swift_docs.sh running in the nested repo as well.
-        cd "${{ github.event.inputs.name }}"
+        cd workflow-swift
         bundle config --global path "$(pwd)/.bundle"
         bundle check || bundle install
+        
         # Don't need to run pod gen, the website script does that itself.
         brew install sourcedocs
+        
+        # Use Xcode 11.4
+        # TODO: Update this to the latest?
+        # * Xcode 11.4 is the version that includes Swift 5.2, which is what our language version is set to
         sudo xcode-select -s /Applications/Xcode_11.4.app
 
     # Docs dependencies
@@ -46,5 +76,58 @@ jobs:
 
     - name: Install Python dependencies
       run: |
+        cd workflow
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+
+    # Build Swift docs
+    - name: Build Swift docs
+      run: |
+        mkdir -p workflow/docs/swift/api
+        
+        cd workflow-swift
+        bundle exec pod gen Development.podspec
+        cd gen/Development
+        
+        sourcedocs generate --output-folder "../../../workflow/docs/swift/api/Workflow" -- -scheme Workflow -workspace Development.xcworkspace
+        sourcedocs generate --output-folder "../../../workflow/docs/swift/api/WorkflowUI" -- -scheme WorkflowUI -workspace Development.xcworkspace
+        sourcedocs generate --output-folder "../../../workflow/docs/swift/api/WorkflowTesting" -- -scheme WorkflowTesting -workspace Development.xcworkspace
+        sourcedocs generate --output-folder "../../../workflow/docs/swift/api/WorkflowReactiveSwift" -- -scheme WorkflowReactiveSwift -workspace Development.xcworkspace
+
+    # Build Kotlin docs
+    - name: Build Kotlin docs
+      run: |
+        cd workflow-kotlin
+        ./gradlew assemble --build-cache --quiet
+        ./gradlew siteDokka --build-cache --quiet
+        
+        mkdir -p ../workflow/docs/kotlin/api
+        mv build/dokka/workflow ../workflow/docs/kotlin/api
+
+    # Generate the mkdocs site
+    - name: Generate site with mkdocs
+      run: |
+        cd workflow
+
+        echo "Building documentation site"
+        mkdocs build
+
+    # Push docs to new branch
+    - name: Create new docs branch
+      uses: actions/checkout@v2.3.3
+      with:
+        ref: gh-pages
+        path: 'workflow-publish'
+
+    - name: Commit updated docs
+      run: |
+        cd workflow-publish
+        git checkout -b ${{ github.event.inputs.docs-branch }}
+        
+        # Copy all the files over from the 'site' directory
+        cp -R ../workflow/site/* .
+        
+        # Commit and push
+        git add .
+        git commit -m "Update documentation"
+        git push origin HEAD:${{ github.event.inputs.docs-branch }}

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -102,7 +102,7 @@ function buildSwiftDocs() {
 	local deployRef="$1"
 	local targetDir="$2"
 	local workingDir=deploy-swift
-	local workflowSchemes=(Workflow WorkflowUI WorkflowTesting)
+	local workflowSchemes=(Workflow WorkflowUI WorkflowTesting WorkflowReactiveSwift)
 
 	if [[ -z "$deployRef" ]]; then echo "buildSwiftDocs: Must pass deploy ref as first arg" >&2; exit 1; fi
 	if [[ -z "$targetDir" ]]; then echo "buildSwiftDocs: Must pass target dir as second arg" >&2; exit 1; fi


### PR DESCRIPTION
This creates a new GitHub Action that can be manually run to generate the documentation for Kotlin and Swift and publishes the resulting site to a defined branch. (I didn't want to auto-merge into `gh-pages` quite yet.)

We will need to take some time to reconcile this against the existing `deploy_website.sh` script.