### PR TITLE
Fixes glossary formatting again.

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -14,7 +14,7 @@ A style of programming where data or events are pushed to the logic processing t
 Unidirectional Data Flow
 </dt>
 <dd>
-Data travels a single path from business logic to UI, and travels the entirety of that path in a single direction. Events travel a single path from UI to business logic and they travel the entirety of that path in a single direction. There are thus 2 sets of directed edges in the graph that are handled separately and neither set has any cycles or back edges on its own.
+Data travels a single path from business logic to UI, and travels the entirety of that path in a single direction. Events travel a single path from UI to business logic and they travel the entirety of that path in a single direction. There are thus two sets of directed edges in the graph that are handled separately and neither set has any cycles or back edges on its own.
 </dd>
 
 <dt>
@@ -35,7 +35,7 @@ An imperative program’s code is a series of statements that directly change a 
 State Machine
 </dt>
 <dd>
-An abstraction that models a program’s logic as a graph of a set of states and the transitions between them (edges). See: https://en.wikipedia.org/wiki/Finite-state_machine
+An abstraction that models a program’s logic as a graph of a set of states and the transitions between them (edges). See: <a href="https://en.wikipedia.org/wiki/Finite-state_machine">en.wikipedia.org/wiki/Finite-state_machine</a>
 </dd>
 
 <dt>
@@ -49,18 +49,19 @@ A function whose side effects won’t be repeated with multiple invocations, the
 Workflow Runtime
 </dt>
 <dd>
+<p>
 An event loop that executes a Workflow Tree. On each pass:
+<ol>
+<li>A Rendering is assembled by calling render() on each Node of the Workflow Tree with each parent Workflow given the option to incorporate the Renderings of its children into its own.
 
-1. A Rendering is assembled by calling render() on each Node of the Workflow Tree with each parent Workflow given the option to incorporate the Renderings of its children into its own.
+<li>The event loop waits for an Action to be sent to the Sink.
 
-1. The event loop waits for an Action to be sent to the Sink.
+<li>This Action provides a (possibly updated) State for the Workflow that created it and possibly an Output.
 
-1. This Action provides a (possibly updated) State for the Workflow that created it and possibly an Output.
+<li>Any Output emitted is processed in turn by an Action defined by the updated Workflow’s parent again possibly updating its State and emitting an Output cascading up the hierarchy.
 
-1. Any Output emitted is processed in turn by an Action defined by the updated Workflow’s parent again possibly updating its State and emitting an Output cascading up the hierarchy.
-
-1. A new render() pass is made against the entire Workflow Tree with the updated States.
-
+<li>A new render() pass is made against the entire Workflow Tree with the updated States.
+</ol>
 We use the term Workflow Runtime to refer to the core code in the framework that executes this event loop, responding to Actions and invoking render().
 </dd>
 
@@ -68,18 +69,20 @@ We use the term Workflow Runtime to refer to the core code in the framework that
 Workflow (Instance)
 </dt>
 <dd>
+<p>
 An object that defines the transitions and side effects of a state machine as, effectively, two functions:
-<br/><br/>
 
-1. Providing the first state: () -> State
+<ol>
+<li>Providing the first state: () -> State
+<li>Providing a rendering: (Props and State) -> (Rendering and Side Effect Invocations and Child Workflow Invocations)
+</ol>
 
-1. Providing a rendering: (Props and State) -> (Rendering and Side Effect Invocations and Child Workflow Invocations)
-
+<p>
 The Child Workflow Invocations declared by the render function result in calls to the children’s render() functions in turn, allowing the parent render function to choose to incorporate child Rendering values into its own.
-
+<p>
 A Workflow is not itself a state machine, and ideally has no state of its own. It is rather a schema that identifies a particular type of state machine that can be started in initialState() by the Workflow Runtime, and advanced by repeated invocations of render().
-
-Note: there is significant fuzziness in using the term ‘Workflow’, as it can mean at times the class/struct that declares the Workflow behavior as well as the object representing the running Workflow Node. To understand the Runtime behavior, grasping this distinction is necessary and valuable, however, when using a Workflow, the formal distinction is less valuable than the mental model of how a Workflow will be run.
+<p>
+Note: there is significant fuzziness in using the term ‘Workflow’, as it can mean at times the class/struct that declares the Workflow behavior as well as the object representing the running Workflow Node. To understand the Runtime behavior, grasping this distinction is necessary and valuable. When using a Workflow, the formal distinction is less valuable than the mental model of how a Workflow will be run.
 </dd>
 
 <dt>
