### PR TITLE
Use Java 21 for Kotlin docs publishing

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -45,11 +45,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v2
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 21
 
     # Build Kotlin docs
     - name: Build Kotlin docs


### PR DESCRIPTION
🤖 This PR updates the docs publishing workflow to install JDK 21 before building workflow-kotlin docs.

Why:
- The v1.28.0 docs publish run failed under Java 17 because workflow-kotlin build logic now requires JVM 21.
- Rerunning the docs workflow from this branch succeeded: https://github.com/square/workflow/actions/runs/26129550316

Release context: v1.28.0 docs were published to gh-pages after the successful rerun.