### PR TITLE
Downgrade to mkdocs-material 8.2.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.3.0
-mkdocs-material==8.2.13
+mkdocs-material==8.2.12
 mkdocs-redirects==1.0.4


### PR DESCRIPTION
Requires python 3.7, GHA is on 3.6