@@ -93,12 +96,13 @@ An active state machine whose behavior is defined by a Workflow Instance. This i
 Workflow Lifecycle
 </dt>
 <dd>
+<p>
 Every Workflow or Side Effect Node has a lifecycle that is determined by its parent. In the case of the root Workflow, this lifecycle is determined by how long the host of the root chooses to use the stream of Renderings from the root Workflow. In the case of a non-root Workflow or Side Effect — that is, in the case of a Child — its lifecycle is determined as follows:
+<ul>
+<li>Start: the first time its parent invokes the Child in the parent’s own render() pass.
 
-- Start: the first time its parent invokes the Child in the parent’s own render() pass.
-
-- End: the first subsequent render() pass that does not invoke the Child.
-
+<li>End: the first subsequent render() pass that does not invoke the Child.
+</ul>
 Note that in between Start and End, the Workflow, or Side Effect is not “re-invoked” in the sense of starting again with each render() pass, but rather the originally invoked instance continues to run until a render() call is made without invoking it.
 </dd>
 
@@ -120,14 +124,15 @@ The root of a Workflow Tree. This is owned by a host which starts the Workflow R
 RenderContext
 </dt>
 <dd>
+<p>
 The object which provides access to the Workflow Runtime from a Workflow render method. Provides three services:
+<ul>
+<li>a Sink for accepting WorkflowActions
 
-- a Sink for accepting WorkflowActions
+<li>recursively rendering Workflow children
 
-- recursively rendering Workflow children
-
-- executing Side Effects
-
+<li>executing Side Effects
+</ul>
 </dd>
 
 <dt>
@@ -155,7 +160,7 @@ When a Child Workflow emits an Output value, this is an Output Event. Handlers a
 UI Event
 </dt>
 <dd>
-Any occurrence in the UI of a program - e.g. click, drag, keypress - the listener for which has been connected to a callback in the Rendering of a Workflow. UI Event callbacks typically add Actions to the Sink, to advance the state of the Workflow.
+Any occurrence in the UI of a program — e.g. click, drag, keypress — the listener for which has been connected to a callback in the Rendering of a Workflow. UI Event callbacks typically add Actions to the Sink, to advance the state of the Workflow.
 </dd>
 
 <dt>
@@ -176,14 +181,14 @@ The handle provided by the RenderContext to send Actions to the Workflow Runtime
 Props
 </dt>
 <dd>
+<p>
 The set of input properties for a particular Workflow. This is the public state which is provided to a child Workflow by its parent, or to the root Workflow by its host.
+<ul>
+<li>For Swift: The set of properties on the struct implementing the Workflow.
 
-- For Swift: The set of properties on the struct implementing the Workflow.
-
-- For Kotlin: Parameter type PropsT type in the Workflow signature.
-
+<li>For Kotlin: Parameter type PropsT type in the Workflow signature.
+</ul>
 In Kotlin there is a formal distinction between Props and other dependencies, typically provided as constructor parameters.
-
 </dd>
 
 <dt>
@@ -197,21 +202,25 @@ The type of the internal state of a Workflow implementation.
 "Immutable" State
 </dt>
 <dd>
-The State object itself is immutable, in other words, its property values cannot be changed. What this means for Workflows is that the Workflow Runtime holds a canonical instance of the internal State of each Workflow. A Workflow’s state is “advanced” when that canonical instance is atomically replaced by one returned when an Action is invoked. State can only be mutated through WorkflowAction which will trigger a re-render. There are a number of benefits to keeping State immutable in this way:
+<p>
+The State object itself is immutable, in other words, its property values cannot be changed. 
+<p>
+What this means for Workflows is that the Workflow Runtime holds a canonical instance of the internal State of each Workflow. A Workflow’s state is “advanced” when that canonical instance is atomically replaced by one returned when an Action is invoked. State can only be mutated through WorkflowAction which will trigger a re-render. There are a number of benefits to keeping State immutable in this way:
+<ul>
+<li>Reasoning about and debugging the Workflow is easier because, for any given State, there is a deterministic Rendering and the State cannot change except as a new parameter value to the render() method.
 
