### PR TITLE
Downgrade mkdocs to 8.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.3.0
-mkdocs-material==8.2.12
+mkdocs-material==8.2.11
 mkdocs-redirects==1.0.4


### PR DESCRIPTION
8.2.12 wants a version of pymdown-extensions that GHA can't provide.