### PR TITLE
Fix Kotlin docs output path

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -59,7 +59,7 @@ jobs:
         ./gradlew siteDokka --build-cache --quiet
 
         mkdir -p ../workflow/docs/kotlin/api
-        mv build/dokka/htmlMultiModule ../workflow/docs/kotlin/api
+        mv build/dokka/workflow ../workflow/docs/kotlin/api
 
     # Generate the mkdocs site
     - name: Generate site with mkdocs

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -81,7 +81,7 @@ function buildKotlinDocs() {
 	# Clean the target dir first.
 	[[ -d "$targetDir" ]] && rm -rf "$targetDir"
 	mkdir -p "$targetDir"
-	mv "$workingDir/build/dokka/htmlMultiModule" "$targetDir"
+	mv "$workingDir/build/dokka/workflow" "$targetDir"
 
 	echo "Removing working directory..."
 	rm -rf "$workingDir"


### PR DESCRIPTION
🤖 Fix the Kotlin docs publish workflow after `workflow-kotlin`'s `siteDokka` output moved from `build/dokka/htmlMultiModule` to `build/dokka/workflow`.

The v1.27.0 docs publish failed after `siteDokka` completed because the workflow tried to move the old `htmlMultiModule` directory. This updates both the GitHub Actions workflow and the older `deploy_website.sh` path to use the current `build/dokka/workflow` output.

Validation:
- `zsh -n deploy_website.sh`
- parsed `.github/workflows/update-docs.yml` with Ruby YAML
- `git diff --check`