-- Reasoning about and debugging the Workflow is easier because, for any given State, there is a deterministic Rendering and the State cannot change except as a new parameter value to the render() method.
-
-- This assists in making render() idempotent as the State will not be modified in the course of the execution of that function.
-
+<li>This assists in making render() idempotent as the State will not be modified in the course of the execution of that function.
+</ul>
+Note that this immutability can be enforced only by convention. It is possible to cheat, but that is strongly discouraged.
 </dd>
 
 <dt>
 Rendering
 </dt>
 <dd>
+<p>
 The externally available public representation of the state of a Workflow. It may include event handling functions. It is given a concrete type in the Workflow signature.
-<br/><br/>
-
+<p>
 Note that this “Rendering” does not have to represent the UI of a program. The “Rendering” is simply the published state of the Workflow, and could simply be data. Often that data is used to render UI, but it can be used in other ways — for example, as the implementation of a service API.
 </dd>
 
@@ -233,12 +242,13 @@ A Workflow which has a parent. A parent may compose a child Workflow’s Renderi
 Side Effect
 </dt>
 <dd>
+<p>
 From render(), runningSideEffect() can be called with a given key and a function that will be called once by the Workflow Runtime.
+<ul>
+<li>For Swift, a Lifetime object is also passed to runningSideEffect() which has an onEnded() closure that can be used for cleanup.
 
-- For Swift, a Lifetime object is also passed to runningSideEffect() which has an onEnded() closure that can be used for cleanup.
-
-- For Kotlin, a coroutine scope is used to execute the function so it can be cancelled() at cleanup time. Given that any property (including the Sink) could be captured by the closure of the Side Effect this is the basic building block that can be used to interact with asynchronous (and often imperative) Workflow Children.
-
+<li>For Kotlin, a coroutine scope is used to execute the function so it can be cancelled() at cleanup time. Given that any property (including the Sink) could be captured by the closure of the Side Effect this is the basic building block that can be used to interact with asynchronous (and often imperative) Workflow Children.
+</ul>
 </dd>
 
 <dt>
@@ -246,38 +256,41 @@ Worker
 </dt>
 <dd>
 A Child Workflow that provides only output, with no rendering — a pattern for doing asynchronous work in Workflows.
+<p>
+<ul>
+<li>For Kotlin, this is an actual Interface which provides a convenient way to specify asynchronous work that produces an Output and a handler for that Output which can provide an Action. There are Kotlin extensions to map Rx Observables and Kotlin Flows to create Worker implementations.
 
-- For Kotlin, this is an actual Interface which provides a convenient way to specify asynchronous work that produces an Output and a handler for that Output which can provide an Action. There are Kotlin extensions to map Rx Observables and Kotlin Flows to create Worker implementations.
-
-- For Swift, there are at least 3 different Worker types which are convenience wrappers around reactive APIs that facilitate performing work.
-
+<li>For Swift, there are at least 3 different Worker types which are convenience wrappers around reactive APIs that facilitate performing work.
+</ul>
 </dd>
 
 <dt>
 View
 </dt>
 <dd>
+<p>
 A class or function managing a 2d box in a graphical user interface system, able to paint a defined region of the display and respond to user input events within its bounds. Views are arranged in a hierarchical tree, with parents able to lay out children and manage their painting and event handling.
-<br/><br/>
+<p>
 Instances supported by Workflow are:
-
-- For Kotlin:
-  - Classic Android: `class android.view.View`
-  - Android JetPack Compose: `@Composable fun Box()`
-
-- For Swift: `class NSViewController`
-
+<ul>
+<li>For Kotlin:
+  <ul>
+  <li>Classic Android: `class android.view.View`
+  <li>Android JetPack Compose: `@Composable fun Box()`
+  </ul>
+<li>For Swift: `class NSViewController`
+</ul>
 </dd>
 
 <dt>
 Screen
 </dt>
 <dd>
+<p>
 An interface / protocol identifying Renderings that model a View. Workflow UI libraries can map a given Screen type to a View instance that can display a series of such Screens.
