### PR TITLE
Update Elm and React comparison Table

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,17 +16,17 @@ We ask this question too! So we wrote a longer answer for it: ["Why Workflow?"](
 [React](https://reactjs.org/) and [the Elm architecture](https://guide.elm-lang.org/architecture/)
 were both strong influences for this library. However both those libraries are written for
 JavaScript. Workflows are written in and for both Kotlin and Swift, making use of features of those
-languages, and with usability from those languages as a major design goal. There are also a few
-architectural differences:
+languages, and with usability from those languages as a major design goal. There are some
+architectural differences which we can see briefly in the following table:
 
 |  | React | Elm | Workflow |
 |---|---|---|---|
-| **Modularity** | `Component` | TK | `Workflow` is analogous to React's `Component` |
+| **Modularity** | `Component` | `Module`s for code organization, but not 'composable' in the same way. | A `Workflow` is analogous to React's `Component` |
 | **State** | Each `Component` has a `state` property that is read directly and updated via a `setState` method. | State is called `Model` in Elm. | `Workflow`s have an associated state type. The state can only be updated when the props change, or with a `WorkflowAction`. |
 | **Views** | `Component`s have a `render` method that returns a tree of elements. | Elm applications have a `view` function that returns a tree of elements. | Since workflows are not tied to any particular UI view layer, they can have an arbitrary rendering type. The `render()` method returns this type. |
-| **Dependencies** | React allows parent components to pass "props" down to their children. | TK | In Swift, `Workflow`s are often structs that need to be initialized with their dependencies and configuration data from their parent. In Kotlin, they have a separate type parameter (`PropsT`) that is always passed down from the parent. `Workflow` instances can also inject dependencies, and play nicely with dependency injection frameworks.
-| **Composability** | TK | TK | TK |
-| **Event Handling** | TK | TK | TK |
+| **Injected Dependencies** | React allows parent components to pass "props" down to their children. | N/A | In Swift, `Workflow`s are often structs that need to be initialized with their dependencies and configuration data from their parent. In Kotlin, they have a separate type parameter (`PropsT`) that is always passed down from the parent. `Workflow` instances can also inject dependencies, and play nicely with dependency injection frameworks.
+| **Composability** | `Component`s are composed of other `Component`s. | N/A | `Workflow`s can have children; they control their lifecycle and can choose to incorporate child renderings into their own. |
+| **Event Handling** | DOM event listeners are hooked up to functions on the `Component`. | The `update` function takes a `Msg` to modify state based on events. | `action` can be sent to the `Sink` to update `State`. |
 
 ## How is this different than MvRx?
 


### PR DESCRIPTION
Here is the updated table:

![image](https://user-images.githubusercontent.com/8658187/130650948-691e4ee6-8704-47b4-8984-138d1bb86b4b.png)
