### PR TITLE
docs: configure edit URI for hosted documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ site_description: "A library for making composable state machines, and UIs drive
 site_author: Square, Inc.
 site_url: https://square.github.io/workflow/
 remote_branch: gh-pages
+edit_uri: edit/main/docs/
 
 copyright: 'Copyright &copy; 2019 Square, Inc.'
 


### PR DESCRIPTION
Configure the [`edit_uri`](https://www.mkdocs.org/user-guide/configuration/#edit_uri) to specify `main` as the repository convergence branch rather than the default of `master`. This resolves a 404 error when selecting the edit icon for any page within the [documentation site](https://square.github.io/workflow/).