-<br/><br/>
-
-In Kotlin, `Screen` is a marker interface. Each type `S : Screen` is mapped by the Android UI library to a `ScreenViewFactory<S>` able to create instances of `android.view.View`; or that provides a `@Composable fun Content(S)` function to be called from a `Box {}` context. (Note that the Android UI support is able to interleave Screens bound to `View` or `@Composable` seamlessly.)
-
+<p>
+In Kotlin, `Screen` is a marker interface. Each type `S : Screen` is mapped by the Android UI library to a `ScreenViewFactory&gt;S>` able to create instances of `android.view.View`; or that provides a `@Composable fun Content(S)` function to be called from a `Box {}` context. (Note that the Android UI support is able to interleave Screens bound to `View` or `@Composable` seamlessly.)
+<p>
 In Swift, the `Screen` protocol defines a single function creating `ViewControllerDescription` instances, objects which create and update `ViewController` instances to display Screens of the corresponding type.
 </dd>
 
@@ -285,9 +298,9 @@ In Swift, the `Screen` protocol defines a single function creating `ViewControll
 Overlay (Kotlin only)
 </dt>
 <dd>
+<p>
 An interface identifying Renderings that model a plane covering (‘higher’ in the z-order, for visibility and event-handling) a base Screen, possibly hosting another Screen.
-<br/><br/>
-
+<p>
 In Kotlin, `Overlay` is a marker interface. Each type `O : Overlay` is mapped by the Android UI library to an `OverlayDialogFactory<O>` able to create and update instances of `android.app.Dialog`
 </dd>
 
@@ -295,9 +308,9 @@ In Kotlin, `Overlay` is a marker interface. Each type `O : Overlay` is mapped by
 Container Screen
 </dt>
 <dd>
+<p>
 A design pattern, describing a Screen type whose instances wrap one or more other Screens, commonly to either annotate those Screens or define the relationships between them.
-<br/><br/>
-
+<p>
 Wrapping one Screen in another does not necessarily imply that the derived View hierarchy will change. It is common for the Kotlin `ScreenViewFactory` or Swift `ViewControllerDescription` bound to a Container Screen to delegate its construction and updating work to those of the wrapped Screens.
 </dd>
 
@@ -305,21 +318,22 @@ Wrapping one Screen in another does not necessarily imply that the derived View 
 Container View
 </dt>
 <dd>
+<p>
 A View able to host children that are driven by Screen renderings. A Container View is generally driven by Container Screens of a specific type — e.g., a BackStackContainer View that can display BackStackScreen values. The exception is a root Container View, which is able to display a series of Screen instances of any type.
+<ul>
+<li>For Kotlin, the root Container Views are `WorkflowLayout : FrameLayout`, and `@Composable Workflow.renderAsState()`. Custom Container Views written to display custom Container Screens can use `WorkflowViewStub : FrameLayout` or `@Composable fun WorkflowRendering()` to display wrapped Screens.
 
-- For Kotlin, the root Container Views are `WorkflowLayout : FrameLayout`, and `@Composable Workflow.renderAsState()`. Custom Container Views written to display custom Container Screens can use `WorkflowViewStub : FrameLayout` or `@Composable fun WorkflowRendering()` to display wrapped Screens.
-
-- For Swift, the root Container View is `ContainerViewController`. Custom Container Views written to render custom Container Screens can be built as subclasses of `ScreenViewController`, and use `DescribedViewController` to display wrapped Screens.
-
+<li>For Swift, the root Container View is `ContainerViewController`. Custom Container Views written to render custom Container Screens can be built as subclasses of `ScreenViewController`, and use `DescribedViewController` to display wrapped Screens.
+</ul>
 </dd>
 
 <dt>
 ViewEnvironment
 </dt>
 <dd>
+<p>
 A read-only key/value map passed from the Container View down to its children at update time, similar in spirit to Swift UI `EnvironmentValues` and Jetpack `CompositionLocal`. Like them, the ViewEnvironment is primarily intended to allow parents to offer children hints about the context in which they are being displayed — for example, to allow a child to know if it is a member of a back stack, and so decide whether or not to display a Go Back button.
-<br/><br/>
-
+<p>
 The ViewEnvironment also can be used judiciously as a service provider for UI-specific concerns, like image loaders — tread carefully.
 </dd>
 


### PR DESCRIPTION
Using &lt;dd> botched all the 'graph and 'list markdown in the glossary entries. I think I missed it b/c I previewed as github markdown?

I made no effort at all to format this well -- life is too short for &lt;/p> and &lt;/li>.
